### PR TITLE
CC-212 Tool palette UI improvements

### DIFF
--- a/src/ui/tool_palette.css
+++ b/src/ui/tool_palette.css
@@ -115,6 +115,7 @@
 .neuroglancer-tool-palette-layer-group-items[tool-stacking="horizontal"] {
   flex-direction: row;
   overflow-x: auto;
+  height: 100%;
 }
 
 .neuroglancer-tool-palette-layer-group-items

--- a/src/ui/tool_palette.css
+++ b/src/ui/tool_palette.css
@@ -114,6 +114,7 @@
 
 .neuroglancer-tool-palette-layer-group-items[tool-stacking="horizontal"] {
   flex-direction: row;
+  align-items: flex-start;
   overflow-x: auto;
   height: 100%;
 }
@@ -121,15 +122,21 @@
 .neuroglancer-tool-palette-layer-group-items
   .neuroglancer-tool-palette-layer-group {
   width: 100%;
+  height: 100%;
+}
+
+.neuroglancer-tool-palette-layer-group-content >.neuroglancer-tool-palette-tool-container {
+  align-items: center;
 }
 
 .neuroglancer-tool-palette-tool-container {
   display: grid;
   grid-template-columns: auto 1fr;
-  align-items: center;
+  align-items: flex-start;
   padding-top: 2px;
   padding-bottom: 2px;
   width: 100%;
+  height: 100%;
 }
 
 .neuroglancer-tool-palette-tool-container:hover {

--- a/src/ui/tool_palette.ts
+++ b/src/ui/tool_palette.ts
@@ -20,7 +20,7 @@ import svg_search from "ikonate/icons/search.svg?raw";
 import swap_horizontal from "ikonate/icons/swap-horizontal.svg?raw";
 import swap_vertical from "ikonate/icons/swap-vertical.svg?raw";
 import svg_tool from "ikonate/icons/tool.svg?raw";
-import { debounce } from "lodash-es";
+import { debounce, throttle } from "lodash-es";
 import type { UserLayer } from "#src/layer/index.js";
 import {
   ElementVisibilityFromTrackableBoolean,
@@ -549,7 +549,7 @@ export class ToolPalettePanel extends SidePanel {
       );
     };
 
-    const update = (event: DragEvent, updateDropEffect: boolean) => {
+    const update = throttle((event: DragEvent, updateDropEffect: boolean) => {
       if (!isDragSourceSupported()) {
         return undefined;
       }
@@ -636,7 +636,7 @@ export class ToolPalettePanel extends SidePanel {
         updateToolDragDropEffect(source, dropEffect, samePalette);
       }
       return dropEffect;
-    };
+    }, 200);
 
     const handleDragOver = (event: DragEvent) => {
       const updateResult = update(event, /*updateDropEffect=*/ true);


### PR DESCRIPTION
Issue [#CC-212](https://metacell.atlassian.net/browse/CC-212) 
Problem: Tool palette UI improvements
Solution: 
1. Make layer group component to fill up all the space when in horizontal stacking
2. Place layer group items on top left

Result: 
https://github.com/user-attachments/assets/52e91ebe-6b35-4821-b8ef-757aa2a938b0
