### PR TITLE
Feature/cc 298

### DIFF
--- a/src/data_panel_layout.ts
+++ b/src/data_panel_layout.ts
@@ -100,7 +100,6 @@ export interface ViewerUIState
   inputEventBindings: InputEventBindings;
   crossSectionBackgroundColor: TrackableRGB;
   perspectiveViewBackgroundColor: TrackableRGB;
-  enableLayerColorWidget: TrackableBoolean;
   hideCrossSectionBackground3D: TrackableBoolean;
 }
 
@@ -183,7 +182,6 @@ export function getCommonViewerState(viewer: ViewerUIState) {
     selectedLayer: viewer.selectedLayer,
     visibility: viewer.visibility,
     scaleBarOptions: viewer.scaleBarOptions,
-    enableLayerColorWidget: viewer.enableLayerColorWidget,
     hideCrossSectionBackground3D: viewer.hideCrossSectionBackground3D,
   };
 }

--- a/src/layer/annotation/index.ts
+++ b/src/layer/annotation/index.ts
@@ -762,16 +762,6 @@ export class AnnotationUserLayer extends Base {
     return undefined;
   }
 
-  colorWidgetTooltip(): string | undefined {
-    const shaderHasDefaultColor =
-      this.annotationDisplayState.shader.value.includes("defaultColor");
-    if (shaderHasDefaultColor && this.annotationDisplayState.color.value) {
-      return `The color comes from the selected shader default color`;
-    }
-
-    return "Your shader code doesn't use the default color, we cannot determine which color you are using";
-  }
-
   static type = "annotation";
   static typeAbbreviation = "ann";
   static supportsLayerBarColorSyncOption = true;

--- a/src/layer/index.ts
+++ b/src/layer/index.ts
@@ -204,10 +204,6 @@ export class UserLayer extends RefCounted {
     return this.automaticLayerBarColor;
   }
 
-  colorWidgetTooltip(): string | undefined {
-    return undefined;
-  }
-
   initializeSelectionState(state: this["selectionState"]) {
     state.generation = -1;
     state.localPositionValid = false;
@@ -759,11 +755,6 @@ export class ManagedUserLayer extends RefCounted {
   get layerBarColor(): string | undefined {
     const userLayer = this.layer;
     return userLayer?.layerBarColor;
-  }
-
-  colorWidgetTooltip(): string | undefined {
-    const userLayer = this.layer;
-    return userLayer?.colorWidgetTooltip();
   }
 
   observeLayerColor(callback: () => void): () => void {

--- a/src/layer/segmentation/index.ts
+++ b/src/layer/segmentation/index.ts
@@ -1330,20 +1330,6 @@ export class SegmentationUserLayer extends Base {
     return undefined;
   }
 
-  colorWidgetTooltip(): string {
-    if (this.displayState.segmentDefaultColor.value) {
-      return `The color comes from the manually selected color`;
-    }
-
-    const visibleSegments =
-      this.displayState.segmentationGroupState.value.visibleSegments;
-    if (visibleSegments.size === 1) {
-      const id = [...visibleSegments][0];
-      return `The color of the visible segment with id "${id}"`;
-    }
-    return "The segmentation layer has multiple segments visible";
-  }
-
   static type = "segmentation";
   static typeAbbreviation = "seg";
   static supportsPickOption = true;

--- a/src/layer_group_viewer.ts
+++ b/src/layer_group_viewer.ts
@@ -102,7 +102,6 @@ export interface LayerGroupViewerState {
   visibleLayerRoles: WatchableSet<RenderLayerRole>;
   crossSectionBackgroundColor: TrackableRGB;
   perspectiveViewBackgroundColor: TrackableRGB;
-  enableLayerColorWidget: TrackableBoolean;
   hideCrossSectionBackground3D: TrackableBoolean;
 }
 
@@ -385,9 +384,6 @@ export class LayerGroupViewer extends RefCounted {
   }
   get scaleBarOptions() {
     return this.viewerState.scaleBarOptions;
-  }
-  get enableLayerColorWidget() {
-    return this.viewerState.enableLayerColorWidget;
   }
   layerPanel: LayerBar | undefined;
   layout: DataPanelLayoutContainer;

--- a/src/layer_groups_layout.ts
+++ b/src/layer_groups_layout.ts
@@ -420,7 +420,6 @@ function getCommonViewerState(viewer: Viewer) {
     velocity: viewer.velocity.addRef(),
     crossSectionBackgroundColor: viewer.crossSectionBackgroundColor,
     perspectiveViewBackgroundColor: viewer.perspectiveViewBackgroundColor,
-    enableLayerColorWidget: viewer.enableLayerColorWidget,
     hideCrossSectionBackground3D: viewer.hideCrossSectionBackground3D,
   };
 }

--- a/src/ui/layer_bar.css
+++ b/src/ui/layer_bar.css
@@ -140,6 +140,13 @@
   );
 }
 
