### PR TITLE
NA-497 The enum labels and the values are slightly different heights

### DIFF
--- a/src/ui/annotation_properties.css
+++ b/src/ui/annotation_properties.css
@@ -98,11 +98,12 @@
 
 .neuroglancer-annotation-textarea {
   height: auto;
+  padding: 0;
   min-height: 1lh;
   max-height: 15lh;
+  line-height: 18px;
   resize: none;
   overflow: hidden;
-  padding: 1px 2px;
 }
 
 .neuroglancer-annotation-textarea[data-readonly="true"] {

--- a/src/ui/annotation_schema_tab.css
+++ b/src/ui/annotation_schema_tab.css
@@ -241,6 +241,11 @@
   margin-bottom: 2px;
 }
 
+.neuroglancer-annotation-schema-enum-entry .neuroglancer-annotation-schema-default-value-input {
+  line-height: 18px;
+  padding: 0;
+}
+
 .neuroglancer-annotation-schema-name-input {
   width: 100%;
   border-radius: 2px;


### PR DESCRIPTION
Issue [#NA-497](https://metacell.atlassian.net/browse/NA-497) 
Problem: The enum labels and the values are slightly different heights
Solution: 
1. Match their paddings and line-height

Result: 
<img width="755" height="463" alt="image" src="https://github.com/user-attachments/assets/92151d2e-6e87-4fb8-a40e-55a7a49b5723" />
