### PR TITLE
CC-189 Styling for the color widget

### DIFF
--- a/src/ui/layer_bar.css
+++ b/src/ui/layer_bar.css
@@ -176,14 +176,6 @@
   transform: scale(1.35);
 }
 
-/* linear-gradient(
-    45deg,
-    rgba(200, 200, 200, 0.3) 25%,
-    transparent 25%
-  ),
-  linear-gradient(-45deg, rgba(200, 200, 200, 0.3) 25%, transparent 25%),
-  linear-gradient(45deg, transparent 75%, rgba(200, 200, 200, 0.3) 75%),
-  linear-gradient(-45deg, transparent 75%, rgba(200, 200, 200, 0.3) 75%); */
 .neuroglancer-layer-item[data-color="unsupported"]
   .neuroglancer-layer-color-value {
   background-image: linear-gradient(

--- a/src/ui/layer_bar.css
+++ b/src/ui/layer_bar.css
@@ -134,6 +134,12 @@
   align-items: center;
 }
 
+.neuroglancer-layer-color-value {
+  border-radius: 50%;
+  height: 10px;
+  width: 10px;
+}
+
 .neuroglancer-layer-item[data-color="fixed"] .neuroglancer-layer-color-value {
   border-radius: 50%;
   height: 10px;
@@ -170,23 +176,30 @@
   transform: scale(1.35);
 }
 
+/* linear-gradient(
+    45deg,
+    rgba(200, 200, 200, 0.3) 25%,
+    transparent 25%
+  ),
+  linear-gradient(-45deg, rgba(200, 200, 200, 0.3) 25%, transparent 25%),
+  linear-gradient(45deg, transparent 75%, rgba(200, 200, 200, 0.3) 75%),
+  linear-gradient(-45deg, transparent 75%, rgba(200, 200, 200, 0.3) 75%); */
 .neuroglancer-layer-item[data-color="unsupported"]
   .neuroglancer-layer-color-value {
   background-image: linear-gradient(
       45deg,
-      rgba(128, 128, 128, 0.5) 25%,
+      rgba(128, 128, 128, 1.5) 25%,
       transparent 25%
     ),
-    linear-gradient(-45deg, rgba(128, 128, 128, 0.5) 25%, transparent 25%),
-    linear-gradient(45deg, transparent 75%, rgba(128, 128, 128, 0.5) 75%),
-    linear-gradient(-45deg, transparent 75%, rgba(128, 128, 128, 0.5) 75%);
+    linear-gradient(-45deg, rgba(128, 128, 128, 1.5) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, rgba(128, 128, 128, 1.5) 75%),
+    linear-gradient(-45deg, transparent 75%, rgba(128, 128, 128, 1.5) 75%);
   background-size: 4px 4px;
   background-position:
     0 0,
     0 2px,
     2px -2px,
     -2px 0px;
-  padding: 6px;
 }
 
 .neuroglancer-layer-color-value-wrapper {

--- a/src/ui/layer_list_panel.css
+++ b/src/ui/layer_list_panel.css
@@ -91,19 +91,18 @@
 .neuroglancer-layer-list-panel-color-value.unsupported {
   background-image: linear-gradient(
       45deg,
-      rgba(128, 128, 128, 0.5) 25%,
+      rgba(128, 128, 128, 1.5) 25%,
       transparent 25%
     ),
-    linear-gradient(-45deg, rgba(128, 128, 128, 0.5) 25%, transparent 25%),
-    linear-gradient(45deg, transparent 75%, rgba(128, 128, 128, 0.5) 75%),
-    linear-gradient(-45deg, transparent 75%, rgba(128, 128, 128, 0.5) 75%);
+    linear-gradient(-45deg, rgba(128, 128, 128, 1.5) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, rgba(128, 128, 128, 1.5) 75%),
+    linear-gradient(-45deg, transparent 75%, rgba(128, 128, 128, 1.5) 75%);
   background-size: 4px 4px;
   background-position:
     0 0,
     0 2px,
     2px -2px,
     -2px 0px;
-  padding: 6px;
 }
 
 .neuroglancer-layer-list-panel-color-value-wrapper.unsupported::before {


### PR DESCRIPTION
Issue [#CC-189](https://metacell.atlassian.net/browse/CC-189)
Problem: Styling for the color widget
Solution: 
1. Make both circle look same (on left side panel and in header list panel item)
2. Make both circles brighter 
Result: 

https://github.com/user-attachments/assets/afa63a13-a137-4f0e-8599-3f53885ed430

