### PR TITLE
NA-475 Add annotatation property description to show as tooltip and modify via edit icon

### DIFF
--- a/src/overlay.css
+++ b/src/overlay.css
@@ -86,6 +86,7 @@
   opacity: 0.6;
 }
 
-.neuroglancer-framed-dialog-close-icon:hover {
-  background-color: transparent;
+.neuroglancer-framed-dialog-close-icon:hover svg {
+  stroke: white;
+  opacity: 1;
 }

--- a/src/ui/annotation_schema_tab.css
+++ b/src/ui/annotation_schema_tab.css
@@ -14,6 +14,7 @@
   padding: 4px 2px;
   border-bottom: 1px solid #222;
   gap: 0.5rem;
+  align-items: flex-start;
 }
 
 .neuroglancer-annotation-schema-text-container {

--- a/src/ui/annotation_schema_tab.css
+++ b/src/ui/annotation_schema_tab.css
@@ -14,7 +14,6 @@
   padding: 4px 2px;
   border-bottom: 1px solid #222;
   gap: 0.5rem;
-  align-items: flex-start;
 }
 
 .neuroglancer-annotation-schema-text-container {

--- a/src/ui/annotation_schema_tab.css
+++ b/src/ui/annotation_schema_tab.css
@@ -220,3 +220,7 @@
   width: 100%;
   flex: 1 0 0;
 }
+
+.neuroglancer-annotation-description-header-close {
+  background-color: black;
+}

--- a/src/ui/annotation_schema_tab.css
+++ b/src/ui/annotation_schema_tab.css
@@ -31,7 +31,9 @@
 .neuroglancer-annotation-schema-row:hover
   .neuroglancer-annotation-schema-delete-cell,
 .neuroglancer-annotation-schema-enum-entry:hover
-  .neuroglancer-annotation-schema-delete-icon {
+  .neuroglancer-annotation-schema-delete-icon,
+.neuroglancer-annotation-schema-row:hover
+  .neuroglancer-annotation-schema-description-cell {
   opacity: 1;
   visibility: visible;
 }
@@ -87,6 +89,13 @@
   border-bottom: none;
   border-right: none;
   max-width: 1.25rem;
+}
+
+.neuroglancer-annotation-schema-description-cell {
+  max-width: 1.25rem;
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
 }
 
 .neuroglancer-annotation-schema-header-row {
@@ -221,6 +230,85 @@
   flex: 1 0 0;
 }
 
-.neuroglancer-annotation-description-header-close {
-  background-color: black;
+.neuroglancer-annotation-description-editor {
+  min-width: 400px;
+  border-radius: 0.25rem;
+  padding: 0;
+  outline: none;
+}
+
+.neuroglancer-annotation-description-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #E6E6E6;
+}
+
+.neuroglancer-annotation-description-header-title {
+  color: #141415;
+  font-size: 15px;
+  font-style: normal;
+  font-weight: 590;
+  line-height: normal;
+}
+
+.neuroglancer-annotation-description-header-close svg {
+  stroke: #141415;
+  opacity: 0.6;
+}
+
+.neuroglancer-annotation-description-header-close:hover {
+  background-color: transparent;
+}
+
+.neuroglancer-annotation-description-body {
+  display: flex;
+  padding: 1rem;
+}
+
+.neuroglancer-annotation-description-text-input {
+  width: 100%;
+  padding: var(--spacing-lg, 12px) 14px;
+  gap: var(--spacing-md, 8px);
+  border-radius: 2px;
+  border: 1px solid #D0D5DD;
+  background: #FFF;
+  resize: none;
+}
+
+.neuroglancer-annotation-description-text-input:focus {
+  border: 2px solid #0474FF;
+  box-shadow: 0px 1px 2px 0px rgba(16, 24, 40, 0.05);
+  outline: none;
+}
+
+.neuroglancer-annotation-description-footer {
+  display: flex;
+  padding: 12px 16px;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 10px;
+  border-top: 1px solid #E6E6E6;
+}
+
+.neuroglancer-annotation-description-save-button,
+.neuroglancer-annotation-description-cancel-button {
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid #D0D5DD;
+  background: #FFF;
+  box-shadow: 0px 0px 0px 1px rgba(16, 24, 40, 0.18) inset, 0px -2px 0px 0px rgba(16, 24, 40, 0.05) inset, 0px 1px 2px 0px rgba(16, 24, 40, 0.05);
+
+  font-size: 13px;
+  font-style: normal;
+  font-weight: 590;
+  line-height: 20px;
+  color: #344054;
+  cursor: pointer;
+}
+
+.neuroglancer-annotation-description-save-button:hover,
+.neuroglancer-annotation-description-cancel-button:hover {
+  background: #F9FAFB;
 }

--- a/src/ui/annotation_schema_tab.css
+++ b/src/ui/annotation_schema_tab.css
@@ -194,7 +194,7 @@
   color: white;
   resize: none;
   overflow: hidden;
-  padding: 2px;
+  font-family: sans-serif;
 }
 
 .neuroglancer-annotation-schema-default-value-input[data-readonly="true"] {

--- a/src/ui/annotation_schema_tab.css
+++ b/src/ui/annotation_schema_tab.css
@@ -91,7 +91,8 @@
   max-width: 1.25rem;
 }
 
