### PR TITLE
NA-386 Fix that new input boxes take up too much space on left and cause URLs not to be the same

### DIFF
--- a/src/widget/display_dimensions_widget.css
+++ b/src/widget/display_dimensions_widget.css
@@ -27,7 +27,6 @@
   display: grid;
   grid-template-rows: 0fr 0fr 0fr 0fr;
   grid-template-columns: 0fr 0fr 0fr;
-  grid-row-gap: 2px;
 }
 
 .neuroglancer-display-dimensions-widget input {
@@ -73,6 +72,7 @@
   font-family: monospace;
   color: white;
   font-size: 0.75rem;
+  line-height: 16px;
 }
 
 .neuroglancer-display-dimensions-widget-dimension:hover {
@@ -84,7 +84,7 @@
 }
 
 .neuroglancer-display-dimensions-widget-name {
-  min-width: 8px;
+  min-width: 6px;
 }
 
 .neuroglancer-display-dimensions-widget-scale-factor {
@@ -121,6 +121,7 @@
 .neuroglancer-display-dimensions-widget-fov {
   display: flex;
   flex-direction: column;
+  margin-top: 12px;
 }
 
 .neuroglancer-display-dimensions-widget-fov-container {
@@ -162,23 +163,25 @@
   display: flex;
   align-items: center;
   white-space: nowrap;
+  gap: 4px;
 }
 
 .neuroglancer-display-dimensions-widget input[type="checkbox"] {
-  margin-right: 0.25rem;
+  margin: 0.25rem;
   vertical-align: middle;
 }
 
 .neuroglancer-depth-range-relative-checkbox-label {
   display: flex;
   align-items: center;
+  gap: 4px;
 }
 
 .neuroglancer-depth-range-widget-grid {
   margin-top: 1em;
   display: grid;
   display: grid;
-  grid-template-columns: 0fr 0fr 0fr;
+  grid-template-columns: 1fr;
   grid-auto-rows: 0fr;
 }
 
@@ -191,11 +194,11 @@
 }
 
 .neuroglancer-depth-range-widget-dimension-names {
-  margin-left: 1ch;
   white-space: nowrap;
 }
 
 .neuroglancer-depth-range-container {
   display: flex;
   align-items: center;
+  gap: 4px;
 }

--- a/src/widget/display_dimensions_widget.css
+++ b/src/widget/display_dimensions_widget.css
@@ -27,15 +27,35 @@
   display: grid;
   grid-template-rows: 0fr 0fr 0fr 0fr;
   grid-template-columns: 0fr 0fr 0fr;
+  grid-row-gap: 2px;
 }
 
 .neuroglancer-display-dimensions-widget input {
   outline: 0px;
   background-color: transparent;
-  border: 1px solid transparent;
   box-shadow: none;
   margin: 0;
+  text-align: right;
+}
+
+.input-base {
   padding: 2px;
+  border: 1px solid transparent;
+  min-width: 26px;
+}
+
+.input-wrapper {
+  display: inline-flex;
+  padding: 2px;
+  line-height: normal;
+}
+
+.input-wrapper input {
+  padding: 0;
+}
+
+.input-wrapper:has(input[style*="display: none"]) {
+  display: none;
 }
 
 .neuroglancer-display-dimensions-widget input:hover {
@@ -63,25 +83,29 @@
   text-decoration: solid underline red;
 }
 
+.neuroglancer-display-dimensions-widget-name {
+  min-width: 8px;
+}
+
 .neuroglancer-display-dimensions-widget-scale-factor {
   text-align: right;
   align-items: end;
   display: inline-block;
   white-space: nowrap;
-  margin-left: 2px;
+  margin-left: 4px;
+  margin-right: 4px;
 }
 
 .neuroglancer-display-dimensions-widget-scale {
   display: inline-block;
   white-space: nowrap;
-  padding-left: 10px;
 }
 
