### PR TITLE
NA-467 Make readonly color widget non-interactive or replace by fixed color display

### DIFF
--- a/src/ui/annotation_schema_tab.ts
+++ b/src/ui/annotation_schema_tab.ts
@@ -304,6 +304,9 @@ class AnnotationUIProperty extends RefCounted {
       colorInput.element.classList.add(
         "neuroglancer-annotation-schema-color-input",
       );
+      if(this.readonly){
+        colorInput.element.disabled = true;
+      }
       inputs.push(colorInput.element);
       changeFunction = () => {
         const newColor = colorInput.getRGB();


### PR DESCRIPTION
Issue [#NA-467](https://metacell.atlassian.net/browse/NA-467)
Problem: Make readonly color widget non-interactive or replace by fixed color display
Solution: 
1. Check if readonly is true to disable color input 

Result: 

https://github.com/user-attachments/assets/18473657-94ab-40b9-b894-2f8df59293d2

