### PR TITLE
fix: previously dimensions were assumed in order but stored in a dict

### DIFF
--- a/python/neuroglancer/viewer_state.py
+++ b/python/neuroglancer/viewer_state.py
@@ -1852,6 +1852,12 @@ class ViewerState(JsonObjectWrapper):
         "toolPalettes", typed_map(key_type=str, value_type=ToolPalette)
     )
 
+    def __init__(self, json_data=None, _readonly=False, **kwargs):
+        if isinstance(json_data, dict) and "dimensions" in json_data:
+            # Patch to convert old viewer state JSON dimensions that was dict to array
+            json_data["dimensions"] = CoordinateSpace(json_data["dimensions"]).to_json()
+        super().__init__(json_data, _readonly=_readonly, **kwargs)
+
     @staticmethod
     def interpolate(a, b, t):
         c = copy.deepcopy(a)

--- a/src/coordinate_transform.ts
+++ b/src/coordinate_transform.ts
@@ -283,7 +283,6 @@ export function coordinateSpaceFromJson(
   allowNumericalDimensions = false,
 ): CoordinateSpace {
   if (obj === undefined) return emptyInvalidCoordinateSpace;
-  verifyObject(obj);
   const isLegacyDict = obj.constructor === Object;
   const unparsedNames = isLegacyDict
     ? Object.keys(obj)
@@ -299,7 +298,8 @@ export function coordinateSpaceFromJson(
         handleCoordinateArray(mem, units, i, scales, coordinateArrays);
       });
     } else {
-      handleCoordinateArray(obj[i], units, i, scales, coordinateArrays);
+      const mem = "scale" in obj[i] ? obj[i].scale : obj[i];
+      handleCoordinateArray(mem, units, i, scales, coordinateArrays);
     }
   }
   return makeCoordinateSpace({
@@ -370,8 +370,7 @@ export function coordinateSpaceToJson(coordinateSpace: CoordinateSpace): any {
     } else {
       json.push({
         name: name,
-        scales: scales[i],
-        units: units[i],
+        scale: [scales[i], units[i]],
       });
     }
   }

--- a/src/coordinate_transform.ts
+++ b/src/coordinate_transform.ts
@@ -283,6 +283,11 @@ export function coordinateSpaceFromJson(
   allowNumericalDimensions = false,
 ): CoordinateSpace {
   if (obj === undefined) return emptyInvalidCoordinateSpace;
+  if (obj === null || typeof obj !== "object") {
+    throw new Error(
+      `Invalid coordinate space JSON: expected object or array, but received ${JSON.stringify(obj)}.`,
+    );
+  }
   const isLegacyDict = obj.constructor === Object;
   const unparsedNames = isLegacyDict
     ? Object.keys(obj)

--- a/src/coordinate_transform.ts
+++ b/src/coordinate_transform.ts
@@ -284,70 +284,95 @@ export function coordinateSpaceFromJson(
 ): CoordinateSpace {
   if (obj === undefined) return emptyInvalidCoordinateSpace;
   verifyObject(obj);
-  const names = dimensionNamesFromJson(
-    Object.keys(obj),
-    allowNumericalDimensions,
-  );
+  const isLegacyDict = obj.constructor === Object;
+  const unparsedNames = isLegacyDict
+    ? Object.keys(obj)
+    : obj.map((x: any) => x.name);
+  const names = dimensionNamesFromJson(unparsedNames, allowNumericalDimensions);
   const rank = names.length;
   const units = new Array<string>(rank);
   const scales = new Float64Array(rank);
   const coordinateArrays = new Array<CoordinateArray | undefined>(rank);
   for (let i = 0; i < rank; ++i) {
-    verifyObjectProperty(obj, names[i], (mem) => {
-      if (Array.isArray(mem)) {
-        // Normal unit-scale dimension.
-        const { unit, scale } = unitAndScaleFromJson(mem);
-        units[i] = unit;
-        scales[i] = scale;
-      } else {
-        // Coordinate array dimension.
-        verifyObject(mem);
-        const coordinates = verifyObjectProperty(
-          mem,
-          "coordinates",
-          verifyIntegerArray,
-        );
-        const labels = verifyObjectProperty(mem, "labels", verifyStringArray);
-        const length = coordinates.length;
-        if (length !== labels.length) {
-          throw new Error(
-            `Length of coordinates array (${length}) ` +
-              `does not match length of labels array (${labels.length})`,
-          );
-        }
-        units[i] = "";
-        scales[i] = 1;
-        coordinateArrays[i] = {
-          explicit: true,
-          ...normalizeCoordinateArray(coordinates, labels),
-        };
-      }
-    });
+    if (isLegacyDict) {
+      verifyObjectProperty(obj, names[i], (mem) => {
+        handleCoordinateArray(mem, units, i, scales, coordinateArrays);
+      });
+    } else {
+      handleCoordinateArray(obj[i], units, i, scales, coordinateArrays);
+    }
   }
   return makeCoordinateSpace({
-    valid: false,
+    valid: true,
     names,
     units,
     scales,
+    rank,
     coordinateArrays,
   });
+}
+
+function handleCoordinateArray(
+  coordinateData: any,
+  units: string[],
+  i: number,
+  scales: Float64Array<ArrayBuffer>,
+  coordinateArrays: (CoordinateArray | undefined)[],
+) {
+  if (Array.isArray(coordinateData)) {
+    // Normal unit-scale dimension.
+    const { unit, scale } = unitAndScaleFromJson(coordinateData);
+    units[i] = unit;
+    scales[i] = scale;
+  } else {
+    // Coordinate array dimension.
+    verifyObject(coordinateData);
+    const coordinates = verifyObjectProperty(
+      coordinateData,
+      "coordinates",
+      verifyIntegerArray,
+    );
+    const labels = verifyObjectProperty(
+      coordinateData,
+      "labels",
+      verifyStringArray,
+    );
+    const length = coordinates.length;
+    if (length !== labels.length) {
+      throw new Error(
+        `Length of coordinates array (${length}) ` +
+          `does not match length of labels array (${labels.length})`,
+      );
+    }
+    units[i] = "";
+    scales[i] = 1;
+    coordinateArrays[i] = {
+      explicit: true,
+      ...normalizeCoordinateArray(coordinates, labels),
+    };
+  }
 }
 
 export function coordinateSpaceToJson(coordinateSpace: CoordinateSpace): any {
   const { rank } = coordinateSpace;
   if (rank === 0) return undefined;
   const { names, units, scales, coordinateArrays } = coordinateSpace;
-  const json: any = {};
+  const json: any = [];
   for (let i = 0; i < rank; ++i) {
     const name = names[i];
     const coordinateArray = coordinateArrays[i];
     if (coordinateArray?.explicit) {
-      json[name] = {
+      json.push({
+        name: name,
         coordinates: Array.from(coordinateArray.coordinates),
         labels: coordinateArray.labels,
-      };
+      });
     } else {
-      json[name] = [scales[i], units[i]];
+      json.push({
+        name: name,
+        scales: scales[i],
+        units: units[i],
+      });
     }
   }
   return json;

--- a/src/coordinate_transform.ts
+++ b/src/coordinate_transform.ts
@@ -303,11 +303,10 @@ export function coordinateSpaceFromJson(
     }
   }
   return makeCoordinateSpace({
-    valid: true,
+    valid: false,
     names,
     units,
     scales,
-    rank,
     coordinateArrays,
   });
 }


### PR DESCRIPTION
Since JSON objects are listed as unordered in the spec, this could cause issues in processing of neuroglancer states by external tools for objects where the name order matters. For example, in something that saves states or processes states.

The primary case where this has come up is in the global viewer `dimensions`. Here the order of the names determines the default order of the viewer, so the order matters.

To help with this, this PR is proposing to change the dimensions to be stored in an array, not an object. Here, the dimensions are handled in a split path. One "legacy" path, for pure dictionary style objects, and a new path, which handles arrays. New states are saved as arrays in the JSON state. This happens pretty automatically in the viewer, but from Python there is an extra kind of conversion call which happens on init of a new state.

Old state dims:
```
"dimensions": {
    "x": [
      4e-9,
      "m"
    ],
    "y": [
      4e-9,
      "m"
    ],
    "z": [
      4e-8,
      "m"
    ]
  }
```

New dims:
```
"dimensions": [
    {
      "name": "x",
      "scale": [
        4e-9,
        "m"
      ]
    },
    {
      "name": "y",
      "scale": [
        4e-9,
        "m"
      ]
    },
    {
      "name": "z",
      "scale": [
        4e-8,
        "m"
      ]
    }
  ],
```