### PR TITLE
Add missing event handler for position plot when rendered as tool in a palette

### DIFF
--- a/src/widget/position_widget.ts
+++ b/src/widget/position_widget.ts
@@ -1558,20 +1558,7 @@ class DimensionTool<Viewer extends object> extends Tool<Viewer> {
       ).element,
     );
 
-    const shouldIgnoreEvent = (event: Event) => {
-      const target = event.target;
-      if (
-        target instanceof Element &&
-        target.matches(".neuroglancer-position-dimension-playback *")
-      ) {
-        return true;
-      }
-      return false;
-    };
-    const mouseHandler = this.registerDisposer(
-      new MouseEventBinder(plot.element, inputEventMap),
-    );
-    mouseHandler.shouldIgnore = shouldIgnoreEvent;
+    this.registerDisposer(new MouseEventBinder(plot.element, inputEventMap));
 
     registerActionListener<WheelEvent>(
       plot.element,

--- a/src/widget/position_widget.ts
+++ b/src/widget/position_widget.ts
@@ -1557,6 +1557,49 @@ class DimensionTool<Viewer extends object> extends Tool<Viewer> {
         }),
       ).element,
     );
+
+    const shouldIgnoreEvent = (event: Event) => {
+      const target = event.target;
+      if (
+        target instanceof Element &&
+        target.matches(".neuroglancer-position-dimension-playback *")
+      ) {
+        return true;
+      }
+      return false;
+    };
+    const mouseHandler = this.registerDisposer(
+      new MouseEventBinder(plot.element, inputEventMap),
+    );
+    mouseHandler.shouldIgnore = shouldIgnoreEvent;
+
+    registerActionListener<WheelEvent>(
+      plot.element,
+      "adjust-via-wheel",
+      (actionEvent) => {
+        actionEvent.stopPropagation();
+        const event = actionEvent.detail;
+        const { deltaY } = event;
+        if (deltaY === 0) {
+          return;
+        }
+        positionWidget.adjustDimensionPosition(
+          this.dimensionId,
+          Math.sign(deltaY),
+        );
+      },
+    );
+
+    registerActionListener<WheelEvent>(
+      plot.element,
+      "adjust-velocity-via-wheel",
+      (actionEvent) => {
+        actionEvent.stopPropagation();
+        const factor = getWheelZoomAmount(actionEvent.detail);
+        viewer.velocity.multiplyVelocity(this.dimensionId, factor);
+      },
+    );
+
     return { positionWidget };
   }
 


### PR DESCRIPTION
## Summary

This PR fixes the dimension fine-tuning when the dimension tool is integrated in a palette. The way the dimension tool is working, when not integrated in a palette, is by grabbing the events from the x/y/z input widgets. When the dimension tool is moved in a palette, only those input widget are reacting to the events from the mouse wheel. This patch adds the mouse event handling also on the `PositionPlot` instance.