### PR TITLE
NA-505 Revert enum styling to have fixed layout with bar on right for separation

### DIFF
--- a/src/ui/annotation_schema_tab.css
+++ b/src/ui/annotation_schema_tab.css
@@ -46,6 +46,11 @@
   visibility: visible;
 }
 
+.neuroglancer-annotation-schema-enum-entry:hover
+  .neuroglancer-annotation-schema-delete-icon {
+  border-color: #222;
+}
+
 .neuroglancer-annotation-schema-delete-cell svg,
 .neuroglancer-annotation-schema-delete-icon svg {
   width: 1rem;
@@ -97,6 +102,12 @@
   border-bottom: none;
   border-right: none;
   max-width: 1.25rem;
+}
+
+.neuroglancer-annotation-schema-delete-icon {
+  min-width: 1.25rem;
+  border-right: 1px solid transparent;
+  padding-right: 2px;
 }
 
 .neuroglancer-annotation-schema-description-cell,


### PR DESCRIPTION
Issue #NA-505 
Problem: Revert enum styling to have fixed layout with bar on right for separation
Solution:
1. Make it hidden/visible instead none/block logic for delete icon
2. Add border right style as in Figma

Result: 

https://github.com/user-attachments/assets/32e7acd2-1704-4c44-9332-5ef0ac1f8217