+.neuroglancer-layer-item[data-visible="false"]
+  .neuroglancer-layer-item-label[data-color="rainbow"],
+.neuroglancer-layer-item[data-visible="false"]
+  .neuroglancer-layer-item-label[data-color="solid"] {
+  opacity: 0.6;
+}
+
 .neuroglancer-layer-item-value {
   grid-row: 1;
   grid-column: 1;

--- a/src/ui/layer_bar.css
+++ b/src/ui/layer_bar.css
@@ -148,9 +148,6 @@
 
 .neuroglancer-layer-item[data-color="rainbow"] .neuroglancer-layer-color-value {
   position: relative;
-  border-radius: 50%;
-  height: 10px;
-  width: 10px;
   overflow: hidden;
 }
 
@@ -158,22 +155,19 @@
   .neuroglancer-layer-color-value::before {
   content: "";
   position: absolute;
-  top: -17.5%;
-  left: -17.5%;
-  width: 135%;
-  height: 135%;
-  background: conic-gradient(
-    from 0deg,
-    hsl(0, 100%, 50%),
-    hsl(60, 100%, 50%),
-    hsl(120, 100%, 50%),
-    hsl(180, 100%, 50%),
-    hsl(240, 100%, 50%),
-    hsl(300, 100%, 50%),
-    hsl(360, 100%, 50%)
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    #6a1b9a 0%,
+    #283593 25%,
+    #00695c 50%,
+    #2e7d32 75%,
+    #f57f17 100%
   );
-  filter: blur(1px);
-  transform: scale(1.35);
+  opacity: 0.6;
 }
 
 .neuroglancer-layer-item[data-color="unsupported"]

--- a/src/ui/layer_bar.css
+++ b/src/ui/layer_bar.css
@@ -62,14 +62,9 @@
   border-color: #daa520;
 }
 
-.neuroglancer-layer-item[data-pick="true"] .neuroglancer-layer-item-label {
-  background-color: #939;
-}
-
 .neuroglancer-layer-item-label {
   display: inline-block;
   position: relative;
-  background-color: #222;
   padding-right: 3px;
 }
 
@@ -134,31 +129,7 @@
   align-items: center;
 }
 
