### PR TITLE
NA-500 Improve enum labels table to make it clearer which is the full delete and which is the row delete

### DIFF
--- a/src/ui/annotation_schema_tab.css
+++ b/src/ui/annotation_schema_tab.css
@@ -17,6 +17,10 @@
   align-items: flex-start;
 }
 
+.neuroglancer-annotation-schema-row:hover {
+  background-color: #111;
+}
+
 .neuroglancer-annotation-schema-text-container {
   padding: 0.25rem;
 }
@@ -30,12 +34,15 @@
 
 .neuroglancer-annotation-schema-row:hover
   .neuroglancer-annotation-schema-delete-cell,
-.neuroglancer-annotation-schema-enum-entry:hover
-  .neuroglancer-annotation-schema-delete-icon,
 .neuroglancer-annotation-schema-row:hover
   .neuroglancer-annotation-schema-description-cell {
   opacity: 1;
   visibility: visible;
+}
+
+.neuroglancer-annotation-schema-enum-entry:hover
+  .neuroglancer-annotation-schema-delete-icon {
+  display: block;
 }
 
 .neuroglancer-annotation-schema-delete-cell svg,
@@ -178,10 +185,14 @@
   align-items: center;
 }
 
-.neuroglancer-annotation-schema-delete-cell,
-.neuroglancer-annotation-schema-delete-icon {
+.neuroglancer-annotation-schema-delete-cell {
   visibility: hidden;
   opacity: 0;
+  transition: opacity 0.2s ease-in-out;
+}
+
+.neuroglancer-annotation-schema-delete-icon {
+  display: none;
   transition: opacity 0.2s ease-in-out;
 }
 


### PR DESCRIPTION
Issue [#NA-500](https://metacell.atlassian.net/browse/NA-500)
Problem: Improve enum labels table to make it clearer which is the full delete and which is the row delete
Solution: 
1. Change bg color on row hover
2. Set display to none when we hover over enum row

Result: 

https://github.com/user-attachments/assets/b8f72cc5-f3b7-4b14-b7e2-f4f1de4a6b6d
