### PR TITLE
chore: update package-lock.json to account for node.js version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "webpack-merge": "^6.0.1"
       },
       "engines": {
-        "node": ">=20.10 <21 || >=21.2"
+        "node": ">=20.11 <21 || >=21.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {


### PR DESCRIPTION
This is a test for the automatic deployments