-.neuroglancer-annotation-schema-description-cell {
+.neuroglancer-annotation-schema-description-cell,
+.neuroglancer-annotation-schema-description-header {
   max-width: 1.25rem;
   visibility: hidden;
   opacity: 0;

--- a/src/ui/annotation_schema_tab.ts
+++ b/src/ui/annotation_schema_tab.ts
@@ -277,14 +277,10 @@ class AnnotationUIProperty extends RefCounted {
       inputValue: identifier,
       className: "neuroglancer-annotation-schema-name-input",
     });
-    const cell = this.createTableCell(nameInput, "");
-    if (description) {
-      cell.title = description;
-    }
     nameInput.name = `neuroglancer-annotation-schema-name-input-${identifier}`;
     nameInput.dataset.readonly = String(this.readonly);
 
-    // const cell = this.createTableCell(document.createElement("div"), "");
+    const cell = this.createTableCell(document.createElement("div"), "");
 
     if (description) {
       const iconWrapper = document.createElement("span");
@@ -1133,10 +1129,15 @@ export class AnnotationSchemaView extends Tab {
     }
     // Append a blank cell for the delete icon
     if (!this.readonly.value) {
+      const descriptionHeader = this.createTableCell(
+        "",
+        "neuroglancer-annotation-schema-description-header",
+      );
       const deleteHeader = this.createTableCell(
         "",
         "neuroglancer-annotation-schema-delete-header",
       );
+      headerRow.appendChild(descriptionHeader);
       headerRow.appendChild(deleteHeader);
     }
     this.schemaTable.appendChild(headerRow);

--- a/src/ui/annotation_schema_tab.ts
+++ b/src/ui/annotation_schema_tab.ts
@@ -28,6 +28,7 @@ import svg_download from "ikonate/icons/download.svg?raw";
 import svg_format_size from "ikonate/icons/text.svg?raw";
 import svg_edit from "ikonate/icons/edit.svg?raw";
 import svg_close from "ikonate/icons/close.svg?raw";
+import svg_info from "ikonate/icons/info.svg?raw";
 import "#src/ui/annotation_schema_tab.css";
 import { AnnotationDisplayState } from "#src/annotation/annotation_layer_state.js";
 import type {
@@ -128,8 +129,6 @@ class AnnotationDescriptionEditDialog extends Overlay {
     headerClose.classList.add(
       "neuroglancer-annotation-description-header-close",
     );
-    // TODO move to css
-    headerClose.style.fill = "#fff";
     header.appendChild(headerTitle);
     header.appendChild(headerClose);
     this.content.appendChild(header);
@@ -268,6 +267,19 @@ class AnnotationUIProperty extends RefCounted {
     element.appendChild(this.createDefaultValueCell(spec.identifier, type));
 
     if (!readonly) {
+      // Add a little icon to the right of the input that lets you change the description
+      const descriptionIcon = makeIcon({
+        svg: svg_edit,
+        title: "Change description",
+      });
+      this.registerEventListener(descriptionIcon, "click", () => {
+        new AnnotationDescriptionEditDialog(this);
+      });
+      const descriptionCell = this.createTableCell(
+        descriptionIcon,
+        "neuroglancer-annotation-schema-description-cell"
+      );
+      element.appendChild(descriptionCell);
       const deleteIcon = document.createElement("span");
       deleteIcon.innerHTML = svg_bin;
       deleteIcon.title = "Delete annotation property";
@@ -294,21 +306,24 @@ class AnnotationUIProperty extends RefCounted {
       inputValue: identifier,
       className: "neuroglancer-annotation-schema-name-input",
     });
-    const cell = this.createTableCell(nameInput, "");
-    if (description) {
-      cell.title = description;
-    }
+    nameInput.name = "neuroglancer-annotation-schema-name-input"
     nameInput.dataset.readonly = String(this.readonly);
+
+    const cell = this.createTableCell(document.createElement("div"), "");
+
+    if (description) {
+      const iconWrapper = document.createElement("span");
+      iconWrapper.classList.add(
+        "neuroglancer-annotation-schema-cell-icon-wrapper",
+      );
+      iconWrapper.innerHTML = svg_info;
+      iconWrapper.title = description
+      cell.appendChild(iconWrapper);
+    }
+    cell.appendChild(nameInput);
+
     if (this.readonly) return cell;
-    // Add a little icon to the right of the input that lets you change the description
-    const descriptionIcon = makeIcon({
-      svg: svg_edit,
-      title: "Change description",
-    });
-    this.registerEventListener(descriptionIcon, "click", () => {
-      new AnnotationDescriptionEditDialog(this);
-    });
-    cell.appendChild(descriptionIcon);
+
     this.registerEventListener(nameInput, "change", (event: Event) => {
       if (!event.target) return;
       const rawValue = (event.target as HTMLInputElement).value;
@@ -326,6 +341,7 @@ class AnnotationUIProperty extends RefCounted {
         this.renameProperty(identifier, sanitizedValue);
       }
     });
+
     return cell;
   }
 

--- a/src/ui/annotation_schema_tab.ts
+++ b/src/ui/annotation_schema_tab.ts
@@ -913,7 +913,10 @@ export class AnnotationSchemaView extends Tab {
       title: "Paste schema from clipboard",
       svg: svg_clipboard,
       onClick: () => {
-        confirmPasteContainer.style.display = "block";
+        // If there is any existing schema, then show a confirm first
+        const hasExistingSchema = this.annotationUIProperties.size > 0;
+        if (hasExistingSchema) confirmPasteContainer.style.display = "block";
+        else this.pasteSchemaFromClipboard();
       },
     });
     schemaActionButtons.appendChild(this.schemaPasteButton);


### PR DESCRIPTION
Issue [#NA-475 ](https://metacell.atlassian.net/browse/NA-475)
Problem: Add annotatation property description to show as tooltip and modify via edit icon
Solution: 
1. Put edit icon next to delete icon
2. Change style of edit modal
3. Put info icon with description on hover next to name input

Result: 

https://github.com/user-attachments/assets/78036934-fbce-4d40-bb18-1b956624970f

