### PR TITLE
CC-198 Bring layout buttons from google NG into main NG

### DIFF
--- a/src/layer_group_viewer.css
+++ b/src/layer_group_viewer.css
@@ -51,3 +51,23 @@
 .neuroglancer-layer-group-viewer-context-menu select {
   margin-left: 5px;
 }
+
+.layout-button-container {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.layout-button-container button {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.25rem;
+  border: 1px solid #222;
+  font-size: 13px;
+  font-weight: 500;
+  color: white;
+  background-color: #222;
+}
+
+.layout-button-container button:hover {
+  background-color: #333;
+}

--- a/src/layer_group_viewer.ts
+++ b/src/layer_group_viewer.ts
@@ -522,6 +522,8 @@ export class LayerGroupViewer extends RefCounted {
   private updateUI() {
     const { options } = this;
     const showLayerPanel = options.showLayerPanel.value;
+    const layoutButtonContainer = document.createElement("div");
+    layoutButtonContainer.className = "layout-button-container";
     if (this.layerPanel !== undefined && !showLayerPanel) {
       this.layerPanel.dispose();
       this.layerPanel = undefined;
@@ -541,6 +543,9 @@ export class LayerGroupViewer extends RefCounted {
         layerPanel.element.title = "Drag to move/copy layer group.";
       }
 
+      //TODO: should be deleted in future, just a mock value
+      let NEUROGLANCER_SHOW_LAYER_BAR_EXTRA_BUTTONS = true;
+
       if (
         typeof NEUROGLANCER_SHOW_LAYER_BAR_EXTRA_BUTTONS !== "undefined" &&
         NEUROGLANCER_SHOW_LAYER_BAR_EXTRA_BUTTONS === true
@@ -552,7 +557,7 @@ export class LayerGroupViewer extends RefCounted {
           button.addEventListener("click", (event: MouseEvent) => {
             dispatchEventAction(event, event, { action: "clear-segments" });
           });
-          layerPanel.element.appendChild(button);
+          layoutButtonContainer.appendChild(button);
         }
         for (const layout of ["3d", "xy", "xz", "yz"]) {
           const button = document.createElement("button");
@@ -571,8 +576,9 @@ export class LayerGroupViewer extends RefCounted {
             }
             this.layout.name = newLayout;
           });
-          layerPanel.element.appendChild(button);
+          layoutButtonContainer.appendChild(button);
         }
+        layerPanel.element.appendChild(layoutButtonContainer);
       }
       layerPanel.element.draggable = true;
       const layerPanelElement = layerPanel.element;


### PR DESCRIPTION
Issue [#CC-198 ](https://metacell.atlassian.net/browse/CC-198)
Problem: Bring layout buttons from google NG into main NG
Solution: 

1. Put all layout buttons in one div and style buttons, apply dark theme to buttons

Result: 

https://github.com/user-attachments/assets/3bed87ec-1b90-474a-bb09-eb19be2411fe

