### PR TITLE
NA-474 Annotation table needs to be scrollable

### DIFF
--- a/src/ui/annotation_schema_tab.css
+++ b/src/ui/annotation_schema_tab.css
@@ -1,3 +1,7 @@
+.neuroglancer-annotations-schema-tab {
+  overflow-y: auto;
+}
+
 .neuroglancer-annotation-schema-grid {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Issue [#NA-474](https://metacell.atlassian.net/browse/NA-474)
Problem: Annotation table needs to be scrollable
Solution: 
1.  Make annotation schema tab scrollable with overflow-y property. We could make schema table be scrollable but in this we will have to use some fixed value to set limit which is not so applicable and we also wouldn't be able to see add button

Result: 

https://github.com/user-attachments/assets/6286f9f1-3f58-42cd-adf3-36fb01927e1a