-.neuroglancer-display-dimensions-widget-scale:not(:empty)::before {
+.input-wrapper:not(:empty)::before {
   content: "(";
 }
 
-.neuroglancer-display-dimensions-widget-scale:not(:empty)::after {
+.input-wrapper:not(:empty)::after {
   content: ")";
 }
 
@@ -108,7 +132,7 @@
 .neuroglancer-display-dimensions-widget:not(:hover):not([data-active="true"])
   .neuroglancer-display-dimensions-widget-scale-factor,
 .neuroglancer-display-dimensions-widget:not(:hover):not([data-active="true"])
-  .neuroglancer-display-dimensions-widget-scale,
+  .input-wrapper,
 .neuroglancer-display-dimensions-widget:not(:hover):not([data-active="true"])
   .neuroglancer-display-dimensions-widget-default,
 .neuroglancer-display-dimensions-widget:not(:hover):not([data-active="true"])
@@ -123,7 +147,7 @@
 .neuroglancer-display-dimensions-widget-dimension[data-is-modified="true"]
   .neuroglancer-display-dimensions-widget-scale-factor,
 .neuroglancer-display-dimensions-widget-dimension[data-is-modified="true"]
-  .neuroglancer-display-dimensions-widget-scale {
+  .input-wrapper {
   visibility: hidden;
 }
 

--- a/src/widget/display_dimensions_widget.ts
+++ b/src/widget/display_dimensions_widget.ts
@@ -122,6 +122,7 @@ export class DisplayDimensionsWidget extends RefCounted {
 
     const name = document.createElement("input");
     name.classList.add("neuroglancer-display-dimensions-widget-name");
+    name.classList.add("input-base");
     name.title = "Change display dimensions";
     name.spellcheck = false;
     name.autocomplete = "off";
@@ -138,6 +139,7 @@ export class DisplayDimensionsWidget extends RefCounted {
       "neuroglancer-display-dimensions-widget-scale-factor",
     );
     const scaleFactor = document.createElement("input");
+    scaleFactor.classList.add("input-base");
     scaleFactor.spellcheck = false;
     scaleFactor.title = "Change relative scale at which dimension is displayed";
     scaleFactor.autocomplete = "off";
@@ -149,11 +151,15 @@ export class DisplayDimensionsWidget extends RefCounted {
     scaleFactorContainer.appendChild(scaleFactor);
     container.appendChild(scaleFactorContainer);
 
+    const scaleWrapper = document.createElement("div");
+    scaleWrapper.classList.add("input-wrapper");
     const scale = document.createElement("input");
     scale.classList.add("neuroglancer-display-dimensions-widget-scale");
+    scale.classList.add("input-base");
     scale.style.gridColumn = "3";
     scale.style.gridRow = `${i + 1}`;
-    container.appendChild(scale);
+    scaleWrapper.appendChild(scale);
+    container.appendChild(scaleWrapper);
     this.dimensionGridContainer.appendChild(container);
     scale.addEventListener("input", () => {
       updateInputFieldWidth(scale);
@@ -444,6 +450,7 @@ export class DisplayDimensionsWidget extends RefCounted {
         const directionIndicator = document.createElement("span");
         directionIndicator.textContent = i === 0 ? "(←→)" : "(↑↓)";
         const input = document.createElement("input");
+        input.classList.add("input-base");
         input.spellcheck = false;
         input.autocomplete = "off";
         this.fovInputElements.push(input);
@@ -583,6 +590,7 @@ export class DisplayDimensionsWidget extends RefCounted {
               plusMinus.textContent = "±";
               container.appendChild(plusMinus);
               const input = document.createElement("input");
+              input.classList.add("input-base");
               input.spellcheck = false;
               input.autocomplete = "off";
               input.addEventListener("focus", () => {


### PR DESCRIPTION
Issue [#NA-386 ](https://metacell.atlassian.net/browse/NA-386)
Problem: Fix that new input boxes take up too much space on left and cause URLs not to be the same
Solution: 
1. Add row gap between widgets
2. Add brackets and wrap inputs with brackets into seperate div

Result: 


https://github.com/user-attachments/assets/9dee8c55-8c85-48d0-8b7f-5abe2fdda820

