### PR TITLE
NA-491 Apply same border styling to schema inputs as property inputs

### DIFF
--- a/src/ui/annotation_schema_tab.css
+++ b/src/ui/annotation_schema_tab.css
@@ -172,13 +172,18 @@
   border-radius: 2px;
   box-sizing: border-box;
   background: transparent;
+  border: 1px solid transparent;
   font-size: 13px;
   color: white;
-  border: none;
 }
 
 .neuroglancer-annotation-schema-name-input[data-readonly="false"]:hover {
   background: rgba(255, 255, 255, 0.4);
+}
+
+.neuroglancer-annotation-schema-name-input:focus {
+  border-color:#016DCC;
+  outline: none;
 }
 
 .neuroglancer-annotation-schema-name-input:hover:focus {
@@ -186,15 +191,32 @@
 }
 
 .neuroglancer-annotation-schema-default-value-input {
+  text-align: left;
+  font-family: monospace;
+  font-size: 12px;
   width: 100%;
+  color: white;
+  padding: 2px;
+  background: rgba(255, 255, 255, 0.30);
+  outline: none;
+  border: 1px solid transparent;
   flex: 1 0 0;
   box-sizing: border-box;
-  border: none;
-  background: rgba(255, 255, 255, 0.3);
-  color: white;
   resize: none;
   overflow: hidden;
-  font-family: sans-serif;
+}
+
+.neuroglancer-annotation-schema-default-value-input::placeholder {
+  color: rgba(255, 255, 255, 0.40);
+}
+
+.neuroglancer-annotation-schema-default-value-input:hover {
+  background: rgba(255, 255, 255, 0.40);
+}
+
+.neuroglancer-annotation-schema-default-value-input:focus {
+  border-color:#016DCC;
+  background: rgba(255, 255, 255, 0.30);
 }
 
 .neuroglancer-annotation-schema-default-value-input[data-readonly="true"] {

--- a/src/ui/annotation_schema_tab.ts
+++ b/src/ui/annotation_schema_tab.ts
@@ -298,6 +298,7 @@ class AnnotationUIProperty extends RefCounted {
     if (description) {
       cell.title = description;
     }
+    nameInput.name = `neuroglancer-annotation-schema-name-input-${identifier}`
     nameInput.dataset.readonly = String(this.readonly);
     if (this.readonly) return cell;
     // Add a little icon to the right of the input that lets you change the description
@@ -402,6 +403,7 @@ class AnnotationUIProperty extends RefCounted {
           },
           { min: 0, max: 1, step: 0.01 },
         ) as HTMLInputElement;
+        alphaInput.name = `neuroglancer-annotation-schema-default-value-input-${type}`
         inputs.push(alphaInput);
         changeFunction = () => {
           const newColor = colorInput.getRGB();
@@ -425,6 +427,7 @@ class AnnotationUIProperty extends RefCounted {
         className: "neuroglancer-annotation-schema-default-value-input",
       }) as HTMLInputElement;
       boolInput.checked = oldProperty.default === 1;
+      boolInput.name = `neuroglancer-annotation-schema-default-value-input-${type}`
       inputs.push(boolInput);
       changeFunction = (event: Event) => {
         const newValue = (event.target as HTMLInputElement).checked;
@@ -455,6 +458,7 @@ class AnnotationUIProperty extends RefCounted {
             dataType,
           },
         );
+        numberInput.name = `neuroglancer-annotation-schema-default-value-input-${type}`
         inputs.push(numberInput);
         changeFunction = (event: Event) => {
           const newValue = (event.target as HTMLInputElement).value;
@@ -513,6 +517,7 @@ class AnnotationUIProperty extends RefCounted {
             className: "neuroglancer-annotation-schema-default-value-input",
             useTextarea: true,
           });
+          nameInput.name = `neuroglancer-annotation-schema-enum-input-text-${enumIndex}`
           if (!this.readonly) {
             nameInput.addEventListener("change", (event) => {
               const newLabel = (event.target as HTMLInputElement).value;
@@ -537,6 +542,7 @@ class AnnotationUIProperty extends RefCounted {
               dataType: propertyTypeDataType[annotationType],
             },
           );
+          valueInput.name = `neuroglancer-annotation-schema-enum-input-value-${enumIndex}`
           if (!this.readonly) {
             valueInput.addEventListener("change", (event) => {
               const inputValue = (event.target as HTMLInputElement).value;


### PR DESCRIPTION
Issue [#NA-491 ](https://metacell.atlassian.net/browse/NA-491)
Problem: Apply same border styling to schema inputs as property inputs
Solution: 
1. Change style of default value inputs and name inputs
2. Apply name property to each of input based on classname+type or identifier

Result: 


https://github.com/user-attachments/assets/074209a2-5c6b-48ce-a82e-0e209977c426

 