### PR TITLE
NA-498 Can't see the types dropdown if the menu is large

### DIFF
--- a/src/ui/annotation_schema_tab.ts
+++ b/src/ui/annotation_schema_tab.ts
@@ -1237,8 +1237,19 @@ export class AnnotationSchemaView extends Tab {
 
       document.body.appendChild(dropdown);
       const rect = addButton.getBoundingClientRect();
+      const dropdownHeight = dropdown.offsetHeight;
+      const spaceBelow = window.innerHeight - rect.bottom;
+      const spaceAbove = rect.top;
+
+      if (spaceBelow >= dropdownHeight || spaceBelow > spaceAbove) {
+        // Enough space - position below
+        dropdown.style.top = `${rect.bottom + window.scrollY}px`;
+      } else {
+        // Not enough space - position above
+        dropdown.style.top = `${(rect.top + window.scrollY - dropdownHeight) - 10}px`;
+      }
+
       dropdown.style.left = `${rect.left}px`;
-      dropdown.style.top = `${rect.bottom + window.scrollY}px`;
 
       const handleOutsideClick = (e: MouseEvent) => {
         if (dropdown && !dropdown.contains(e.target as Node)) {


### PR DESCRIPTION
Issue [#NA-498](https://metacell.atlassian.net/browse/NA-498)
Problem: Can't see the types dropdown if the menu is large
Solution: 
1. Calculate position of a screen and place it accordingly below add button or above it

Result: 

https://github.com/user-attachments/assets/061c3f71-1734-4c49-9e7f-03c8f646ac53