-.neuroglancer-layer-color-value {
-  border-radius: 50%;
-  height: 10px;
-  width: 10px;
-}
-
-.neuroglancer-layer-item[data-color="fixed"] .neuroglancer-layer-color-value {
-  border-radius: 50%;
-  height: 10px;
-  width: 10px;
-}
-
-.neuroglancer-layer-item[data-color="rainbow"] .neuroglancer-layer-color-value {
-  position: relative;
-  overflow: hidden;
-}
-
-.neuroglancer-layer-item[data-color="rainbow"]
-  .neuroglancer-layer-color-value::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+.neuroglancer-layer-item-label[data-color="rainbow"] {
   background: linear-gradient(
     90deg,
     #6a1b9a 0%,
@@ -167,60 +138,6 @@
     #2e7d32 75%,
     #f57f17 100%
   );
-  opacity: 0.6;
-}
-
-.neuroglancer-layer-item[data-color="unsupported"]
-  .neuroglancer-layer-color-value {
-  background-image: linear-gradient(
-      45deg,
-      rgba(128, 128, 128, 1.5) 25%,
-      transparent 25%
-    ),
-    linear-gradient(-45deg, rgba(128, 128, 128, 1.5) 25%, transparent 25%),
-    linear-gradient(45deg, transparent 75%, rgba(128, 128, 128, 1.5) 75%),
-    linear-gradient(-45deg, transparent 75%, rgba(128, 128, 128, 1.5) 75%);
-  background-size: 4px 4px;
-  background-position:
-    0 0,
-    0 2px,
-    2px -2px,
-    -2px 0px;
-}
-
-.neuroglancer-layer-color-value-wrapper {
-  position: relative;
-  width: 10px;
-  height: 10px;
-  padding: 5px;
-  margin: 0 4px;
-}
-
-.neuroglancer-layer-item[data-color="unsupported"]
-  .neuroglancer-layer-color-value-wrapper {
-  position: relative;
-}
-
-.neuroglancer-layer-item[data-visible="false"]
-  .neuroglancer-layer-color-value-wrapper
-  .neuroglancer-layer-color-value,
-.neuroglancer-layer-item[data-visible="false"]
-  .neuroglancer-layer-color-value-wrapper
-  .neuroglancer-layer-color-value::before {
-  opacity: 0.4;
-}
-
-.neuroglancer-layer-item[data-visible="false"]
-  .neuroglancer-layer-color-value-wrapper::before {
-  content: "";
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 18px;
-  height: 1px;
-  background-color: rgb(255, 255, 255);
-  transform: translate(-50%, -50%) rotate(135deg);
-  z-index: 1;
 }
 
 .neuroglancer-layer-item-value {

--- a/src/ui/layer_bar.ts
+++ b/src/ui/layer_bar.ts
@@ -161,7 +161,6 @@ class LayerWidget extends RefCounted {
     labelElementText.textContent = layer.name;
     element.dataset.visible = layer.visible.toString();
     element.dataset.selected = (layer === panel.selectedLayer.layer).toString();
-    element.dataset.pick = layer.pickEnabled.toString();
     let title = `Click to ${
       layer.visible ? "hide" : "show"
     }, control+click to show side panel`;
@@ -176,20 +175,18 @@ class LayerWidget extends RefCounted {
     if (layer.supportsLayerBarColorSyncOption) {
       const color = layer.layerBarColor;
       if (color) {
-        element.dataset.color = "fixed";
         labelElement.style.backgroundColor = color;
         const textColor = useWhiteBackground(parseRGBColorSpecification(color))
           ? "white"
           : "black";
         labelElement.style.color = textColor;
       } else {
-        element.dataset.color = "rainbow";
-        labelElement.style.color = "black";
+        labelElement.dataset.color = "rainbow";
+        labelElement.style.color = "white";
       }
     } else {
-      labelElement.style.backgroundColor = "";
+      labelElement.style.backgroundColor = "#222";
       labelElement.style.color = "white";
-      element.dataset.color = "unsupported";
     }
   }
 

--- a/src/ui/layer_bar.ts
+++ b/src/ui/layer_bar.ts
@@ -179,6 +179,7 @@ class LayerWidget extends RefCounted {
         const textColor = useWhiteBackground(parseRGBColorSpecification(color))
           ? "white"
           : "black";
+        labelElement.dataset.color = "solid";
         labelElement.style.color = textColor;
       } else {
         labelElement.dataset.color = "rainbow";
@@ -186,7 +187,7 @@ class LayerWidget extends RefCounted {
       }
     } else {
       labelElement.style.backgroundColor = "#222";
-      labelElement.style.color = "white";
+      labelElement.style.color = "";
     }
   }
 

--- a/src/ui/layer_bar.ts
+++ b/src/ui/layer_bar.ts
@@ -191,9 +191,6 @@ class LayerWidget extends RefCounted {
       labelElement.style.color = "white";
       element.dataset.color = "unsupported";
     }
-    labelElement.title =
-      layer.colorWidgetTooltip() ||
-      "The color of this layer cannot be determined";
   }
 
   disposed() {

--- a/src/ui/layer_list_panel.css
+++ b/src/ui/layer_list_panel.css
@@ -88,7 +88,7 @@
   width: 10px;
 }
 
