### PR TITLE
NA-507 Change readonly color display in annotation property view

### DIFF
--- a/src/ui/annotations.css
+++ b/src/ui/annotations.css
@@ -156,15 +156,9 @@ div.neuroglancer-annotation-details-description {
   font: 10pt sans-serif;
 }
 
-.neuroglancer-annotation-details-position {
-}
-
 .neuroglancer-annotation-toolbox {
   display: flex;
   align-items: stretch;
-}
-
-.neuroglancer-annotation-segment-list {
 }
 
 .neuroglancer-annotation-segment-item {
@@ -265,6 +259,9 @@ div.neuroglancer-annotation-details-description {
 
 .neuroglancer-annotation-property-value {
   font-family: monospace;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
 }
 
 .neuroglancer-annotation-property-id .neuroglancer-annotation-property-value {
@@ -355,6 +352,24 @@ input.neuroglancer-segment-list-entry-id {
   border-radius: 2px;
   padding: 2px;
   width: 100%;
+}
+
+.neuroglancer-annotation-property-color-readable {
+  display: inline-flex;
+  width: 1rem;
+  height: 1rem;
+  padding: 0.125rem;
+  border-radius: 0.125rem;
+  background-color: #333;
+  vertical-align: middle;
+  box-sizing: border-box;
+  justify-content: center;
+  align-items: center;
+}
+
+.neuroglancer-annotation-property-color-readable span {
+  width: 0.5rem;
+  height: 0.5rem;
 }
 
 .neuroglancer-related-segment-list-header-checkbox {

--- a/src/ui/annotations.ts
+++ b/src/ui/annotations.ts
@@ -1947,12 +1947,31 @@ export function UserLayerWithAnnotationsMixin<
                       annotationLayer.source.commit(reference);
                     };
                   valueElement = document.createElement("span");
-                  labelElementSetter = (value) => {
+                  labelElementSetter = (color) => {
                     const label = document.createElement("span");
-                    label.textContent = value;
+                    label.textContent = formatColor(color);
                     label.style.textTransform = "uppercase";
                     return label;
                   };
+
+                  const formatColor = (color: string): string => {
+                    if (color.startsWith('#')) {
+                      return color;
+                    }
+
+                    const rgbaMatch = color.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*([\d.]+)\s*)?\)/i);
+                    if (!rgbaMatch) return color;
+
+                    const [_, r, g, b, a] = rgbaMatch;
+                    const hex = rgbToHex(parseInt(r), parseInt(g), parseInt(b));
+
+                    return a !== undefined ? `${hex} ${parseFloat(a).toFixed(1)}` : hex;
+                  };
+
+                  const rgbToHex = (r: number, g: number, b: number): string => {
+                    return `#${[r, g, b].map(v => Math.min(255, Math.max(0, v)).toString(16).padStart(2, '0')).join('').toUpperCase()}`;
+                  };
+
                   valueElementSetter = (value) => {
                     valueElement.textContent = value;
                   };
@@ -2001,8 +2020,8 @@ export function UserLayerWithAnnotationsMixin<
                   } else if (property.type === "rgba") {
                     const colorVec = unpackRGB(value);
                     if (sourceReadonly) {
-                      const hex = serializeColor(colorVec);
-                      const previewBox = createColorPreviewBox(hex);
+                      const hex = serializeColor(unpackRGBA(value));
+                      const previewBox = createColorPreviewBox(serializeColor(unpackRGB(value)));
                       
                       valueElement.appendChild(previewBox);
                       valueElement.appendChild(labelElementSetter(hex));


### PR DESCRIPTION
Issue [#NA-507](https://metacell.atlassian.net/browse/NA-507?atlOrigin=eyJpIjoiNmUxZWNiOWQ1NzU0NGUzNWExMDA5NjIwYTFjZTUzMDYiLCJwIjoiaiJ9)
Problem: Change readonly color display in schema to be like properties
Solution:
1. Add a function to add custom preview box for readable color inputs
2. Add a function to render text

Result: 
![image](https://github.com/user-attachments/assets/64e4fd3f-2df8-4858-b1b4-9e097e730951)