-.neuroglancer-layer-list-panel-color-value.rainbow {
+.neuroglancer-layer-list-panel-color-value[data-color="rainbow"] {
   position: relative;
   border-radius: 50%;
   height: 10px;
@@ -96,7 +96,7 @@
   overflow: hidden;
 }
 
-.neuroglancer-layer-list-panel-color-value.rainbow::before {
+.neuroglancer-layer-list-panel-color-value[data-color="rainbow"]::before {
   content: "";
   position: absolute;
   top: -17.5%;
@@ -117,7 +117,7 @@
   transform: scale(1.35);
 }
 
-.neuroglancer-layer-list-panel-color-value.unsupported {
+.neuroglancer-layer-list-panel-color-value[data-color="unsupported"] {
   background-image: linear-gradient(
       45deg,
       rgba(128, 128, 128, 1.5) 25%,
@@ -134,18 +134,13 @@
     -2px 0px;
 }
 
-.neuroglancer-layer-list-panel-color-value-wrapper.unsupported::before {
-  position: relative;
+.neuroglancer-layer-list-panel-color-value-wrapper[data-visible="false"]
+  .neuroglancer-layer-list-panel-color-value {
+  opacity: 0.3;
 }
 
-.neuroglancer-layer-list-panel-color-value-wrapper.cross
-  .neuroglancer-layer-list-panel-color-value,
-.neuroglancer-layer-list-panel-color-value-wrapper.cross
-  .neuroglancer-layer-list-panel-color-value.rainbow::before {
-  opacity: 0.4;
-}
-
-.neuroglancer-layer-list-panel-color-value-wrapper.cross::before {
+/* Place a / over the color value in widget when it is not visible */
+.neuroglancer-layer-list-panel-color-value-wrapper[data-visible="false"]::before {
   content: "";
   position: absolute;
   top: 50%;

--- a/src/ui/layer_list_panel.ts
+++ b/src/ui/layer_list_panel.ts
@@ -92,8 +92,6 @@ export class LayerVisibilityWidget extends RefCounted {
         this.layer.setVisible(true);
       },
     });
-    element.style.display = "flex";
-    element.style.alignItems = "center";
     hideIcon.classList.add("neuroglancer-layer-list-panel-eye-icon");
     showIcon.classList.add("neuroglancer-layer-list-panel-eye-icon");
     element.appendChild(showIcon);
@@ -123,20 +121,17 @@ class LayerColorWidget extends RefCounted {
       "neuroglancer-layer-list-panel-color-value-wrapper";
     elementWrapper.appendChild(element);
     const updateLayerColorWidget = () => {
-      element.classList.remove("rainbow");
-      element.classList.remove("unsupported");
       const color = this.layer.layerBarColor;
       if (color) {
         element.style.backgroundColor = color;
         element.title = "Primary layer color";
-        element.classList.remove("rainbow");
       } else {
         if (this.layer.supportsLayerBarColorSyncOption) {
           element.title = "Multi-colored layer";
-          element.classList.add("rainbow");
+          element.dataset.color = "rainbow";
         } else {
           element.title = "Layer does not support color legend";
-          element.classList.add("unsupported");
+          element.dataset.color = "unsupported";
         }
         element.style.backgroundColor = "";
       }
@@ -148,11 +143,7 @@ class LayerColorWidget extends RefCounted {
     );
     this.registerDisposer(
       layer.layerChanged.add(() => {
-        if (!this.layer.visible) {
-          elementWrapper.classList.add("cross");
-        } else {
-          elementWrapper.classList.remove("cross");
-        }
+        elementWrapper.dataset.visible = this.layer.visible.toString();
         updateLayerColorWidget();
       }),
     );

--- a/src/ui/layer_list_panel.ts
+++ b/src/ui/layer_list_panel.ts
@@ -128,12 +128,16 @@ class LayerColorWidget extends RefCounted {
       const color = this.layer.layerBarColor;
       if (color) {
         element.style.backgroundColor = color;
+        element.title = "Primary layer color";
         element.classList.remove("rainbow");
       } else {
-        const style = this.layer.supportsLayerBarColorSyncOption
-          ? "rainbow"
-          : "unsupported";
-        element.classList.add(style);
+        if (this.layer.supportsLayerBarColorSyncOption) {
+          element.title = "Multi-colored layer";
+          element.classList.add("rainbow");
+        } else {
+          element.title = "Layer does not support color legend";
+          element.classList.add("unsupported");
+        }
         element.style.backgroundColor = "";
       }
     };

--- a/src/ui/layer_list_panel.ts
+++ b/src/ui/layer_list_panel.ts
@@ -108,32 +108,32 @@ export class LayerVisibilityWidget extends RefCounted {
 
 class LayerColorWidget extends RefCounted {
   element = document.createElement("div");
-  elementWrapper = document.createElement("div");
+  colorIndicator = document.createElement("div");
 
   constructor(
     public panel: LayerListPanel,
     public layer: ManagedUserLayer,
   ) {
     super();
-    const { element, elementWrapper } = this;
-    element.className = "neuroglancer-layer-list-panel-color-value";
-    elementWrapper.className =
+    const { colorIndicator, element } = this;
+    colorIndicator.className = "neuroglancer-layer-list-panel-color-value";
+    element.className =
       "neuroglancer-layer-list-panel-color-value-wrapper";
-    elementWrapper.appendChild(element);
+    element.appendChild(colorIndicator);
     const updateLayerColorWidget = () => {
       const color = this.layer.layerBarColor;
       if (color) {
-        element.style.backgroundColor = color;
-        element.title = "Primary layer color";
+        colorIndicator.style.backgroundColor = color;
+        colorIndicator.title = "Primary layer color";
       } else {
         if (this.layer.supportsLayerBarColorSyncOption) {
-          element.title = "Multi-colored layer";
-          element.dataset.color = "rainbow";
+          colorIndicator.title = "Multi-colored layer";
+          colorIndicator.dataset.color = "rainbow";
         } else {
-          element.title = "Layer does not support color legend";
-          element.dataset.color = "unsupported";
+          colorIndicator.title = "Layer does not support color legend";
+          colorIndicator.dataset.color = "unsupported";
         }
-        element.style.backgroundColor = "";
+        colorIndicator.style.backgroundColor = "";
       }
     };
     this.registerDisposer(
@@ -143,10 +143,11 @@ class LayerColorWidget extends RefCounted {
     );
     this.registerDisposer(
       layer.layerChanged.add(() => {
-        elementWrapper.dataset.visible = this.layer.visible.toString();
+        element.dataset.visible = this.layer.visible.toString();
         updateLayerColorWidget();
       }),
     );
+    element.dataset.visible = this.layer.visible.toString();
     updateLayerColorWidget();
   }
 }
@@ -220,7 +221,7 @@ class LayerListItem extends RefCounted {
       this.registerDisposer(new LayerVisibilityWidget(layer)).element,
     );
     element.appendChild(
-      this.registerDisposer(new LayerColorWidget(panel, layer)).elementWrapper,
+      this.registerDisposer(new LayerColorWidget(panel, layer)).element,
     );
     element.appendChild(new LayerTypeIndicatorWidget(layer).element);
     element.appendChild(layerNameWidget.element);

--- a/src/ui/layer_list_panel.ts
+++ b/src/ui/layer_list_panel.ts
@@ -25,7 +25,6 @@ import type {
 } from "#src/layer/index.js";
 import { deleteLayer } from "#src/layer/index.js";
 import { TrackableBooleanCheckbox } from "#src/trackable_boolean.js";
-import { observeWatchable } from "#src/trackable_value.js";
 import type { DropLayers } from "#src/ui/layer_drag_and_drop.js";
 import {
   registerLayerBarDragLeaveHandler,
@@ -138,12 +137,6 @@ class LayerColorWidget extends RefCounted {
         element.style.backgroundColor = "";
       }
     };
-    this.registerDisposer(
-      observeWatchable((layerColorEnabled) => {
-        elementWrapper.style.display = layerColorEnabled ? "block" : "none";
-        updateLayerColorWidget();
-      }, panel.sidePanelManager.viewerState.enableLayerColorWidget),
-    );
     this.registerDisposer(
       layer.observeLayerColor(() => {
         updateLayerColorWidget();

--- a/src/ui/layer_list_panel.ts
+++ b/src/ui/layer_list_panel.ts
@@ -152,6 +152,7 @@ class LayerColorWidget extends RefCounted {
         updateLayerColorWidget();
       }),
     );
+    updateLayerColorWidget();
   }
 }
 

--- a/src/ui/side_panel.ts
+++ b/src/ui/side_panel.ts
@@ -29,7 +29,6 @@ import {
 } from "#src/util/drag_and_drop.js";
 import { startRelativeMouseDrag } from "#src/util/mouse_drag.js";
 import { Signal } from "#src/util/signal.js";
-import type { ViewerState } from "#src/viewer_state.js";
 import { WatchableVisibilityPriority } from "#src/visibility_priority/frontend.js";
 import { makeCloseButton } from "#src/widget/close_button.js";
 
@@ -274,7 +273,6 @@ export class SidePanelManager extends RefCounted {
     public visibility = new WatchableVisibilityPriority(
       WatchableVisibilityPriority.VISIBLE,
     ),
-    public viewerState: ViewerState,
   ) {
     super();
     const { element, centerColumn } = this;

--- a/src/ui/viewer_settings.ts
+++ b/src/ui/viewer_settings.ts
@@ -133,7 +133,6 @@ export class ViewerSettingsPanel extends SidePanel {
       "Enable adaptive downsampling",
       viewer.enableAdaptiveDownsampling,
     );
-    addCheckbox("Enable layer color legend", viewer.enableLayerColorWidget);
 
     const addColor = (label: string, value: WatchableValueInterface<vec3>) => {
       const labelElement = document.createElement("label");

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -288,7 +288,6 @@ class TrackableViewerState extends CompoundTrackable {
     this.add("selectedStateServer", viewer.selectedStateServer);
     this.add("toolBindings", viewer.toolBinder);
     this.add("toolPalettes", viewer.toolPalettes);
-    this.add("enableLayerColorWidget", viewer.enableLayerColorWidget);
   }
 
   restoreState(obj: any) {
@@ -430,7 +429,6 @@ export class Viewer extends RefCounted implements ViewerState {
     vec3.fromValues(0.5, 0.5, 0.5),
   );
   perspectiveViewBackgroundColor = new TrackableRGB(vec3.fromValues(0, 0, 0));
-  enableLayerColorWidget = new TrackableBoolean(false, false);
 
   scaleBarOptions = new TrackableScaleBarOptions();
   partialViewport = new TrackableWindowedViewport();
@@ -935,12 +933,7 @@ export class Viewer extends RefCounted implements ViewerState {
       new RootLayoutContainer(this, "4panel"),
     );
     this.sidePanelManager = this.registerDisposer(
-      new SidePanelManager(
-        this.display,
-        this.layout.element,
-        this.visibility,
-        this,
-      ),
+      new SidePanelManager(this.display, this.layout.element, this.visibility),
     );
     this.registerDisposer(
       this.sidePanelManager.registerPanel({

--- a/src/viewer_state.ts
+++ b/src/viewer_state.ts
@@ -36,5 +36,4 @@ export interface ViewerState extends VisibilityPrioritySpecification {
   layerManager: LayerManager;
   selectedLayer: SelectedLayerState;
   selectionDetailsState: TrackableDataSelectionState;
-  enableLayerColorWidget: TrackableBoolean;
 }


### PR DESCRIPTION
This removes logic around needing a setting to turn on or off the color legend, it would just always be on.

It also removes the color widget from the top bar, instead replacing it by just the background color.

The tooltip logic is also removed as now that we are using the background color, there isn't really any small widget for the tooltip to be associated with. As such it ends up blocking the main tooltips on the layer top bar.

It also refactors a little with these changes in mind. And one unrelated refactor to follow neuroglancer's usual pattern that the `element` of a Widget is the top level `element`. We strayed from that in using `elementWrapper` as the top level

![image](https://github.com/user-attachments/assets/b78ff067-b235-4ccc-8742-e4b07e8913f7)
