### PR TITLE
feat: Add catmaid spatially indexed skeletons (read-only)

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,12 @@
       "neuroglancer/datasource/boss:disabled": "./src/util/false.ts",
       "default": "./src/datasource/boss/backend.ts"
     },
+    "#datasource/catmaid/backend": {
+      "default": "./src/datasource/catmaid/backend.ts"
+    },
+    "#datasource/catmaid/register_default": {
+      "default": "./src/datasource/catmaid/register_default.ts"
+    },
     "#datasource/boss/async_computation": {
       "neuroglancer/datasource/boss:enabled": "./src/datasource/boss/async_computation.ts",
       "neuroglancer/datasource:none_by_default": "./src/util/false.ts",

--- a/src/datasource/catmaid/api.ts
+++ b/src/datasource/catmaid/api.ts
@@ -1,0 +1,263 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import { vec3 } from "#src/util/geom.js";
+
+export interface CatmaidNode {
+    id: number;
+    parent_id: number | null;
+    x: number;
+    y: number;
+    z: number;
+    radius: number;
+    confidence: number;
+    skeleton_id: number;
+}
+
+export class CatmaidClient {
+    // Mock data storage for testing without a real CATMAID server
+    private static mockNodes: Map<number, CatmaidNode> = new Map();
+    private static nextNodeId = 1000;
+    private static useMockData = true; // Set to false to use real CATMAID server
+
+    constructor(
+        public baseUrl: string,
+        public projectId: number,
+        public token?: string
+    ) {
+        // Initialize mock data if not already done
+        if (CatmaidClient.mockNodes.size === 0) {
+            this.initializeMockData();
+        }
+    }
+
+    private initializeMockData() {
+        console.log('Initializing CATMAID mock data...');
+        
+        // Create a sample neuron with multiple branches
+        // Main trunk along z-axis - positioned at [500, 500, 500] for easy viewing
+        const nodes: CatmaidNode[] = [
+            // Root node
+            { id: 1, parent_id: null, x: 500, y: 500, z: 500, radius: 8, confidence: 5, skeleton_id: 1 },
+            // Main trunk
+            { id: 2, parent_id: 1, x: 500, y: 500, z: 600, radius: 6, confidence: 5, skeleton_id: 1 },
+            { id: 3, parent_id: 2, x: 500, y: 500, z: 700, radius: 5, confidence: 5, skeleton_id: 1 },
+            { id: 4, parent_id: 3, x: 500, y: 500, z: 800, radius: 5, confidence: 5, skeleton_id: 1 },
+            { id: 5, parent_id: 4, x: 500, y: 500, z: 900, radius: 4, confidence: 5, skeleton_id: 1 },
+            
+            // Branch 1 - extending in +x direction
+            { id: 6, parent_id: 3, x: 600, y: 500, z: 700, radius: 4, confidence: 5, skeleton_id: 1 },
+            { id: 7, parent_id: 6, x: 700, y: 500, z: 700, radius: 3, confidence: 5, skeleton_id: 1 },
+            { id: 8, parent_id: 7, x: 800, y: 500, z: 750, radius: 3, confidence: 4, skeleton_id: 1 },
+            
+            // Branch 2 - extending in -x direction
+            { id: 9, parent_id: 3, x: 400, y: 500, z: 700, radius: 4, confidence: 5, skeleton_id: 1 },
+            { id: 10, parent_id: 9, x: 300, y: 500, z: 700, radius: 3, confidence: 5, skeleton_id: 1 },
+            
+            // Branch 3 - extending in +y direction from node 4
+            { id: 11, parent_id: 4, x: 500, y: 600, z: 800, radius: 4, confidence: 5, skeleton_id: 1 },
+            { id: 12, parent_id: 11, x: 500, y: 700, z: 850, radius: 3, confidence: 5, skeleton_id: 1 },
+            { id: 13, parent_id: 12, x: 550, y: 750, z: 900, radius: 2, confidence: 4, skeleton_id: 1 },
+            
+            // Branch 4 - extending in -y direction from node 4
+            { id: 14, parent_id: 4, x: 500, y: 400, z: 800, radius: 4, confidence: 5, skeleton_id: 1 },
+            { id: 15, parent_id: 14, x: 500, y: 300, z: 850, radius: 3, confidence: 5, skeleton_id: 1 },
+        ];
+
+        // Add a second neuron nearby
+        const neuron2Nodes: CatmaidNode[] = [
+            { id: 100, parent_id: null, x: 1000, y: 1000, z: 500, radius: 7, confidence: 5, skeleton_id: 2 },
+            { id: 101, parent_id: 100, x: 1000, y: 1000, z: 600, radius: 6, confidence: 5, skeleton_id: 2 },
+            { id: 102, parent_id: 101, x: 950, y: 950, z: 700, radius: 5, confidence: 5, skeleton_id: 2 },
+            { id: 103, parent_id: 102, x: 900, y: 900, z: 800, radius: 4, confidence: 5, skeleton_id: 2 },
+            { id: 104, parent_id: 103, x: 850, y: 850, z: 900, radius: 3, confidence: 4, skeleton_id: 2 },
+        ];
+
+        [...nodes, ...neuron2Nodes].forEach(node => {
+            CatmaidClient.mockNodes.set(node.id, node);
+        });
+
+        CatmaidClient.nextNodeId = 200;
+        console.log(`Initialized ${CatmaidClient.mockNodes.size} mock nodes`);
+    }
+
+    private async fetch(
+        endpoint: string,
+        options: RequestInit = {}
+    ): Promise<any> {
+        const url = `${this.baseUrl}/${this.projectId}/${endpoint}`;
+        const headers = new Headers(options.headers);
+        if (this.token) {
+            headers.append("X-Authorization", `Token ${this.token}`);
+        }
+        const response = await fetch(url, { ...options, headers });
+        if (!response.ok) {
+            throw new Error(`CATMAID request failed: ${response.statusText}`);
+        }
+        return response.json();
+    }
+
+    async getSkeleton(skeletonId: number): Promise<CatmaidNode[]> {
+        if (CatmaidClient.useMockData) {
+            console.log(`Mock: Getting skeleton ${skeletonId}`);
+            const nodes = Array.from(CatmaidClient.mockNodes.values())
+                .filter(n => n.skeleton_id === skeletonId);
+            console.log(`Mock: Found ${nodes.length} nodes for skeleton ${skeletonId}`);
+            return nodes;
+        }
+
+        // Real implementation
+        const data = await this.fetch(`skeletons/${skeletonId}/compact-detail`);
+        const nodes = data[0];
+        return nodes.map((n: any[]) => ({
+            id: n[0],
+            parent_id: n[1],
+            x: n[3],
+            y: n[4],
+            z: n[5],
+            radius: n[6],
+            confidence: n[7],
+            skeleton_id: skeletonId,
+        }));
+    }
+
+    async boxQuery(min: vec3, max: vec3): Promise<CatmaidNode[]> {
+        if (CatmaidClient.useMockData) {
+            console.log(`Mock: Box query [${min[0]}, ${min[1]}, ${min[2]}] to [${max[0]}, ${max[1]}, ${max[2]}]`);
+            const nodes = Array.from(CatmaidClient.mockNodes.values()).filter(node => {
+                return node.x >= min[0] && node.x <= max[0] &&
+                       node.y >= min[1] && node.y <= max[1] &&
+                       node.z >= min[2] && node.z <= max[2];
+            });
+            console.log(`Mock: Found ${nodes.length} nodes in box`);
+            return nodes;
+        }
+
+        // Real implementation
+        const body = new URLSearchParams({
+            left: min[0].toString(),
+            top: min[1].toString(),
+            z1: min[2].toString(),
+            right: max[0].toString(),
+            bottom: max[1].toString(),
+            z2: max[2].toString(),
+        });
+
+        const data = await this.fetch(`nodes/`, {
+            method: "POST",
+            body: body,
+        });
+
+        const nodes = data[0];
+        return nodes.map((n: any[]) => ({
+            id: n[0],
+            parent_id: n[1],
+            x: n[2],
+            y: n[3],
+            z: n[4],
+            confidence: n[5],
+            radius: n[6],
+            skeleton_id: n[7],
+        }));
+    }
+
+    async moveNode(
+        nodeId: number,
+        x: number,
+        y: number,
+        z: number
+    ): Promise<void> {
+        if (CatmaidClient.useMockData) {
+            console.log(`Mock: Moving node ${nodeId} to [${x}, ${y}, ${z}]`);
+            const node = CatmaidClient.mockNodes.get(nodeId);
+            if (node) {
+                node.x = x;
+                node.y = y;
+                node.z = z;
+                console.log(`Mock: Node ${nodeId} moved successfully`);
+            } else {
+                console.warn(`Mock: Node ${nodeId} not found`);
+            }
+            return;
+        }
+
+        // Real implementation
+        await this.fetch(`node/${nodeId}/move`, {
+            method: "POST",
+            body: JSON.stringify({ x, y, z }),
+        });
+    }
+
+    async deleteNode(nodeId: number): Promise<void> {
+        if (CatmaidClient.useMockData) {
+            console.log(`Mock: Deleting node ${nodeId}`);
+            const deleted = CatmaidClient.mockNodes.delete(nodeId);
+            if (deleted) {
+                console.log(`Mock: Node ${nodeId} deleted successfully`);
+            } else {
+                console.warn(`Mock: Node ${nodeId} not found`);
+            }
+            return;
+        }
+
+        // Real implementation
+        await this.fetch(`node/${nodeId}/delete`, {
+            method: "POST",
+        });
+    }
+
+    async addNode(
+        skeletonId: number,
+        x: number,
+        y: number,
+        z: number,
+        parentId?: number
+    ): Promise<number> {
+        if (CatmaidClient.useMockData) {
+            const nodeId = CatmaidClient.nextNodeId++;
+            console.log(`Mock: Adding node ${nodeId} at [${x}, ${y}, ${z}] with parent ${parentId} to skeleton ${skeletonId}`);
+            
+            const newNode: CatmaidNode = {
+                id: nodeId,
+                parent_id: parentId || null,
+                x,
+                y,
+                z,
+                radius: 3,
+                confidence: 5,
+                skeleton_id: skeletonId,
+            };
+            
+            CatmaidClient.mockNodes.set(nodeId, newNode);
+            console.log(`Mock: Node ${nodeId} added successfully`);
+            return nodeId;
+        }
+
+        // Real implementation
+        const res = await this.fetch(`node/add`, {
+            method: "POST",
+            body: JSON.stringify({
+                skeleton_id: skeletonId,
+                x,
+                y,
+                z,
+                parent_id: parentId,
+            }),
+        });
+        return res.node_id;
+    }
+}

--- a/src/datasource/catmaid/api.ts
+++ b/src/datasource/catmaid/api.ts
@@ -144,6 +144,10 @@ function fetchWithCatmaidCredentials(
 
 export class CatmaidClient implements SpatiallyIndexedSkeletonSource {
     private metadataInfoPromiseByKey = new Map<string, Promise<CatmaidStackInfo | null>>();
+    private readonly msgpackUnpackr = new Unpackr({
+        mapsAsObjects: false,
+        int64AsType: "number",
+    });
 
     constructor(
         public baseUrl: string,
@@ -185,12 +189,8 @@ export class CatmaidClient implements SpatiallyIndexedSkeletonSource {
                 return response.json();
             }
             const buffer = await response.arrayBuffer();
-            const unpackr = new Unpackr({
-                mapsAsObjects: false,
-                int64AsType: "number",
-            });
             try {
-                return unpackr.unpack(new Uint8Array(buffer));
+                return this.msgpackUnpackr.unpack(new Uint8Array(buffer));
             } catch (error) {
                 // Some CATMAID deployments return a JSON error body with a msgpack request.
                 try {

--- a/src/datasource/catmaid/api.ts
+++ b/src/datasource/catmaid/api.ts
@@ -39,7 +39,7 @@ export interface CatmaidSource {
     getDimensions(): Promise<{ min: { x: number; y: number; z: number }; max: { x: number; y: number; z: number } } | null>;
     getResolution(): Promise<{ x: number; y: number; z: number } | null>;
     getGridCellSize(): Promise<{ x: number; y: number; z: number }>;
-    fetchNodes(boundingBox: { min: { x: number, y: number, z: number }, max: { x: number, y: number, z: number } }): Promise<CatmaidNode[]>;
+    fetchNodes(boundingBox: { min: { x: number, y: number, z: number }, max: { x: number, y: number, z: number } }, lod?: number): Promise<CatmaidNode[]>;
     addNode(
         skeletonId: number,
         x: number,
@@ -250,6 +250,7 @@ export class CatmaidClient implements CatmaidSource {
             min: { x: number; y: number; z: number };
             max: { x: number; y: number; z: number };
         },
+        lod: number = 0,
     ): Promise<CatmaidNode[]> {
         const params = new URLSearchParams({
             left: boundingBox.min.x.toString(),
@@ -259,7 +260,7 @@ export class CatmaidClient implements CatmaidSource {
             bottom: boundingBox.max.y.toString(),
             z2: boundingBox.max.z.toString(),
             lod_type: 'percent',
-            lod: '0',
+            lod: lod.toString(),
             format: 'msgpack',
         });
 

--- a/src/datasource/catmaid/api.ts
+++ b/src/datasource/catmaid/api.ts
@@ -119,13 +119,24 @@ export class CatmaidClient implements CatmaidSource {
         const info = await this.getMetadataInfo();
         if (!info) return null;
 
-        // Return world-space bounds in nanometers
-        const { dimension, resolution, translation } = info;
-        const min = translation;
+        // Return voxel-space bounds (dimension from stack info)
+        // The "dimension" field in the stack info represents the size in voxels
+        const { dimension, translation } = info;
+
+        // Use translation if available, otherwise 0,0,0
+        const offX = translation?.x ?? 0;
+        const offY = translation?.y ?? 0;
+        const offZ = translation?.z ?? 0;
+
+        const min = {
+            x: offX,
+            y: offY,
+            z: offZ,
+        };
         const max = {
-            x: translation.x + dimension.x * resolution.x,
-            y: translation.y + dimension.y * resolution.y,
-            z: translation.z + dimension.z * resolution.z,
+            x: offX + dimension.x,
+            y: offY + dimension.y,
+            z: offZ + dimension.z,
         };
         return { min, max };
     }

--- a/src/datasource/catmaid/api.ts
+++ b/src/datasource/catmaid/api.ts
@@ -34,7 +34,7 @@ export interface SkeletonSummary {
 export interface CatmaidSource {
     listSkeletons(): Promise<number[]>;
     getSkeleton(skeletonId: number): Promise<CatmaidNode[]>;
-    getStackInfo(stackId?: number): Promise<any>;
+    getMetadataInfo(stackId?: number): Promise<any>;
     addNode(
         skeletonId: number,
         x: number,
@@ -83,7 +83,9 @@ export class CatmaidClient implements CatmaidSource {
         return this.fetch("skeletons/");
     }
 
-    async getStackInfo(stackId?: number): Promise<any> {
+    async getMetadataInfo(stackId?: number): Promise<any> {
+        return null // From the tests tried applying the stack resolution was making things worse
+
         // If a specific stack id is provided, fetch its info directly.
         if (stackId !== undefined) {
             return this.fetch(`stack/${stackId}/info`);

--- a/src/datasource/catmaid/api.ts
+++ b/src/datasource/catmaid/api.ts
@@ -34,6 +34,7 @@ export interface SkeletonSummary {
 export interface CatmaidSource {
     listSkeletons(): Promise<number[]>;
     getSkeleton(skeletonId: number): Promise<CatmaidNode[]>;
+    getStackInfo(stackId?: number): Promise<any>;
     addNode(
         skeletonId: number,
         x: number,
@@ -80,6 +81,18 @@ export class CatmaidClient implements CatmaidSource {
 
     async listSkeletons(): Promise<number[]> {
         return this.fetch("skeletons/");
+    }
+
+    async getStackInfo(stackId?: number): Promise<any> {
+        // If a specific stack id is provided, fetch its info directly.
+        if (stackId !== undefined) {
+            return this.fetch(`stack/${stackId}/info`);
+        }
+        // Otherwise, list stacks and return info for the first one.
+        const stacks: Array<{ id: number }> = await this.fetch("stacks");
+        if (!stacks || stacks.length === 0) return null;
+        const targetId = stacks[0].id;
+        return this.fetch(`stack/${targetId}/info`);
     }
 
     async getSkeleton(skeletonId: number): Promise<CatmaidNode[]> {

--- a/src/datasource/catmaid/backend.ts
+++ b/src/datasource/catmaid/backend.ts
@@ -54,7 +54,6 @@ export class CatmaidSpatiallyIndexedSkeletonSourceBackend extends WithParameters
             min: { x: localMin[0], y: localMin[1], z: localMin[2] },
             max: { x: localMax[0], y: localMax[1], z: localMax[2] },
         };
-        //console.log('Fetching nodes with bbox:', bbox);
         const nodes = await this.client.fetchNodes(bbox);
 
         const numVertices = nodes.length;
@@ -73,7 +72,6 @@ export class CatmaidSpatiallyIndexedSkeletonSourceBackend extends WithParameters
             vertexAttributes[i] = node.skeleton_id;
         }
 
-        const missingConnections: Array<{ nodeId: number; parentId: number; vertexIndex: number; skeletonId: number }> = [];
 
         for (let i = 0; i < numVertices; ++i) {
             const node = nodes[i];
@@ -81,14 +79,6 @@ export class CatmaidSpatiallyIndexedSkeletonSourceBackend extends WithParameters
                 const parentIndex = nodeMap.get(node.parent_id);
                 if (parentIndex !== undefined) {
                     indices.push(i, parentIndex);
-                } else {
-                    // Parent is in a different chunk - store for later resolution
-                    missingConnections.push({
-                        nodeId: node.id,
-                        parentId: node.parent_id,
-                        vertexIndex: i,
-                        skeletonId: node.skeleton_id
-                    });
                 }
             }
         }
@@ -99,8 +89,6 @@ export class CatmaidSpatiallyIndexedSkeletonSourceBackend extends WithParameters
 
         // Pack only segment IDs into vertexAttributes (positions are in vertexPositions)
         chunk.vertexAttributes = [vertexAttributes];
-        chunk.missingConnections = missingConnections;
-        chunk.nodeMap = nodeMap;
     }
 }
 

--- a/src/datasource/catmaid/backend.ts
+++ b/src/datasource/catmaid/backend.ts
@@ -54,7 +54,10 @@ export class CatmaidSpatiallyIndexedSkeletonSourceBackend extends WithParameters
             min: { x: localMin[0], y: localMin[1], z: localMin[2] },
             max: { x: localMax[0], y: localMax[1], z: localMax[2] },
         };
-        const nodes = await this.client.fetchNodes(bbox);
+        
+        // Use currentLod from the source backend
+        const lodValue = this.currentLod;
+        const nodes = await this.client.fetchNodes(bbox, lodValue);
 
         const numVertices = nodes.length;
         const vertexPositions = new Float32Array(numVertices * 3);

--- a/src/datasource/catmaid/backend.ts
+++ b/src/datasource/catmaid/backend.ts
@@ -1,0 +1,240 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    AnnotationGeometryChunk,
+    AnnotationGeometryChunkSourceBackend,
+    AnnotationGeometryData,
+    AnnotationSource,
+} from "#src/annotation/backend.js";
+import {
+    Annotation,
+    AnnotationId,
+    AnnotationType,
+    makeAnnotationPropertySerializers,
+    annotationTypeHandlers,
+} from "#src/annotation/index.js";
+import { WithParameters } from "#src/chunk_manager/backend.js";
+import { CatmaidClient, CatmaidNode } from "#src/datasource/catmaid/api.js";
+import { 
+    CatmaidAnnotationSourceParameters,
+    CatmaidAnnotationGeometryChunkSourceParameters 
+} from "#src/datasource/catmaid/base.js";
+import { registerSharedObject } from "#src/worker_rpc.js";
+import { vec3 } from "#src/util/geom.js";
+
+function serializeAnnotations(
+    annotations: Annotation[]
+): AnnotationGeometryData {
+    const rank = 3;
+    const properties: any[] = [];
+    const propertySerializers = makeAnnotationPropertySerializers(
+        rank,
+        properties
+    );
+
+    const typeToAnnotations = new Map<AnnotationType, Annotation[]>();
+    for (const ann of annotations) {
+        if (!typeToAnnotations.has(ann.type)) {
+            typeToAnnotations.set(ann.type, []);
+        }
+        typeToAnnotations.get(ann.type)!.push(ann);
+    }
+
+    const geometryData = new AnnotationGeometryData();
+    geometryData.typeToIds = [];
+    geometryData.typeToOffset = [];
+    geometryData.typeToIdMaps = [];
+    geometryData.typeToInstanceCounts = [];
+    geometryData.typeToSize = [];
+
+    let totalBytes = 0;
+    for (const [type, anns] of typeToAnnotations) {
+        const serializer = propertySerializers[type];
+        const handler = annotationTypeHandlers[type];
+        const geometryBytes = handler.serializedBytes(rank);
+        const stride = geometryBytes + serializer.serializedBytes;
+        totalBytes += anns.length * stride;
+    }
+
+    geometryData.data = new Uint8Array(totalBytes);
+    const dv = new DataView(geometryData.data.buffer);
+    let currentOffset = 0;
+
+    for (const [type, anns] of typeToAnnotations) {
+        geometryData.typeToOffset[type] = currentOffset;
+        geometryData.typeToIds[type] = anns.map((a) => a.id);
+        geometryData.typeToIdMaps[type] = new Map(anns.map((a, i) => [a.id, i]));
+        geometryData.typeToSize[type] = anns.length;
+        geometryData.typeToInstanceCounts[type] = anns.map((_, i) => i);
+
+        const serializer = propertySerializers[type];
+        const handler = annotationTypeHandlers[type];
+        const geometryBytes = handler.serializedBytes(rank);
+        const stride = geometryBytes + serializer.serializedBytes;
+
+        for (let i = 0; i < anns.length; ++i) {
+            const ann = anns[i];
+            const offset = currentOffset + i * stride;
+
+            handler.serialize(dv, offset, true, rank, ann);
+
+            serializer.serialize(
+                dv,
+                offset + geometryBytes,
+                i,
+                anns.length,
+                true,
+                ann.properties
+            );
+        }
+        currentOffset += anns.length * stride;
+    }
+
+    return geometryData;
+}
+
+@registerSharedObject()
+export class CatmaidAnnotationGeometryChunkSourceBackend extends WithParameters(
+    AnnotationGeometryChunkSourceBackend,
+    CatmaidAnnotationGeometryChunkSourceParameters
+) {
+    get client(): CatmaidClient {
+        const { catmaidParameters } = this.parameters;
+        return new CatmaidClient(
+            catmaidParameters.url,
+            catmaidParameters.projectId,
+            catmaidParameters.token
+        );
+    }
+
+    async download(chunk: AnnotationGeometryChunk, _signal: AbortSignal) {
+        console.log('CATMAID Backend: download called for chunk:', chunk.chunkGridPosition);
+        const { chunkGridPosition } = chunk;
+        const { spec } = this;
+        const { chunkDataSize } = spec;
+
+        // Calculate bounding box in voxel coordinates
+        const minVoxel = vec3.create();
+        const maxVoxel = vec3.create();
+        for (let i = 0; i < 3; ++i) {
+            minVoxel[i] = chunkGridPosition[i] * chunkDataSize[i];
+            maxVoxel[i] = (chunkGridPosition[i] + 1) * chunkDataSize[i];
+        }
+        
+        console.log('CATMAID Backend: Querying box:', minVoxel, 'to', maxVoxel);
+
+        // Since we don't have the full transform chain here easily, and CATMAID usually works in physical coordinates (nm),
+        // we assume the chunk grid is aligned with physical space or we need to apply the transform.
+        // For this POC, let's assume 1 voxel = 1 nm if no transform is applied, or use the transform if available.
+        // spec.chunkToMultiscaleTransform is available.
+
+        // TODO: Apply transform correctly. For now, assuming identity/scaling is handled elsewhere or simple mapping.
+        // If chunkToMultiscaleTransform is identity, then voxel coords = physical coords.
+
+        const nodes = await this.client.boxQuery(minVoxel, maxVoxel);
+        
+        console.log('CATMAID Backend: Retrieved', nodes.length, 'nodes');
+
+        const annotations: Annotation[] = [];
+        const nodeMap = new Map<number, CatmaidNode>();
+        for (const node of nodes) {
+            nodeMap.set(node.id, node);
+            annotations.push({
+                type: AnnotationType.POINT,
+                id: `node_${node.id}`,
+                point: new Float32Array([node.x, node.y, node.z]),
+                properties: [],
+                description: undefined,
+                relatedSegments: undefined,
+            });
+        }
+
+        for (const node of nodes) {
+            if (node.parent_id && nodeMap.has(node.parent_id)) {
+                const parent = nodeMap.get(node.parent_id)!;
+                annotations.push({
+                    type: AnnotationType.LINE,
+                    id: `edge_${node.id}_${node.parent_id}`,
+                    pointA: new Float32Array([node.x, node.y, node.z]),
+                    pointB: new Float32Array([parent.x, parent.y, parent.z]),
+                    properties: [],
+                    description: undefined,
+                    relatedSegments: undefined,
+                });
+            }
+        }
+
+        console.log('CATMAID Backend: Created', annotations.length, 'annotations');
+        
+        chunk.data = serializeAnnotations(annotations);
+        
+        console.log('CATMAID Backend: Chunk data serialized successfully');
+    }
+}
+
+@registerSharedObject()
+export class CatmaidAnnotationSource extends WithParameters(
+    AnnotationSource,
+    CatmaidAnnotationSourceParameters
+) {
+    constructor(rpc: any, options: any) {
+        console.log('CATMAID Backend: CatmaidAnnotationSource constructor called with options:', options);
+        console.log('CATMAID Backend: options.metadataChunkSource:', options.metadataChunkSource);
+        console.log('CATMAID Backend: options.segmentFilteredSource:', options.segmentFilteredSource);
+        console.log('CATMAID Backend: options.chunkManager:', options.chunkManager);
+        super(rpc, options);
+        console.log('CATMAID Backend: CatmaidAnnotationSource constructor completed');
+    }
+
+    get client(): CatmaidClient {
+        const { catmaidParameters } = this.parameters;
+        return new CatmaidClient(
+            catmaidParameters.url,
+            catmaidParameters.projectId,
+            catmaidParameters.token
+        );
+    }
+
+    async add(annotation: Annotation): Promise<AnnotationId> {
+        if (annotation.type === AnnotationType.POINT) {
+            const point = (annotation as any).point;
+            const id = await this.client.addNode(
+                1, // TODO: Handle skeleton ID selection
+                point[0],
+                point[1],
+                point[2]
+            );
+            return `node_${id}`;
+        }
+        throw new Error("Only points supported for add in POC");
+    }
+
+    async delete(id: AnnotationId): Promise<void> {
+        if (id.startsWith("node_")) {
+            const nodeId = parseInt(id.substring(5));
+            await this.client.deleteNode(nodeId);
+        }
+    }
+
+    async update(id: AnnotationId, newAnnotation: Annotation): Promise<void> {
+        if (newAnnotation.type === AnnotationType.POINT) {
+            const nodeId = parseInt(id.substring(5));
+            const point = (newAnnotation as any).point;
+            await this.client.moveNode(nodeId, point[0], point[1], point[2]);
+        }
+    }
+}

--- a/src/datasource/catmaid/backend.ts
+++ b/src/datasource/catmaid/backend.ts
@@ -92,6 +92,8 @@ export class CatmaidSpatiallyIndexedSkeletonSourceBackend extends WithParameters
             }
         }
 
+        console.log(`[CATMAID-BACKEND] Created ${indices.length / 2} edges from parent-child relationships`);
+
         chunk.vertexPositions = vertexPositions;
         chunk.indices = new Uint32Array(indices);
 

--- a/src/datasource/catmaid/backend.ts
+++ b/src/datasource/catmaid/backend.ts
@@ -73,6 +73,7 @@ export class CatmaidSpatiallyIndexedSkeletonSourceBackend extends WithParameters
             vertexAttributes[i] = node.skeleton_id;
         }
 
+        const missingConnections: Array<{ nodeId: number; parentId: number; vertexIndex: number; skeletonId: number }> = [];
 
         for (let i = 0; i < numVertices; ++i) {
             const node = nodes[i];
@@ -80,6 +81,14 @@ export class CatmaidSpatiallyIndexedSkeletonSourceBackend extends WithParameters
                 const parentIndex = nodeMap.get(node.parent_id);
                 if (parentIndex !== undefined) {
                     indices.push(i, parentIndex);
+                } else {
+                    // Parent is in a different chunk - store for later resolution
+                    missingConnections.push({
+                        nodeId: node.id,
+                        parentId: node.parent_id,
+                        vertexIndex: i,
+                        skeletonId: node.skeleton_id
+                    });
                 }
             }
         }
@@ -90,6 +99,8 @@ export class CatmaidSpatiallyIndexedSkeletonSourceBackend extends WithParameters
 
         // Pack only segment IDs into vertexAttributes (positions are in vertexPositions)
         chunk.vertexAttributes = [vertexAttributes];
+        chunk.missingConnections = missingConnections;
+        chunk.nodeMap = nodeMap;
     }
 }
 

--- a/src/datasource/catmaid/backend.ts
+++ b/src/datasource/catmaid/backend.ts
@@ -88,22 +88,8 @@ export class CatmaidSpatiallyIndexedSkeletonSourceBackend extends WithParameters
         chunk.vertexPositions = vertexPositions;
         chunk.indices = new Uint32Array(indices);
 
-        const positionsBytes = new Uint8Array(vertexPositions.buffer);
-        const segmentsBytes = new Uint8Array(vertexAttributes.buffer);
-
-        const totalBytes = positionsBytes.byteLength + segmentsBytes.byteLength;
-        const packedData = new Uint8Array(totalBytes);
-        packedData.set(positionsBytes, 0);
-        packedData.set(segmentsBytes, positionsBytes.byteLength);
-
-        chunk.vertexAttributes = [packedData];
-
-        const positionsByteLength = numVertices * 3 * 4;
-        const segmentsByteLength = numVertices * 1 * 4;
-        (chunk as any).vertexAttributeOffsets = new Uint32Array([
-            0,
-            positionsByteLength,
-            positionsByteLength + segmentsByteLength
-        ]);
+        // Pack only segment IDs into vertexAttributes (positions are in vertexPositions)
+        // This will be serialized as a separate attribute
+        chunk.vertexAttributes = [vertexAttributes];
     }
 }

--- a/src/datasource/catmaid/backend.ts
+++ b/src/datasource/catmaid/backend.ts
@@ -55,8 +55,8 @@ export class CatmaidSpatiallyIndexedSkeletonSourceBackend extends WithParameters
             max: { x: localMax[0], y: localMax[1], z: localMax[2] },
         };
         
-        // Use currentLod from the source backend
-        const lodValue = this.currentLod;
+        // Use LOD stored on the chunk to support per-view LODs on shared sources.
+        const lodValue = chunk.lod ?? this.currentLod;
         // Get cache provider from parameters (passed from frontend)
         const cacheProvider = this.parameters.catmaidParameters.cacheProvider;
         const nodes = await this.client.fetchNodes(bbox, lodValue, cacheProvider);

--- a/src/datasource/catmaid/backend.ts
+++ b/src/datasource/catmaid/backend.ts
@@ -54,6 +54,7 @@ export class CatmaidSpatiallyIndexedSkeletonSourceBackend extends WithParameters
             min: { x: localMin[0], y: localMin[1], z: localMin[2] },
             max: { x: localMax[0], y: localMax[1], z: localMax[2] },
         };
+        console.log('Fetching nodes with bbox:', bbox);
         const nodes = await this.client.fetchNodes(bbox);
 
         const numVertices = nodes.length;

--- a/src/datasource/catmaid/backend.ts
+++ b/src/datasource/catmaid/backend.ts
@@ -66,6 +66,9 @@ export class CatmaidSpatiallyIndexedSkeletonSourceBackend extends WithParameters
         const indices: number[] = [];
         const nodeMap = new Map<number, number>();
 
+        // Track unique skeleton IDs for debugging
+        const uniqueSkeletonIds = new Set<number>();
+
         for (let i = 0; i < numVertices; ++i) {
             const node = nodes[i];
             nodeMap.set(node.id, i);
@@ -73,7 +76,11 @@ export class CatmaidSpatiallyIndexedSkeletonSourceBackend extends WithParameters
             vertexPositions[i * 3 + 1] = node.y;
             vertexPositions[i * 3 + 2] = node.z;
             vertexAttributes[i] = node.skeleton_id;
+            uniqueSkeletonIds.add(node.skeleton_id);
         }
+
+        console.log('[CATMAID-BACKEND] Unique skeleton IDs in chunk:', Array.from(uniqueSkeletonIds));
+        console.log('[CATMAID-BACKEND] Sample segment IDs:', Array.from(vertexAttributes.slice(0, Math.min(10, numVertices))));
 
         for (let i = 0; i < numVertices; ++i) {
             const node = nodes[i];

--- a/src/datasource/catmaid/backend.ts
+++ b/src/datasource/catmaid/backend.ts
@@ -54,7 +54,7 @@ export class CatmaidSpatiallyIndexedSkeletonSourceBackend extends WithParameters
             min: { x: localMin[0], y: localMin[1], z: localMin[2] },
             max: { x: localMax[0], y: localMax[1], z: localMax[2] },
         };
-        console.log('Fetching nodes with bbox:', bbox);
+        //console.log('Fetching nodes with bbox:', bbox);
         const nodes = await this.client.fetchNodes(bbox);
 
         const numVertices = nodes.length;

--- a/src/datasource/catmaid/backend.ts
+++ b/src/datasource/catmaid/backend.ts
@@ -29,14 +29,21 @@ export class CatmaidSpatiallyIndexedSkeletonSourceBackend extends WithParameters
     WithSharedCredentialsProviderCounterpart<CatmaidToken>()(SpatiallyIndexedSkeletonSourceBackend),
     CatmaidSkeletonSourceParameters
 ) {
+    private clientInstance: CatmaidClient | undefined;
+
     get client(): CatmaidClient {
-        const { catmaidParameters } = this.parameters;
-        return new CatmaidClient(
-            catmaidParameters.url,
-            catmaidParameters.projectId,
-            catmaidParameters.token,
-            this.credentialsProvider
-        );
+        let client = this.clientInstance;
+        if (client === undefined) {
+            const { catmaidParameters } = this.parameters;
+            client = new CatmaidClient(
+                catmaidParameters.url,
+                catmaidParameters.projectId,
+                catmaidParameters.token,
+                this.credentialsProvider
+            );
+            this.clientInstance = client;
+        }
+        return client;
     }
 
     constructor(...args: any[]) {
@@ -117,14 +124,21 @@ export class CatmaidSkeletonSourceBackend extends WithParameters(
     WithSharedCredentialsProviderCounterpart<CatmaidToken>()(SkeletonSource),
     CatmaidCompleteSkeletonSourceParameters
 ) {
+    private clientInstance: CatmaidClient | undefined;
+
     get client(): CatmaidClient {
-        const { catmaidParameters } = this.parameters;
-        return new CatmaidClient(
-            catmaidParameters.url,
-            catmaidParameters.projectId,
-            catmaidParameters.token,
-            this.credentialsProvider
-        );
+        let client = this.clientInstance;
+        if (client === undefined) {
+            const { catmaidParameters } = this.parameters;
+            client = new CatmaidClient(
+                catmaidParameters.url,
+                catmaidParameters.projectId,
+                catmaidParameters.token,
+                this.credentialsProvider
+            );
+            this.clientInstance = client;
+        }
+        return client;
     }
 
     constructor(...args: any[]) {

--- a/src/datasource/catmaid/backend.ts
+++ b/src/datasource/catmaid/backend.ts
@@ -57,7 +57,9 @@ export class CatmaidSpatiallyIndexedSkeletonSourceBackend extends WithParameters
         
         // Use currentLod from the source backend
         const lodValue = this.currentLod;
-        const nodes = await this.client.fetchNodes(bbox, lodValue);
+        // Get cache provider from parameters (passed from frontend)
+        const cacheProvider = this.parameters.catmaidParameters.cacheProvider;
+        const nodes = await this.client.fetchNodes(bbox, lodValue, cacheProvider);
 
         const numVertices = nodes.length;
         const vertexPositions = new Float32Array(numVertices * 3);

--- a/src/datasource/catmaid/backend.ts
+++ b/src/datasource/catmaid/backend.ts
@@ -66,6 +66,12 @@ export class CatmaidSpatiallyIndexedSkeletonSourceBackend extends WithParameters
         const vertexAttributes = new Float32Array(numVertices);
         const indices: number[] = [];
         const nodeMap = new Map<number, number>();
+        const missingConnections: Array<{
+            nodeId: number;
+            parentId: number;
+            vertexIndex: number;
+            skeletonId: number;
+        }> = [];
 
 
         for (let i = 0; i < numVertices; ++i) {
@@ -84,6 +90,13 @@ export class CatmaidSpatiallyIndexedSkeletonSourceBackend extends WithParameters
                 const parentIndex = nodeMap.get(node.parent_id);
                 if (parentIndex !== undefined) {
                     indices.push(i, parentIndex);
+                } else {
+                    missingConnections.push({
+                        nodeId: node.id,
+                        parentId: node.parent_id,
+                        vertexIndex: i,
+                        skeletonId: node.skeleton_id,
+                    });
                 }
             }
         }
@@ -94,6 +107,8 @@ export class CatmaidSpatiallyIndexedSkeletonSourceBackend extends WithParameters
 
         // Pack only segment IDs into vertexAttributes (positions are in vertexPositions)
         chunk.vertexAttributes = [vertexAttributes];
+        chunk.missingConnections = missingConnections;
+        chunk.nodeMap = nodeMap;
     }
 }
 

--- a/src/datasource/catmaid/base.ts
+++ b/src/datasource/catmaid/base.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AnnotationSourceParameters } from "#src/datasource/precomputed/base.js";
+import type { AnnotationGeometryChunkSpecification } from "#src/annotation/base.js";
+
+export class CatmaidDataSourceParameters {
+    url: string;
+    projectId: number;
+    token?: string;
+}
+
+export class CatmaidAnnotationSourceParameters extends AnnotationSourceParameters {
+    catmaidParameters: CatmaidDataSourceParameters;
+}
+
+export class CatmaidAnnotationGeometryChunkSourceParameters {
+    catmaidParameters: CatmaidDataSourceParameters;
+    spec: AnnotationGeometryChunkSpecification;
+    
+    static readonly RPC_ID = "catmaid/AnnotationGeometryChunkSource";
+}

--- a/src/datasource/catmaid/base.ts
+++ b/src/datasource/catmaid/base.ts
@@ -37,7 +37,8 @@ export class CatmaidAnnotationGeometryChunkSourceParameters {
 
 export class CatmaidSkeletonSourceParameters extends SkeletonSourceParameters {
     catmaidParameters: CatmaidDataSourceParameters;
-    useChunkSizeForScaleSelection?: boolean;
+    gridIndex?: number;
+    view?: string;
     static RPC_ID = "catmaid/SkeletonSource";
 }
 

--- a/src/datasource/catmaid/base.ts
+++ b/src/datasource/catmaid/base.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { AnnotationSourceParameters } from "#src/datasource/precomputed/base.js";
+import { AnnotationSourceParameters, SkeletonSourceParameters } from "#src/datasource/precomputed/base.js";
 import type { AnnotationGeometryChunkSpecification } from "#src/annotation/base.js";
 
 export class CatmaidDataSourceParameters {
@@ -30,6 +30,11 @@ export class CatmaidAnnotationSourceParameters extends AnnotationSourceParameter
 export class CatmaidAnnotationGeometryChunkSourceParameters {
     catmaidParameters: CatmaidDataSourceParameters;
     spec: AnnotationGeometryChunkSpecification;
-    
+
     static readonly RPC_ID = "catmaid/AnnotationGeometryChunkSource";
+}
+
+export class CatmaidSkeletonSourceParameters extends SkeletonSourceParameters {
+    catmaidParameters: CatmaidDataSourceParameters;
+    static RPC_ID = "catmaid/SkeletonSource";
 }

--- a/src/datasource/catmaid/base.ts
+++ b/src/datasource/catmaid/base.ts
@@ -21,6 +21,7 @@ export class CatmaidDataSourceParameters {
     url: string;
     projectId: number;
     token?: string;
+    cacheProvider?: string;
 }
 
 export class CatmaidAnnotationSourceParameters extends AnnotationSourceParameters {

--- a/src/datasource/catmaid/base.ts
+++ b/src/datasource/catmaid/base.ts
@@ -38,3 +38,8 @@ export class CatmaidSkeletonSourceParameters extends SkeletonSourceParameters {
     catmaidParameters: CatmaidDataSourceParameters;
     static RPC_ID = "catmaid/SkeletonSource";
 }
+
+export class CatmaidCompleteSkeletonSourceParameters extends SkeletonSourceParameters {
+    catmaidParameters: CatmaidDataSourceParameters;
+    static RPC_ID = "catmaid/CompleteSkeletonSource";
+}

--- a/src/datasource/catmaid/base.ts
+++ b/src/datasource/catmaid/base.ts
@@ -36,6 +36,7 @@ export class CatmaidAnnotationGeometryChunkSourceParameters {
 
 export class CatmaidSkeletonSourceParameters extends SkeletonSourceParameters {
     catmaidParameters: CatmaidDataSourceParameters;
+    useChunkSizeForScaleSelection?: boolean;
     static RPC_ID = "catmaid/SkeletonSource";
 }
 

--- a/src/datasource/catmaid/credentials_provider.ts
+++ b/src/datasource/catmaid/credentials_provider.ts
@@ -1,0 +1,57 @@
+import {
+    CredentialsProvider,
+    makeCredentialsGetter,
+} from "#src/credentials_provider/index.js";
+import { getCredentialsWithStatus } from "#src/credentials_provider/interactive_credentials_provider.js";
+import type { CatmaidToken } from "#src/datasource/catmaid/api.js";
+import { fetchOk } from "#src/util/http_request.js";
+import { ProgressSpan } from "#src/util/progress_listener.js";
+
+async function getAnonymousToken(
+    serverUrl: string,
+    signal: AbortSignal,
+): Promise<CatmaidToken> {
+    // serverUrl passed here is the base URL.
+
+    const tokenUrl = `${serverUrl}/accounts/anonymous-api-token`;
+
+    const response = await fetchOk(tokenUrl, {
+        method: "GET",
+        signal: signal,
+    });
+
+    const json = await response.json();
+    if (typeof json === 'object' && json !== null && typeof json.token === 'string') {
+        return { token: json.token };
+    }
+    throw new Error(`Unexpected response from ${tokenUrl}: ${JSON.stringify(json)}`);
+}
+
+export class CatmaidCredentialsProvider extends CredentialsProvider<CatmaidToken> {
+    constructor(public serverUrl: string) {
+        super();
+    }
+
+    get = makeCredentialsGetter(async (options) => {
+        using _span = new ProgressSpan(options.progressListener, {
+            message: `Requesting CATMAID access token from ${this.serverUrl}`,
+        });
+        return await getCredentialsWithStatus(
+            {
+                description: `CATMAID server ${this.serverUrl}`,
+                supportsImmediate: true,
+                get: async (signal, immediate) => {
+                    if (immediate) {
+                        try {
+                            return await getAnonymousToken(this.serverUrl, signal);
+                        } catch (e) {
+                            throw e;
+                        }
+                    }
+                    return await getAnonymousToken(this.serverUrl, signal);
+                },
+            },
+            options.signal,
+        );
+    });
+}

--- a/src/datasource/catmaid/frontend.ts
+++ b/src/datasource/catmaid/frontend.ts
@@ -80,7 +80,7 @@ export class CatmaidDataSourceProvider implements DataSourceProvider {
         );
         let stackInfo: any = null;
         try {
-            stackInfo = await client.getStackInfo();
+            stackInfo = await client.getMetadataInfo();
         } catch {
             // Ignore stack info errors.
         }

--- a/src/datasource/catmaid/frontend.ts
+++ b/src/datasource/catmaid/frontend.ts
@@ -213,6 +213,13 @@ export class CatmaidDataSourceProvider implements DataSourceProvider {
             chunkLayout,
         };
 
+        console.info('CATMAID Spatially Indexed Skeleton Source:', {
+            chunkSize: { x: chunkDataSize[0], y: chunkDataSize[1], z: chunkDataSize[2] },
+            resolution: { x: resolution.x, y: resolution.y, z: resolution.z, unit: 'nm' },
+            totalDimension: dimensions,
+            totalNumberOfSkeletons: skeletonIds.length
+        });
+
         const source = options.registry.chunkManager.getChunkSource(
             CatmaidSpatiallyIndexedSkeletonSource,
             { parameters, spec, credentialsProvider }

--- a/src/datasource/catmaid/frontend.ts
+++ b/src/datasource/catmaid/frontend.ts
@@ -268,12 +268,12 @@ export class CatmaidDataSourceProvider implements DataSourceProvider {
         const subsources = [
             {
                 id: "skeletons-chunked",
-                default: false,
+                default: true,
                 subsource: { mesh: source },
             },
             {
                 id: "skeletons",
-                default: true,
+                default: false,
                 subsource: { mesh: completeSkeletonSource },
             },
             {

--- a/src/datasource/catmaid/frontend.ts
+++ b/src/datasource/catmaid/frontend.ts
@@ -111,20 +111,20 @@ export class CatmaidMultiscaleSpatiallyIndexedSkeletonSource extends MultiscaleS
     }
 
     getPerspectiveSources(): SliceViewSingleResolutionSource<SpatiallyIndexedSkeletonSource>[] {
-        const sources = this.getSources({ view: "3d" } as any);
+        const sources = this.getSources({} as any);
         return sources.length > 0 ? sources[0] : [];
     }
 
     getSliceViewPanelSources(): SliceViewSingleResolutionSource<SpatiallyIndexedSkeletonSource>[] {
-        const sources = this.getSources({ view: "2d" } as any);
+        const sources = this.getSources({} as any);
         return sources.length > 0 ? sources[0] : [];
     }
 
     getSources(
-        options: SliceViewSourceOptions,
+        _options: SliceViewSourceOptions,
     ): SliceViewSingleResolutionSource<SpatiallyIndexedSkeletonSource>[][] {
+        void _options;
         const sources: SliceViewSingleResolutionSource<SpatiallyIndexedSkeletonSource>[] = [];
-        const view = (options as { view?: string } | undefined)?.view ?? "2d";
         
         // Sorted by minimum dimension (Descending: Large/Coarse -> Small/Fine)
         const sortedGridSizes = this.sortedGridCellSizes;
@@ -181,7 +181,6 @@ export class CatmaidMultiscaleSpatiallyIndexedSkeletonSource extends MultiscaleS
             parameters.catmaidParameters.projectId = this.projectId;
             parameters.catmaidParameters.cacheProvider = this.cacheProvider;
             parameters.gridIndex = gridIndex;
-            parameters.view = view;
             parameters.metadata = {
                 transform: mat4.create(),
                 vertexAttributes: new Map([

--- a/src/datasource/catmaid/frontend.ts
+++ b/src/datasource/catmaid/frontend.ts
@@ -139,20 +139,9 @@ export class CatmaidMultiscaleSpatiallyIndexedSkeletonSource extends MultiscaleS
         // Sorted by minimum dimension (Descending: Large/Coarse -> Small/Fine)
         const sortedGridSizes = this.sortedGridCellSizes;
 
-        // Calculate per-dimension min size for relative scaling
-        let minX = Number.MAX_VALUE;
-        let minY = Number.MAX_VALUE;
-        let minZ = Number.MAX_VALUE;
-        for (const s of sortedGridSizes) {
-            minX = Math.min(minX, s.x);
-            minY = Math.min(minY, s.y);
-            minZ = Math.min(minZ, s.z);
-        }
-
         if (CatmaidMultiscaleSpatiallyIndexedSkeletonSource.DEBUG_SCALE_SELECTION) {
             console.debug("[CATMAID] Spatially indexed skeleton scales", {
                 gridCellSizes: sortedGridSizes,
-                minGridCellSize: { x: minX, y: minY, z: minZ },
             });
         }
 
@@ -205,16 +194,10 @@ export class CatmaidMultiscaleSpatiallyIndexedSkeletonSource extends MultiscaleS
                 { parameters, spec, credentialsProvider: this.credentialsProvider }
             );
 
-            // Calculate relative scale based on grid size vs minimum grid size
-            const relativeScaleX = gridCellSize.x / minX;
-            const relativeScaleY = gridCellSize.y / minY;
-            const relativeScaleZ = gridCellSize.z / minZ;
-            
+            // CATMAID grid cell sizes are already expressed in project-space nanometers.
+            // Use identity here; additional relative scaling would double-apply grid size
+            // and can skew per-grid visible chunk counts and requests.
             const chunkToMultiscaleTransform = mat4.create();
-            mat4.fromScaling(
-                chunkToMultiscaleTransform,
-                vec3.fromValues(relativeScaleX, relativeScaleY, relativeScaleZ)
-            );
             sources.push({
                 chunkSource,
                 chunkToMultiscaleTransform,
@@ -223,7 +206,7 @@ export class CatmaidMultiscaleSpatiallyIndexedSkeletonSource extends MultiscaleS
             if (CatmaidMultiscaleSpatiallyIndexedSkeletonSource.DEBUG_SCALE_SELECTION) {
                 console.debug("[CATMAID] Spatially indexed skeleton scale", {
                     gridCellSize,
-                    relativeScale: { x: relativeScaleX, y: relativeScaleY, z: relativeScaleZ },
+                    chunkToMultiscaleTransform: "identity",
                 });
             }
         }

--- a/src/datasource/catmaid/frontend.ts
+++ b/src/datasource/catmaid/frontend.ts
@@ -92,7 +92,6 @@ export class CatmaidMultiscaleSpatiallyIndexedSkeletonSource extends MultiscaleS
         return 3;
     }
 
-    private static readonly DEBUG_SCALE_SELECTION = true;
     private sortedGridCellSizes: Array<{ x: number; y: number; z: number }>;
 
     constructor(
@@ -138,12 +137,6 @@ export class CatmaidMultiscaleSpatiallyIndexedSkeletonSource extends MultiscaleS
         
         // Sorted by minimum dimension (Descending: Large/Coarse -> Small/Fine)
         const sortedGridSizes = this.sortedGridCellSizes;
-
-        if (CatmaidMultiscaleSpatiallyIndexedSkeletonSource.DEBUG_SCALE_SELECTION) {
-            console.debug("[CATMAID] Spatially indexed skeleton scales", {
-                gridCellSizes: sortedGridSizes,
-            });
-        }
 
         for (const [gridIndex, gridCellSize] of sortedGridSizes.entries()) {
             const chunkDataSize = Uint32Array.from([
@@ -203,12 +196,6 @@ export class CatmaidMultiscaleSpatiallyIndexedSkeletonSource extends MultiscaleS
                 chunkToMultiscaleTransform,
             });
 
-            if (CatmaidMultiscaleSpatiallyIndexedSkeletonSource.DEBUG_SCALE_SELECTION) {
-                console.debug("[CATMAID] Spatially indexed skeleton scale", {
-                    gridCellSize,
-                    chunkToMultiscaleTransform: "identity",
-                });
-            }
         }
 
         return [sources];
@@ -277,7 +264,6 @@ export class CatmaidDataSourceProvider implements DataSourceProvider {
 
         // CATMAID node and grid-cache coordinates are in project-space nanometers.
         // Convert stack dimensions (pixels) to project-space nanometer bounds.
-        const { dimension, translation, resolution } = stackInfo;
         const projectBounds = getCatmaidProjectSpaceBounds(stackInfo);
 
         // Extract grid cell sizes from metadata
@@ -345,25 +331,6 @@ export class CatmaidDataSourceProvider implements DataSourceProvider {
             lowerCoordinateBound[i] = lowerBounds[i];
             upperCoordinateBound[i] = upperBounds[i];
         }
-
-        // Log information about available chunk sizes
-        console.info("CATMAID Multiscale Skeleton Source:", {
-            chunkSizes: gridCellSizes.map((size) => ({
-                x: size.x,
-                y: size.y,
-                z: size.z,
-                unit: "nm",
-            })),
-            stackDimension: { ...dimension, unit: "px" },
-            stackResolution: { x: resolution.x, y: resolution.y, z: resolution.z, unit: "nm/px" },
-            stackTranslation: { x: translation?.x ?? 0, y: translation?.y ?? 0, z: translation?.z ?? 0, unit: "nm" },
-            projectBounds: {
-                min: projectBounds.min,
-                max: projectBounds.max,
-                unit: "nm",
-            },
-            totalNumberOfSkeletons: skeletonIds.length,
-        });
 
         // Extract cache provider from metadata
         const cacheProvider = stackInfo.metadata?.cache_provider;

--- a/src/datasource/catmaid/frontend.ts
+++ b/src/datasource/catmaid/frontend.ts
@@ -1,0 +1,161 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    makeCoordinateSpace,
+    makeIdentityTransform,
+} from "#src/coordinate_transform.js";
+import {
+    AnnotationGeometryChunkSource,
+    MultiscaleAnnotationSource,
+} from "#src/annotation/frontend_source.js";
+import { WithParameters } from "#src/chunk_manager/frontend.js";
+import {
+    DataSource,
+    DataSourceProvider,
+    GetDataSourceOptions,
+} from "#src/datasource/index.js";
+import {
+    CatmaidAnnotationSourceParameters,
+    CatmaidAnnotationGeometryChunkSourceParameters,
+    CatmaidDataSourceParameters,
+} from "#src/datasource/catmaid/base.js";
+import type { SliceViewSingleResolutionSource } from "#src/sliceview/frontend.js";
+import { makeSliceViewChunkSpecification } from "#src/sliceview/base.js";
+import { mat4 } from "#src/util/geom.js";
+
+export class CatmaidAnnotationGeometryChunkSource extends WithParameters(
+    AnnotationGeometryChunkSource,
+    CatmaidAnnotationGeometryChunkSourceParameters
+) { }
+
+export class CatmaidAnnotationSource extends WithParameters(
+    MultiscaleAnnotationSource,
+    CatmaidAnnotationSourceParameters
+) {
+    initializeCounterpart(rpc: any, options: any) {
+        console.log('CATMAID Frontend: initializeCounterpart called with options:', options);
+        super.initializeCounterpart(rpc, options);
+        console.log('CATMAID Frontend: initializeCounterpart completed, options now:', options);
+    }
+
+    getSources(): SliceViewSingleResolutionSource<AnnotationGeometryChunkSource>[][] {
+        // Create a single resolution level with one chunk source
+        const spec = (this.parameters as any).spec;
+        if (!spec) {
+            throw new Error('CATMAID annotation source: spec is required');
+        }
+        
+        const chunkSourceParameters: CatmaidAnnotationGeometryChunkSourceParameters = {
+            catmaidParameters: this.parameters.catmaidParameters,
+            spec,
+        };
+        
+        const chunkSource = this.chunkManager.getChunkSource(
+            CatmaidAnnotationGeometryChunkSource,
+            {
+                parent: this,
+                parameters: chunkSourceParameters,
+                spec,
+            },
+        );
+
+        // Return a 2D array: [scales][alternatives]
+        // We have one scale with one alternative
+        return [[
+            {
+                chunkSource,
+                chunkToMultiscaleTransform: spec.chunkToMultiscaleTransform,
+            },
+        ]];
+    }
+}
+
+export class CatmaidDataSourceProvider implements DataSourceProvider {
+    get scheme() {
+        return "catmaid";
+    }
+
+    get description() {
+        return "CATMAID";
+    }
+
+    async get(options: GetDataSourceOptions): Promise<DataSource> {
+        const { providerUrl } = options;
+        // Parse URL: catmaid://<server>/<project_id>
+        const parts = providerUrl.split("/");
+        const projectId = parseInt(parts[parts.length - 1]);
+        const baseUrl = "https://" + parts.slice(0, parts.length - 1).join("/");
+
+        const parameters = new CatmaidAnnotationSourceParameters();
+        parameters.catmaidParameters = new CatmaidDataSourceParameters();
+        parameters.catmaidParameters.url = baseUrl;
+        parameters.catmaidParameters.projectId = projectId;
+        parameters.rank = 3;
+        parameters.properties = []; // Default properties
+
+        // Create a simple chunk specification for spatial indexing
+        // Use 1000nm chunks (1 micron) which is reasonable for neuron tracing
+        const chunkDataSize = new Uint32Array([1000, 1000, 1000]);
+        const upperVoxelBound = new Float32Array([1000000000, 1000000000, 1000000000]); // 1 billion nm = 1 meter cube
+        const lowerVoxelBound = new Float32Array([0, 0, 0]);
+        
+        // Use the helper function to create a proper spec
+        const baseSpec = makeSliceViewChunkSpecification({
+            rank: 3,
+            chunkDataSize,
+            upperVoxelBound,
+            lowerVoxelBound,
+        });
+        
+        // Add the additional properties needed for AnnotationGeometryChunkSpecification
+        const spec = {
+            ...baseSpec,
+            chunkToMultiscaleTransform: mat4.create(), // Identity transform
+            limit: 0, // No limit on annotation density
+        };
+        
+        // Store spec in parameters for getSources to access it
+        (parameters as any).spec = spec;
+
+        const source = options.registry.chunkManager.getChunkSource(
+            CatmaidAnnotationSource,
+            {
+                parameters,
+                rank: 3,
+                relationships: [],
+                properties: [],
+            } as any
+        );
+
+        const modelSpace = makeCoordinateSpace({
+            names: ["x", "y", "z"],
+            units: ["nm", "nm", "nm"],
+            scales: Float64Array.of(1, 1, 1),
+        });
+
+        return {
+            modelTransform: makeIdentityTransform(modelSpace),
+            subsources: [
+                {
+                    id: "annotations",
+                    default: true,
+                    subsource: { annotation: source },
+                },
+            ],
+        };
+    }
+}

--- a/src/datasource/catmaid/register_credentials_provider.ts
+++ b/src/datasource/catmaid/register_credentials_provider.ts
@@ -1,0 +1,9 @@
+import { registerDefaultCredentialsProvider } from "#src/credentials_provider/default_manager.js";
+import { credentialsKey } from "#src/datasource/catmaid/api.js";
+import { CatmaidCredentialsProvider } from "#src/datasource/catmaid/credentials_provider.js";
+
+registerDefaultCredentialsProvider(
+    credentialsKey,
+    (params: { serverUrl: string }) =>
+        new CatmaidCredentialsProvider(params.serverUrl),
+);

--- a/src/datasource/catmaid/register_default.ts
+++ b/src/datasource/catmaid/register_default.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { registerProvider } from "#src/datasource/default_provider.js";
+import { CatmaidDataSourceProvider } from "#src/datasource/catmaid/frontend.js";
+
+registerProvider(new CatmaidDataSourceProvider());

--- a/src/datasource/enabled_backend_modules.ts
+++ b/src/datasource/enabled_backend_modules.ts
@@ -12,3 +12,4 @@ import "#datasource/python/backend";
 import "#datasource/render/backend";
 import "#datasource/vtk/backend";
 import "#datasource/zarr/backend";
+import "#datasource/catmaid/backend";

--- a/src/datasource/enabled_frontend_modules.ts
+++ b/src/datasource/enabled_frontend_modules.ts
@@ -16,3 +16,4 @@ import "#datasource/python/register_default";
 import "#datasource/render/register_default";
 import "#datasource/vtk/register_default";
 import "#datasource/zarr/register_default";
+import "#datasource/catmaid/register_default";

--- a/src/datasource/graphene/frontend.ts
+++ b/src/datasource/graphene/frontend.ts
@@ -1360,9 +1360,9 @@ class GraphConnection extends SegmentationGraphSourceConnection {
 
   meshAddNewSegments(segments: bigint[]) {
     const meshSource = this.getMeshSource();
-    if (meshSource) {
+    if (meshSource && 'rpc' in meshSource && meshSource.rpc) {
       for (const segment of segments) {
-        meshSource.rpc!.invoke(GRAPHENE_MESH_NEW_SEGMENT_RPC_ID, {
+        meshSource.rpc.invoke(GRAPHENE_MESH_NEW_SEGMENT_RPC_ID, {
           rpcId: meshSource.rpcId!,
           segment,
         });

--- a/src/datasource/graphene/frontend.ts
+++ b/src/datasource/graphene/frontend.ts
@@ -1359,10 +1359,12 @@ class GraphConnection extends SegmentationGraphSourceConnection {
   }
 
   meshAddNewSegments(segments: bigint[]) {
-    const meshSource = this.getMeshSource();
-    if (meshSource && 'rpc' in meshSource && meshSource.rpc) {
+    // `DataSubsource.mesh` is widened for spatial skeleton support, but Graphene
+    // segment updates still target mesh sources.
+    const meshSource = this.getMeshSource() as MeshSource | undefined;
+    if (meshSource) {
       for (const segment of segments) {
-        meshSource.rpc.invoke(GRAPHENE_MESH_NEW_SEGMENT_RPC_ID, {
+        meshSource.rpc!.invoke(GRAPHENE_MESH_NEW_SEGMENT_RPC_ID, {
           rpcId: meshSource.rpcId!,
           segment,
         });

--- a/src/datasource/index.ts
+++ b/src/datasource/index.ts
@@ -42,7 +42,7 @@ import type { MeshSource, MultiscaleMeshSource } from "#src/mesh/frontend.js";
 import type { SegmentPropertyMap } from "#src/segmentation_display_state/property_map.js";
 import type { SegmentationGraphSource } from "#src/segmentation_graph/source.js";
 import type { SingleMeshSource } from "#src/single_mesh/frontend.js";
-import type { SkeletonSource, SpatiallyIndexedSkeletonSource } from "#src/skeleton/frontend.js";
+import type { SkeletonSource, SpatiallyIndexedSkeletonSource, MultiscaleSpatiallyIndexedSkeletonSource } from "#src/skeleton/frontend.js";
 import type { MultiscaleVolumeChunkSource } from "#src/sliceview/volume/frontend.js";
 import type { WatchableValueInterface } from "#src/trackable_value.js";
 import type {
@@ -125,7 +125,7 @@ export interface ConvertLegacyUrlOptions extends ConvertLegacyUrlOptionsBase {
 
 export interface DataSubsource {
   volume?: MultiscaleVolumeChunkSource;
-  mesh?: MeshSource | MultiscaleMeshSource | SkeletonSource | SpatiallyIndexedSkeletonSource;
+  mesh?: MeshSource | MultiscaleMeshSource | SkeletonSource | SpatiallyIndexedSkeletonSource | MultiscaleSpatiallyIndexedSkeletonSource;
   annotation?: MultiscaleAnnotationSource;
   staticAnnotations?: AnnotationSource;
   local?: LocalDataSource;

--- a/src/datasource/index.ts
+++ b/src/datasource/index.ts
@@ -42,7 +42,7 @@ import type { MeshSource, MultiscaleMeshSource } from "#src/mesh/frontend.js";
 import type { SegmentPropertyMap } from "#src/segmentation_display_state/property_map.js";
 import type { SegmentationGraphSource } from "#src/segmentation_graph/source.js";
 import type { SingleMeshSource } from "#src/single_mesh/frontend.js";
-import type { SkeletonSource } from "#src/skeleton/frontend.js";
+import type { SkeletonSource, SpatiallyIndexedSkeletonSource } from "#src/skeleton/frontend.js";
 import type { MultiscaleVolumeChunkSource } from "#src/sliceview/volume/frontend.js";
 import type { WatchableValueInterface } from "#src/trackable_value.js";
 import type {
@@ -125,7 +125,7 @@ export interface ConvertLegacyUrlOptions extends ConvertLegacyUrlOptionsBase {
 
 export interface DataSubsource {
   volume?: MultiscaleVolumeChunkSource;
-  mesh?: MeshSource | MultiscaleMeshSource | SkeletonSource;
+  mesh?: MeshSource | MultiscaleMeshSource | SkeletonSource | SpatiallyIndexedSkeletonSource;
   annotation?: MultiscaleAnnotationSource;
   staticAnnotations?: AnnotationSource;
   local?: LocalDataSource;
@@ -587,9 +587,9 @@ export class DataSourceRegistry extends RefCounted {
         });
         return applyCompletionOffset(
           url.length -
-            finalComponent.length +
-            parsedFinalComponent.scheme.length +
-            1,
+          finalComponent.length +
+          parsedFinalComponent.scheme.length +
+          1,
           completions,
         );
       }
@@ -619,12 +619,11 @@ export class DataSourceRegistry extends RefCounted {
 }
 
 export class KvStoreBasedDataSourceLegacyUrlAdapter
-  implements DataSourceProvider
-{
+  implements DataSourceProvider {
   constructor(
     public base: KvStoreBasedDataSourceProvider,
     public scheme = base.scheme,
-  ) {}
+  ) { }
 
   get hidden() {
     return true;

--- a/src/layer/segmentation/index.ts
+++ b/src/layer/segmentation/index.ts
@@ -535,6 +535,7 @@ class SegmentationUserLayerDisplayState implements SegmentationDisplayState {
     0,
   );
   objectAlpha = trackableAlphaValue(1.0);
+  hiddenObjectAlpha = trackableAlphaValue(0.0);
   ignoreNullVisibleSet = new TrackableBoolean(true, true);
   skeletonRenderingOptions = new SkeletonRenderingOptions();
   shaderError = makeWatchableShaderError();
@@ -663,6 +664,9 @@ export class SegmentationUserLayer extends Base {
     this.displayState.objectAlpha.changed.add(
       this.specificationChanged.dispatch,
     );
+    this.displayState.hiddenObjectAlpha.changed.add(
+      this.specificationChanged.dispatch,
+    );
     this.displayState.hoverHighlight.changed.add(
       this.specificationChanged.dispatch,
     );
@@ -750,6 +754,18 @@ export class SegmentationUserLayer extends Base {
           (x) =>
             x instanceof PerspectiveViewSkeletonLayer ||
             x instanceof PerspectiveViewSpatiallyIndexedSkeletonLayer,
+        ),
+      { changed: this.layersChanged, value: this.renderLayers },
+    ),
+  );
+
+  readonly hasSpatiallyIndexedSkeletonsLayer = this.registerDisposer(
+    makeCachedLazyDerivedWatchableValue(
+      (layers) =>
+        layers.some(
+          (x) =>
+            x instanceof PerspectiveViewSpatiallyIndexedSkeletonLayer ||
+            x instanceof SliceViewPanelSpatiallyIndexedSkeletonLayer,
         ),
       { changed: this.layersChanged, value: this.renderLayers },
     ),
@@ -1061,6 +1077,9 @@ export class SegmentationUserLayer extends Base {
     this.displayState.objectAlpha.restoreState(
       specification[json_keys.OBJECT_ALPHA_JSON_KEY],
     );
+    this.displayState.hiddenObjectAlpha.restoreState(
+      specification[json_keys.HIDDEN_OPACITY_3D_JSON_KEY],
+    );
     this.displayState.baseSegmentColoring.restoreState(
       specification[json_keys.BASE_SEGMENT_COLORING_JSON_KEY],
     );
@@ -1124,6 +1143,7 @@ export class SegmentationUserLayer extends Base {
       this.displayState.notSelectedAlpha.toJSON();
     x[json_keys.SATURATION_JSON_KEY] = this.displayState.saturation.toJSON();
     x[json_keys.OBJECT_ALPHA_JSON_KEY] = this.displayState.objectAlpha.toJSON();
+    x[json_keys.HIDDEN_OPACITY_3D_JSON_KEY] = this.displayState.hiddenObjectAlpha.toJSON();
     x[json_keys.HOVER_HIGHLIGHT_JSON_KEY] =
       this.displayState.hoverHighlight.toJSON();
     x[json_keys.BASE_SEGMENT_COLORING_JSON_KEY] =

--- a/src/layer/segmentation/index.ts
+++ b/src/layer/segmentation/index.ts
@@ -35,6 +35,7 @@ import type { LoadedDataSubsource } from "#src/layer/layer_data_source.js";
 import { layerDataSourceSpecificationFromJson } from "#src/layer/layer_data_source.js";
 import * as json_keys from "#src/layer/segmentation/json_keys.js";
 import { registerLayerControls } from "#src/layer/segmentation/layer_controls.js";
+import { appendSpatialSkeletonSerializationState } from "#src/layer/segmentation/spatial_skeleton_serialization.js";
 import {
   MeshLayer,
   MeshSource,
@@ -1678,20 +1679,26 @@ export class SegmentationUserLayer extends Base {
       this.displayState.notSelectedAlpha.toJSON();
     x[json_keys.SATURATION_JSON_KEY] = this.displayState.saturation.toJSON();
     x[json_keys.OBJECT_ALPHA_JSON_KEY] = this.displayState.objectAlpha.toJSON();
-    x[json_keys.HIDDEN_OPACITY_3D_JSON_KEY] = this.displayState.hiddenObjectAlpha.toJSON();
-    x[json_keys.SKELETON_LOD_JSON_KEY] = this.displayState.skeletonLod.toJSON();
-    x[json_keys.SPATIAL_SKELETON_GRID_RESOLUTION_TARGET_2D_JSON_KEY] =
-      this.displayState.spatialSkeletonGridResolutionTarget2d.toJSON();
-    x[json_keys.SPATIAL_SKELETON_GRID_RESOLUTION_TARGET_3D_JSON_KEY] =
-      this.displayState.spatialSkeletonGridResolutionTarget3d.toJSON();
-    x[json_keys.SPATIAL_SKELETON_GRID_RESOLUTION_RELATIVE_2D_JSON_KEY] =
-      this.displayState.spatialSkeletonGridResolutionRelative2d.toJSON();
-    x[json_keys.SPATIAL_SKELETON_GRID_RESOLUTION_RELATIVE_3D_JSON_KEY] =
-      this.displayState.spatialSkeletonGridResolutionRelative3d.toJSON();
-    x[json_keys.SPATIAL_SKELETON_GRID_LEVEL_2D_JSON_KEY] =
-      this.displayState.spatialSkeletonGridLevel2d.toJSON();
-    x[json_keys.SPATIAL_SKELETON_GRID_LEVEL_3D_JSON_KEY] =
-      this.displayState.spatialSkeletonGridLevel3d.toJSON();
+    appendSpatialSkeletonSerializationState(
+      x,
+      {
+        hiddenObjectAlpha: this.displayState.hiddenObjectAlpha,
+        skeletonLod: this.displayState.skeletonLod,
+        spatialSkeletonGridResolutionTarget2d:
+          this.displayState.spatialSkeletonGridResolutionTarget2d,
+        spatialSkeletonGridResolutionTarget3d:
+          this.displayState.spatialSkeletonGridResolutionTarget3d,
+        spatialSkeletonGridResolutionRelative2d:
+          this.displayState.spatialSkeletonGridResolutionRelative2d,
+        spatialSkeletonGridResolutionRelative3d:
+          this.displayState.spatialSkeletonGridResolutionRelative3d,
+        spatialSkeletonGridLevel2d:
+          this.displayState.spatialSkeletonGridLevel2d,
+        spatialSkeletonGridLevel3d:
+          this.displayState.spatialSkeletonGridLevel3d,
+      },
+      this.hasSpatiallyIndexedSkeletonsLayer.value,
+    );
     x[json_keys.HOVER_HIGHLIGHT_JSON_KEY] =
       this.displayState.hoverHighlight.toJSON();
     x[json_keys.BASE_SEGMENT_COLORING_JSON_KEY] =

--- a/src/layer/segmentation/index.ts
+++ b/src/layer/segmentation/index.ts
@@ -92,6 +92,7 @@ import { SegmentationRenderLayer } from "#src/sliceview/volume/segmentation_rend
 import { StatusMessage } from "#src/status.js";
 import { trackableAlphaValue } from "#src/trackable_alpha.js";
 import { TrackableBoolean } from "#src/trackable_boolean.js";
+import { trackableFiniteFloat } from "#src/trackable_finite_float.js";
 import type {
   TrackableValueInterface,
   WatchableValueInterface,
@@ -536,6 +537,7 @@ class SegmentationUserLayerDisplayState implements SegmentationDisplayState {
   );
   objectAlpha = trackableAlphaValue(1.0);
   hiddenObjectAlpha = trackableAlphaValue(0.0);
+  skeletonLod = trackableFiniteFloat(0.0);
   ignoreNullVisibleSet = new TrackableBoolean(true, true);
   skeletonRenderingOptions = new SkeletonRenderingOptions();
   shaderError = makeWatchableShaderError();
@@ -665,6 +667,9 @@ export class SegmentationUserLayer extends Base {
       this.specificationChanged.dispatch,
     );
     this.displayState.hiddenObjectAlpha.changed.add(
+      this.specificationChanged.dispatch,
+    );
+    this.displayState.skeletonLod.changed.add(
       this.specificationChanged.dispatch,
     );
     this.displayState.hoverHighlight.changed.add(
@@ -1080,6 +1085,9 @@ export class SegmentationUserLayer extends Base {
     this.displayState.hiddenObjectAlpha.restoreState(
       specification[json_keys.HIDDEN_OPACITY_3D_JSON_KEY],
     );
+    this.displayState.skeletonLod.restoreState(
+      specification[json_keys.SKELETON_LOD_JSON_KEY],
+    );
     this.displayState.baseSegmentColoring.restoreState(
       specification[json_keys.BASE_SEGMENT_COLORING_JSON_KEY],
     );
@@ -1144,6 +1152,7 @@ export class SegmentationUserLayer extends Base {
     x[json_keys.SATURATION_JSON_KEY] = this.displayState.saturation.toJSON();
     x[json_keys.OBJECT_ALPHA_JSON_KEY] = this.displayState.objectAlpha.toJSON();
     x[json_keys.HIDDEN_OPACITY_3D_JSON_KEY] = this.displayState.hiddenObjectAlpha.toJSON();
+    x[json_keys.SKELETON_LOD_JSON_KEY] = this.displayState.skeletonLod.toJSON();
     x[json_keys.HOVER_HIGHLIGHT_JSON_KEY] =
       this.displayState.hoverHighlight.toJSON();
     x[json_keys.BASE_SEGMENT_COLORING_JSON_KEY] =

--- a/src/layer/segmentation/index.ts
+++ b/src/layer/segmentation/index.ts
@@ -82,6 +82,7 @@ import {
   SliceViewPanelSkeletonLayer,
   PerspectiveViewSpatiallyIndexedSkeletonLayer,
   SliceViewPanelSpatiallyIndexedSkeletonLayer,
+  SliceViewSpatiallyIndexedSkeletonLayer,
   SpatiallyIndexedSkeletonLayer,
   SpatiallyIndexedSkeletonSource,
 } from "#src/skeleton/frontend.js";
@@ -799,6 +800,7 @@ export class SegmentationUserLayer extends Base {
           const displayState = {
             ...this.displayState,
             transform: loadedSubsource.getRenderLayerTransform(),
+            localPosition: this.localPosition,
           };
           if (mesh instanceof MeshSource) {
             loadedSubsource.addRenderLayer(
@@ -820,6 +822,9 @@ export class SegmentationUserLayer extends Base {
             );
             loadedSubsource.addRenderLayer(
               new PerspectiveViewSpatiallyIndexedSkeletonLayer(base.addRef()),
+            );
+            loadedSubsource.addRenderLayer(
+              new SliceViewSpatiallyIndexedSkeletonLayer(base.addRef()),
             );
             loadedSubsource.addRenderLayer(
               new SliceViewPanelSpatiallyIndexedSkeletonLayer(
@@ -854,6 +859,9 @@ export class SegmentationUserLayer extends Base {
             );
             loadedSubsource.addRenderLayer(
               new PerspectiveViewSpatiallyIndexedSkeletonLayer(base.addRef()),
+            );
+            loadedSubsource.addRenderLayer(
+              new SliceViewSpatiallyIndexedSkeletonLayer(base.addRef()),
             );
             loadedSubsource.addRenderLayer(
               new SliceViewPanelSpatiallyIndexedSkeletonLayer(

--- a/src/layer/segmentation/index.ts
+++ b/src/layer/segmentation/index.ts
@@ -1278,11 +1278,10 @@ export class SegmentationUserLayer extends Base {
       const {
         volume,
         mesh,
-        skeleton,
         segmentPropertyMap,
         segmentationGraph,
         local,
-      } = loadedSubsource.subsourceEntry.subsource as any;
+      } = loadedSubsource.subsourceEntry.subsource;
       if (volume instanceof MultiscaleVolumeChunkSource) {
         switch (volume.dataType) {
           case DataType.FLOAT32:
@@ -1403,59 +1402,6 @@ export class SegmentationUserLayer extends Base {
             const base = new SkeletonLayer(
               this.manager.chunkManager,
               mesh,
-              displayState,
-            );
-            loadedSubsource.addRenderLayer(
-              new PerspectiveViewSkeletonLayer(base.addRef()),
-            );
-            loadedSubsource.addRenderLayer(
-              new SliceViewPanelSkeletonLayer(/* transfer ownership */ base),
-            );
-          }
-        }, this.displayState.segmentationGroupState.value);
-      } else if (skeleton !== undefined) {
-        loadedSubsource.activate(() => {
-          const displayState = {
-            ...this.displayState,
-            transform: loadedSubsource.getRenderLayerTransform(),
-            localPosition: this.localPosition,
-          };
-          if (skeleton instanceof SpatiallyIndexedSkeletonSource) {
-            const base3d = new SpatiallyIndexedSkeletonLayer(
-              this.manager.chunkManager,
-              skeleton,
-              displayState,
-              {
-                gridLevel: displayState.spatialSkeletonGridLevel3d,
-                lod: displayState.skeletonLod,
-              },
-            );
-            loadedSubsource.addRenderLayer(
-              new PerspectiveViewSpatiallyIndexedSkeletonLayer(
-                /* transfer ownership */ base3d,
-              ),
-            );
-            const base2d = new SpatiallyIndexedSkeletonLayer(
-              this.manager.chunkManager,
-              skeleton,
-              displayState,
-              {
-                gridLevel: displayState.spatialSkeletonGridLevel2d,
-                lod: displayState.spatialSkeletonLod2d,
-              },
-            );
-            loadedSubsource.addRenderLayer(
-              new SliceViewSpatiallyIndexedSkeletonLayer(base2d.addRef()),
-            );
-            loadedSubsource.addRenderLayer(
-              new SliceViewPanelSpatiallyIndexedSkeletonLayer(
-                /* transfer ownership */ base2d,
-              ),
-            );
-          } else {
-            const base = new SkeletonLayer(
-              this.manager.chunkManager,
-              skeleton,
               displayState,
             );
             loadedSubsource.addRenderLayer(

--- a/src/layer/segmentation/index.ts
+++ b/src/layer/segmentation/index.ts
@@ -1306,6 +1306,11 @@ export class SegmentationUserLayer extends Base {
           this.displayState.segmentationGroupState.value,
         );
       } else if (mesh !== undefined) {
+        if (mesh instanceof MultiscaleSpatiallyIndexedSkeletonSource) {
+          // Collect grid metadata outside `activate`, since `activate` is a no-op
+          // when guard values are unchanged and may skip the callback.
+          spatialSkeletonGridSizes = mesh.getSpatialSkeletonGridSizes();
+        }
         loadedSubsource.activate(() => {
           const displayState = {
             ...this.displayState,
@@ -1366,7 +1371,6 @@ export class SegmentationUserLayer extends Base {
                 ),
               );
             }
-            spatialSkeletonGridSizes = mesh.getSpatialSkeletonGridSizes();
           } else if (mesh instanceof SpatiallyIndexedSkeletonSource) {
             const base3d = new SpatiallyIndexedSkeletonLayer(
               this.manager.chunkManager,

--- a/src/layer/segmentation/index.ts
+++ b/src/layer/segmentation/index.ts
@@ -735,7 +735,9 @@ export class SegmentationUserLayer extends Base {
             x instanceof MeshLayer ||
             x instanceof MultiscaleMeshLayer ||
             x instanceof PerspectiveViewSkeletonLayer ||
-            x instanceof SliceViewPanelSkeletonLayer,
+            x instanceof SliceViewPanelSkeletonLayer ||
+            x instanceof PerspectiveViewSpatiallyIndexedSkeletonLayer ||
+            x instanceof SliceViewPanelSpatiallyIndexedSkeletonLayer,
         ),
       { changed: this.layersChanged, value: this.renderLayers },
     ),
@@ -743,7 +745,12 @@ export class SegmentationUserLayer extends Base {
 
   readonly hasSkeletonsLayer = this.registerDisposer(
     makeCachedLazyDerivedWatchableValue(
-      (layers) => layers.some((x) => x instanceof PerspectiveViewSkeletonLayer),
+      (layers) =>
+        layers.some(
+          (x) =>
+            x instanceof PerspectiveViewSkeletonLayer ||
+            x instanceof PerspectiveViewSpatiallyIndexedSkeletonLayer,
+        ),
       { changed: this.layersChanged, value: this.renderLayers },
     ),
   );
@@ -751,6 +758,9 @@ export class SegmentationUserLayer extends Base {
   readonly getSkeletonLayer = () => {
     for (const layer of this.renderLayers) {
       if (layer instanceof PerspectiveViewSkeletonLayer) {
+        return layer.base;
+      }
+      if (layer instanceof PerspectiveViewSpatiallyIndexedSkeletonLayer) {
         return layer.base;
       }
     }

--- a/src/layer/segmentation/index.ts
+++ b/src/layer/segmentation/index.ts
@@ -850,6 +850,7 @@ export class SegmentationUserLayer extends Base {
           const displayState = {
             ...this.displayState,
             transform: loadedSubsource.getRenderLayerTransform(),
+            localPosition: this.localPosition,
           };
           if (skeleton instanceof SpatiallyIndexedSkeletonSource) {
             const base = new SpatiallyIndexedSkeletonLayer(

--- a/src/layer/segmentation/json_keys.ts
+++ b/src/layer/segmentation/json_keys.ts
@@ -1,6 +1,7 @@
 export const SELECTED_ALPHA_JSON_KEY = "selectedAlpha";
 export const NOT_SELECTED_ALPHA_JSON_KEY = "notSelectedAlpha";
 export const OBJECT_ALPHA_JSON_KEY = "objectAlpha";
+export const HIDDEN_OPACITY_3D_JSON_KEY = "hiddenObjectAlpha";
 export const SATURATION_JSON_KEY = "saturation";
 export const HOVER_HIGHLIGHT_JSON_KEY = "hoverHighlight";
 export const HIDE_SEGMENT_ZERO_JSON_KEY = "hideSegmentZero";

--- a/src/layer/segmentation/json_keys.ts
+++ b/src/layer/segmentation/json_keys.ts
@@ -7,6 +7,14 @@ export const SPATIAL_SKELETON_GRID_LEVEL_2D_JSON_KEY =
   "spatialSkeletonGridLevel2d";
 export const SPATIAL_SKELETON_GRID_LEVEL_3D_JSON_KEY =
   "spatialSkeletonGridLevel3d";
+export const SPATIAL_SKELETON_GRID_RESOLUTION_TARGET_2D_JSON_KEY =
+  "spatialSkeletonGridResolutionTarget2d";
+export const SPATIAL_SKELETON_GRID_RESOLUTION_TARGET_3D_JSON_KEY =
+  "spatialSkeletonGridResolutionTarget3d";
+export const SPATIAL_SKELETON_GRID_RESOLUTION_RELATIVE_2D_JSON_KEY =
+  "spatialSkeletonGridResolutionRelative2d";
+export const SPATIAL_SKELETON_GRID_RESOLUTION_RELATIVE_3D_JSON_KEY =
+  "spatialSkeletonGridResolutionRelative3d";
 export const SATURATION_JSON_KEY = "saturation";
 export const HOVER_HIGHLIGHT_JSON_KEY = "hoverHighlight";
 export const HIDE_SEGMENT_ZERO_JSON_KEY = "hideSegmentZero";

--- a/src/layer/segmentation/json_keys.ts
+++ b/src/layer/segmentation/json_keys.ts
@@ -3,6 +3,10 @@ export const NOT_SELECTED_ALPHA_JSON_KEY = "notSelectedAlpha";
 export const OBJECT_ALPHA_JSON_KEY = "objectAlpha";
 export const HIDDEN_OPACITY_3D_JSON_KEY = "hiddenObjectAlpha";
 export const SKELETON_LOD_JSON_KEY = "skeletonLod";
+export const SPATIAL_SKELETON_GRID_LEVEL_2D_JSON_KEY =
+  "spatialSkeletonGridLevel2d";
+export const SPATIAL_SKELETON_GRID_LEVEL_3D_JSON_KEY =
+  "spatialSkeletonGridLevel3d";
 export const SATURATION_JSON_KEY = "saturation";
 export const HOVER_HIGHLIGHT_JSON_KEY = "hoverHighlight";
 export const HIDE_SEGMENT_ZERO_JSON_KEY = "hideSegmentZero";

--- a/src/layer/segmentation/json_keys.ts
+++ b/src/layer/segmentation/json_keys.ts
@@ -2,6 +2,7 @@ export const SELECTED_ALPHA_JSON_KEY = "selectedAlpha";
 export const NOT_SELECTED_ALPHA_JSON_KEY = "notSelectedAlpha";
 export const OBJECT_ALPHA_JSON_KEY = "objectAlpha";
 export const HIDDEN_OPACITY_3D_JSON_KEY = "hiddenObjectAlpha";
+export const SKELETON_LOD_JSON_KEY = "skeletonLod";
 export const SATURATION_JSON_KEY = "saturation";
 export const HOVER_HIGHLIGHT_JSON_KEY = "hoverHighlight";
 export const HIDE_SEGMENT_ZERO_JSON_KEY = "hideSegmentZero";

--- a/src/layer/segmentation/layer_controls.ts
+++ b/src/layer/segmentation/layer_controls.ts
@@ -86,6 +86,16 @@ export const LAYER_CONTROLS: LayerControlDefinition<SegmentationUserLayer>[] = [
     })),
   },
   {
+    label: "LOD",
+    toolJson: json_keys.SKELETON_LOD_JSON_KEY,
+    isValid: (layer) => layer.hasSpatiallyIndexedSkeletonsLayer,
+    title: "Level of detail for spatially indexed skeletons (0-1)",
+    ...rangeLayerControl((layer) => ({
+      value: layer.displayState.skeletonLod,
+      options: { min: 0, max: 1, step: 0.01 },
+    })),
+  },
+  {
     label: "Silhouette (3d)",
     toolJson: json_keys.MESH_SILHOUETTE_RENDERING_JSON_KEY,
     isValid: (layer) => layer.has3dLayer,

--- a/src/layer/segmentation/layer_controls.ts
+++ b/src/layer/segmentation/layer_controls.ts
@@ -73,7 +73,7 @@ export const LAYER_CONTROLS: LayerControlDefinition<SegmentationUserLayer>[] = [
   },
   {
     label: "Resolution (skeleton grid 2D)",
-    toolJson: json_keys.SPATIAL_SKELETON_GRID_LEVEL_2D_JSON_KEY,
+    toolJson: json_keys.SPATIAL_SKELETON_GRID_RESOLUTION_TARGET_2D_JSON_KEY,
     isValid: (layer) =>
       makeCachedDerivedWatchableValue(
         (levels, hasSpatialSkeletons) =>
@@ -87,12 +87,16 @@ export const LAYER_CONTROLS: LayerControlDefinition<SegmentationUserLayer>[] = [
       "Select the grid size level for spatially indexed skeletons in 2D views",
     ...spatialSkeletonGridResolutionLayerControl((layer) => ({
       levels: layer.displayState.spatialSkeletonGridLevels,
-      target: layer.displayState.spatialSkeletonGridLevel2d,
+      target: layer.displayState.spatialSkeletonGridResolutionTarget2d,
+      relative: layer.displayState.spatialSkeletonGridResolutionRelative2d,
+      pixelSize: layer.displayState.spatialSkeletonGridPixelSize2d,
+      relativeTooltip:
+        "Interpret the 2D skeleton grid resolution target as relative to zoom",
     })),
   },
   {
     label: "Resolution (skeleton grid 3D)",
-    toolJson: json_keys.SPATIAL_SKELETON_GRID_LEVEL_3D_JSON_KEY,
+    toolJson: json_keys.SPATIAL_SKELETON_GRID_RESOLUTION_TARGET_3D_JSON_KEY,
     isValid: (layer) =>
       makeCachedDerivedWatchableValue(
         (levels, hasSpatialSkeletons) =>
@@ -106,7 +110,11 @@ export const LAYER_CONTROLS: LayerControlDefinition<SegmentationUserLayer>[] = [
       "Select the grid size level for spatially indexed skeletons in 3D views",
     ...spatialSkeletonGridResolutionLayerControl((layer) => ({
       levels: layer.displayState.spatialSkeletonGridLevels,
-      target: layer.displayState.spatialSkeletonGridLevel3d,
+      target: layer.displayState.spatialSkeletonGridResolutionTarget3d,
+      relative: layer.displayState.spatialSkeletonGridResolutionRelative3d,
+      pixelSize: layer.displayState.spatialSkeletonGridPixelSize3d,
+      relativeTooltip:
+        "Interpret the 3D skeleton grid resolution target as relative to zoom",
     })),
   },
   {

--- a/src/layer/segmentation/layer_controls.ts
+++ b/src/layer/segmentation/layer_controls.ts
@@ -8,7 +8,7 @@ import { rangeLayerControl } from "#src/widget/layer_control_range.js";
 import { makeCachedDerivedWatchableValue } from "#src/trackable_value.js";
 import {
   renderScaleLayerControl,
-  spatialSkeletonGridResolutionLayerControl,
+  spatialSkeletonGridRenderScaleLayerControl,
 } from "#src/widget/render_scale_widget.js";
 import {
   colorSeedLayerControl,
@@ -85,14 +85,16 @@ export const LAYER_CONTROLS: LayerControlDefinition<SegmentationUserLayer>[] = [
       ),
     title:
       "Select the grid size level for spatially indexed skeletons in 2D views",
-    ...spatialSkeletonGridResolutionLayerControl((layer) => ({
-      levels: layer.displayState.spatialSkeletonGridLevels,
-      target: layer.displayState.spatialSkeletonGridResolutionTarget2d,
-      relative: layer.displayState.spatialSkeletonGridResolutionRelative2d,
-      pixelSize: layer.displayState.spatialSkeletonGridPixelSize2d,
-      relativeTooltip:
-        "Interpret the 2D skeleton grid resolution target as relative to zoom",
-    })),
+    ...spatialSkeletonGridRenderScaleLayerControl(
+      (layer) => ({
+        histogram: layer.displayState.spatialSkeletonGridRenderScaleHistogram2d,
+        target: layer.displayState.spatialSkeletonGridResolutionTarget2d,
+        relative: layer.displayState.spatialSkeletonGridResolutionRelative2d,
+        pixelSize: layer.displayState.spatialSkeletonGridPixelSize2d,
+        relativeTooltip:
+          "Interpret the 2D skeleton grid resolution target as relative to zoom",
+      }),
+    ),
   },
   {
     label: "Resolution (skeleton grid 3D)",
@@ -108,14 +110,16 @@ export const LAYER_CONTROLS: LayerControlDefinition<SegmentationUserLayer>[] = [
       ),
     title:
       "Select the grid size level for spatially indexed skeletons in 3D views",
-    ...spatialSkeletonGridResolutionLayerControl((layer) => ({
-      levels: layer.displayState.spatialSkeletonGridLevels,
-      target: layer.displayState.spatialSkeletonGridResolutionTarget3d,
-      relative: layer.displayState.spatialSkeletonGridResolutionRelative3d,
-      pixelSize: layer.displayState.spatialSkeletonGridPixelSize3d,
-      relativeTooltip:
-        "Interpret the 3D skeleton grid resolution target as relative to zoom",
-    })),
+    ...spatialSkeletonGridRenderScaleLayerControl(
+      (layer) => ({
+        histogram: layer.displayState.spatialSkeletonGridRenderScaleHistogram3d,
+        target: layer.displayState.spatialSkeletonGridResolutionTarget3d,
+        relative: layer.displayState.spatialSkeletonGridResolutionRelative3d,
+        pixelSize: layer.displayState.spatialSkeletonGridPixelSize3d,
+        relativeTooltip:
+          "Interpret the 3D skeleton grid resolution target as relative to zoom",
+      }),
+    ),
   },
   {
     label: "Opacity (3d)",

--- a/src/layer/segmentation/layer_controls.ts
+++ b/src/layer/segmentation/layer_controls.ts
@@ -77,6 +77,15 @@ export const LAYER_CONTROLS: LayerControlDefinition<SegmentationUserLayer>[] = [
     })),
   },
   {
+    label: "Hidden Opacity (3d)",
+    toolJson: json_keys.HIDDEN_OPACITY_3D_JSON_KEY,
+    isValid: (layer) => layer.hasSpatiallyIndexedSkeletonsLayer,
+    title: "Opacity of hidden (non-visible) skeleton nodes in 3D views",
+    ...rangeLayerControl((layer) => ({
+      value: layer.displayState.hiddenObjectAlpha,
+    })),
+  },
+  {
     label: "Silhouette (3d)",
     toolJson: json_keys.MESH_SILHOUETTE_RENDERING_JSON_KEY,
     isValid: (layer) => layer.has3dLayer,

--- a/src/layer/segmentation/layer_controls.ts
+++ b/src/layer/segmentation/layer_controls.ts
@@ -5,7 +5,11 @@ import { registerLayerControl } from "#src/widget/layer_control.js";
 import { checkboxLayerControl } from "#src/widget/layer_control_checkbox.js";
 import { enumLayerControl } from "#src/widget/layer_control_enum.js";
 import { rangeLayerControl } from "#src/widget/layer_control_range.js";
-import { renderScaleLayerControl } from "#src/widget/render_scale_widget.js";
+import { makeCachedDerivedWatchableValue } from "#src/trackable_value.js";
+import {
+  renderScaleLayerControl,
+  spatialSkeletonGridResolutionLayerControl,
+} from "#src/widget/render_scale_widget.js";
 import {
   colorSeedLayerControl,
   fixedColorLayerControl,
@@ -68,6 +72,44 @@ export const LAYER_CONTROLS: LayerControlDefinition<SegmentationUserLayer>[] = [
     })),
   },
   {
+    label: "Resolution (skeleton grid 2D)",
+    toolJson: json_keys.SPATIAL_SKELETON_GRID_LEVEL_2D_JSON_KEY,
+    isValid: (layer) =>
+      makeCachedDerivedWatchableValue(
+        (levels, hasSpatialSkeletons) =>
+          hasSpatialSkeletons && levels.length > 0,
+        [
+          layer.displayState.spatialSkeletonGridLevels,
+          layer.hasSpatiallyIndexedSkeletonsLayer,
+        ],
+      ),
+    title:
+      "Select the grid size level for spatially indexed skeletons in 2D views",
+    ...spatialSkeletonGridResolutionLayerControl((layer) => ({
+      levels: layer.displayState.spatialSkeletonGridLevels,
+      target: layer.displayState.spatialSkeletonGridLevel2d,
+    })),
+  },
+  {
+    label: "Resolution (skeleton grid 3D)",
+    toolJson: json_keys.SPATIAL_SKELETON_GRID_LEVEL_3D_JSON_KEY,
+    isValid: (layer) =>
+      makeCachedDerivedWatchableValue(
+        (levels, hasSpatialSkeletons) =>
+          hasSpatialSkeletons && levels.length > 0,
+        [
+          layer.displayState.spatialSkeletonGridLevels,
+          layer.hasSpatiallyIndexedSkeletonsLayer,
+        ],
+      ),
+    title:
+      "Select the grid size level for spatially indexed skeletons in 3D views",
+    ...spatialSkeletonGridResolutionLayerControl((layer) => ({
+      levels: layer.displayState.spatialSkeletonGridLevels,
+      target: layer.displayState.spatialSkeletonGridLevel3d,
+    })),
+  },
+  {
     label: "Opacity (3d)",
     toolJson: json_keys.OBJECT_ALPHA_JSON_KEY,
     isValid: (layer) => layer.has3dLayer,
@@ -83,16 +125,6 @@ export const LAYER_CONTROLS: LayerControlDefinition<SegmentationUserLayer>[] = [
     title: "Opacity of hidden (non-visible) skeleton nodes in 3D views",
     ...rangeLayerControl((layer) => ({
       value: layer.displayState.hiddenObjectAlpha,
-    })),
-  },
-  {
-    label: "LOD",
-    toolJson: json_keys.SKELETON_LOD_JSON_KEY,
-    isValid: (layer) => layer.hasSpatiallyIndexedSkeletonsLayer,
-    title: "Level of detail for spatially indexed skeletons (0-1)",
-    ...rangeLayerControl((layer) => ({
-      value: layer.displayState.skeletonLod,
-      options: { min: 0, max: 1, step: 0.01 },
     })),
   },
   {

--- a/src/layer/segmentation/spatial_skeleton_serialization.spec.ts
+++ b/src/layer/segmentation/spatial_skeleton_serialization.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import * as json_keys from "#src/layer/segmentation/json_keys.js";
+import { appendSpatialSkeletonSerializationState } from "#src/layer/segmentation/spatial_skeleton_serialization.js";
+import { trackableAlphaValue } from "#src/trackable_alpha.js";
+import { TrackableBoolean } from "#src/trackable_boolean.js";
+import { trackableFiniteFloat } from "#src/trackable_finite_float.js";
+import { TrackableValue } from "#src/trackable_value.js";
+import {
+  verifyFiniteNonNegativeFloat,
+  verifyNonnegativeInt,
+} from "#src/util/json.js";
+
+function makeTrackables() {
+  return {
+    hiddenObjectAlpha: trackableAlphaValue(0.5),
+    skeletonLod: trackableFiniteFloat(0),
+    spatialSkeletonGridResolutionTarget2d: new TrackableValue<number>(
+      1,
+      verifyFiniteNonNegativeFloat,
+      1,
+    ),
+    spatialSkeletonGridResolutionTarget3d: new TrackableValue<number>(
+      1,
+      verifyFiniteNonNegativeFloat,
+      1,
+    ),
+    spatialSkeletonGridResolutionRelative2d: new TrackableBoolean(false, false),
+    spatialSkeletonGridResolutionRelative3d: new TrackableBoolean(false, false),
+    spatialSkeletonGridLevel2d: new TrackableValue<number>(
+      0,
+      verifyNonnegativeInt,
+      0,
+    ),
+    spatialSkeletonGridLevel3d: new TrackableValue<number>(
+      0,
+      verifyNonnegativeInt,
+      0,
+    ),
+  };
+}
+
+describe("appendSpatialSkeletonSerializationState", () => {
+  it("does not emit spatial skeleton keys when round-tripping a legacy spec", () => {
+    const legacySpec: Record<string, unknown> = {};
+    const trackables = makeTrackables();
+    trackables.hiddenObjectAlpha.restoreState(
+      legacySpec[json_keys.HIDDEN_OPACITY_3D_JSON_KEY],
+    );
+    trackables.skeletonLod.restoreState(
+      legacySpec[json_keys.SKELETON_LOD_JSON_KEY],
+    );
+    trackables.spatialSkeletonGridResolutionTarget2d.restoreState(
+      legacySpec[json_keys.SPATIAL_SKELETON_GRID_RESOLUTION_TARGET_2D_JSON_KEY],
+    );
+    trackables.spatialSkeletonGridResolutionTarget3d.restoreState(
+      legacySpec[json_keys.SPATIAL_SKELETON_GRID_RESOLUTION_TARGET_3D_JSON_KEY],
+    );
+    trackables.spatialSkeletonGridResolutionRelative2d.restoreState(
+      legacySpec[
+        json_keys.SPATIAL_SKELETON_GRID_RESOLUTION_RELATIVE_2D_JSON_KEY
+      ],
+    );
+    trackables.spatialSkeletonGridResolutionRelative3d.restoreState(
+      legacySpec[
+        json_keys.SPATIAL_SKELETON_GRID_RESOLUTION_RELATIVE_3D_JSON_KEY
+      ],
+    );
+    trackables.spatialSkeletonGridLevel2d.restoreState(
+      legacySpec[json_keys.SPATIAL_SKELETON_GRID_LEVEL_2D_JSON_KEY],
+    );
+    trackables.spatialSkeletonGridLevel3d.restoreState(
+      legacySpec[json_keys.SPATIAL_SKELETON_GRID_LEVEL_3D_JSON_KEY],
+    );
+
+    const serialized: Record<string, unknown> = {};
+    appendSpatialSkeletonSerializationState(
+      serialized,
+      trackables,
+      /* includeDefaults= */ false,
+    );
+    expect(serialized).toEqual({});
+  });
+
+  it("emits non-default values for non-spatial layers", () => {
+    const trackables = makeTrackables();
+    trackables.skeletonLod.value = 0.35;
+
+    const serialized: Record<string, unknown> = {};
+    appendSpatialSkeletonSerializationState(
+      serialized,
+      trackables,
+      /* includeDefaults= */ false,
+    );
+    expect(serialized).toEqual({
+      [json_keys.SKELETON_LOD_JSON_KEY]: 0.35,
+    });
+  });
+
+  it("emits defaults for spatially indexed skeleton layers", () => {
+    const trackables = makeTrackables();
+
+    const serialized: Record<string, unknown> = {};
+    appendSpatialSkeletonSerializationState(
+      serialized,
+      trackables,
+      /* includeDefaults= */ true,
+    );
+    expect(serialized).toEqual({
+      [json_keys.HIDDEN_OPACITY_3D_JSON_KEY]: 0.5,
+      [json_keys.SKELETON_LOD_JSON_KEY]: 0,
+      [json_keys.SPATIAL_SKELETON_GRID_RESOLUTION_TARGET_2D_JSON_KEY]: 1,
+      [json_keys.SPATIAL_SKELETON_GRID_RESOLUTION_TARGET_3D_JSON_KEY]: 1,
+      [json_keys.SPATIAL_SKELETON_GRID_RESOLUTION_RELATIVE_2D_JSON_KEY]: false,
+      [json_keys.SPATIAL_SKELETON_GRID_RESOLUTION_RELATIVE_3D_JSON_KEY]: false,
+      [json_keys.SPATIAL_SKELETON_GRID_LEVEL_2D_JSON_KEY]: 0,
+      [json_keys.SPATIAL_SKELETON_GRID_LEVEL_3D_JSON_KEY]: 0,
+    });
+  });
+});

--- a/src/layer/segmentation/spatial_skeleton_serialization.ts
+++ b/src/layer/segmentation/spatial_skeleton_serialization.ts
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as json_keys from "#src/layer/segmentation/json_keys.js";
+
+export interface JsonSerializableTrackable<T = unknown> {
+  toJSON(): any;
+  value: T;
+}
+
+export interface SpatialSkeletonSerializationTrackables {
+  hiddenObjectAlpha: JsonSerializableTrackable<number>;
+  skeletonLod: JsonSerializableTrackable<number>;
+  spatialSkeletonGridResolutionTarget2d: JsonSerializableTrackable<number>;
+  spatialSkeletonGridResolutionTarget3d: JsonSerializableTrackable<number>;
+  spatialSkeletonGridResolutionRelative2d: JsonSerializableTrackable<boolean>;
+  spatialSkeletonGridResolutionRelative3d: JsonSerializableTrackable<boolean>;
+  spatialSkeletonGridLevel2d: JsonSerializableTrackable<number>;
+  spatialSkeletonGridLevel3d: JsonSerializableTrackable<number>;
+}
+
+function getSerializedTrackableValue<T>(
+  trackable: JsonSerializableTrackable<T>,
+  includeDefaults: boolean,
+) {
+  const value = trackable.toJSON();
+  if (value !== undefined) return value;
+  if (!includeDefaults) return undefined;
+  return trackable.value;
+}
+
+function setSerializedTrackable<T>(
+  target: Record<string, any>,
+  key: string,
+  trackable: JsonSerializableTrackable<T>,
+  includeDefaults: boolean,
+) {
+  const value = getSerializedTrackableValue(trackable, includeDefaults);
+  if (value !== undefined) {
+    target[key] = value;
+  }
+}
+
+export function appendSpatialSkeletonSerializationState(
+  target: Record<string, any>,
+  trackables: SpatialSkeletonSerializationTrackables,
+  includeDefaults: boolean,
+) {
+  setSerializedTrackable(
+    target,
+    json_keys.HIDDEN_OPACITY_3D_JSON_KEY,
+    trackables.hiddenObjectAlpha,
+    includeDefaults,
+  );
+  setSerializedTrackable(
+    target,
+    json_keys.SKELETON_LOD_JSON_KEY,
+    trackables.skeletonLod,
+    includeDefaults,
+  );
+  setSerializedTrackable(
+    target,
+    json_keys.SPATIAL_SKELETON_GRID_RESOLUTION_TARGET_2D_JSON_KEY,
+    trackables.spatialSkeletonGridResolutionTarget2d,
+    includeDefaults,
+  );
+  setSerializedTrackable(
+    target,
+    json_keys.SPATIAL_SKELETON_GRID_RESOLUTION_TARGET_3D_JSON_KEY,
+    trackables.spatialSkeletonGridResolutionTarget3d,
+    includeDefaults,
+  );
+  setSerializedTrackable(
+    target,
+    json_keys.SPATIAL_SKELETON_GRID_RESOLUTION_RELATIVE_2D_JSON_KEY,
+    trackables.spatialSkeletonGridResolutionRelative2d,
+    includeDefaults,
+  );
+  setSerializedTrackable(
+    target,
+    json_keys.SPATIAL_SKELETON_GRID_RESOLUTION_RELATIVE_3D_JSON_KEY,
+    trackables.spatialSkeletonGridResolutionRelative3d,
+    includeDefaults,
+  );
+  setSerializedTrackable(
+    target,
+    json_keys.SPATIAL_SKELETON_GRID_LEVEL_2D_JSON_KEY,
+    trackables.spatialSkeletonGridLevel2d,
+    includeDefaults,
+  );
+  setSerializedTrackable(
+    target,
+    json_keys.SPATIAL_SKELETON_GRID_LEVEL_3D_JSON_KEY,
+    trackables.spatialSkeletonGridLevel3d,
+    includeDefaults,
+  );
+}

--- a/src/render_scale_statistics.ts
+++ b/src/render_scale_statistics.ts
@@ -26,15 +26,17 @@ export const renderScaleHistogramOrigin = -4;
 export function getRenderScaleHistogramOffset(
   renderScale: number,
   origin: number = renderScaleHistogramOrigin,
+  binSize: number = renderScaleHistogramBinSize,
 ): number {
-  return (Math.log2(renderScale) - origin) / renderScaleHistogramBinSize;
+  return (Math.log2(renderScale) - origin) / binSize;
 }
 
 export function getRenderScaleFromHistogramOffset(
   offset: number,
   origin: number = renderScaleHistogramOrigin,
+  binSize: number = renderScaleHistogramBinSize,
 ): number {
-  return 2 ** (offset * renderScaleHistogramBinSize + origin);
+  return 2 ** (offset * binSize + origin);
 }
 
 export function trackableRenderScaleTarget(
@@ -62,9 +64,14 @@ export class RenderScaleHistogram {
   visibility = new VisibilityPriorityAggregator();
   changed = new NullarySignal();
   logScaleOrigin: number;
+  logScaleBinSize: number;
 
-  constructor(origin: number = renderScaleHistogramOrigin) {
+  constructor(
+    origin: number = renderScaleHistogramOrigin,
+    binSize: number = renderScaleHistogramBinSize,
+  ) {
     this.logScaleOrigin = origin;
+    this.logScaleBinSize = binSize;
   }
 
   /**
@@ -142,7 +149,11 @@ export class RenderScaleHistogram {
         Math.max(
           0,
           Math.round(
-            getRenderScaleHistogramOffset(renderScale, this.logScaleOrigin),
+            getRenderScaleHistogramOffset(
+              renderScale,
+              this.logScaleOrigin,
+              this.logScaleBinSize,
+            ),
           ),
         ),
         numRenderScaleHistogramBins - 1,

--- a/src/segmentation_display_state/frontend.ts
+++ b/src/segmentation_display_state/frontend.ts
@@ -826,6 +826,7 @@ export function makeSegmentWidget(
 export interface SegmentationDisplayStateWithAlpha
   extends SegmentationDisplayState {
   objectAlpha: TrackableAlphaValue;
+  hiddenObjectAlpha?: TrackableAlphaValue;
 }
 
 export interface SegmentationDisplayState3D

--- a/src/skeleton/api.ts
+++ b/src/skeleton/api.ts
@@ -4,8 +4,6 @@ export interface SpatiallyIndexedSkeletonNode {
     x: number;
     y: number;
     z: number;
-    radius: number;
-    confidence: number;
     skeleton_id: number;
 }
 

--- a/src/skeleton/api.ts
+++ b/src/skeleton/api.ts
@@ -1,0 +1,32 @@
+export interface SpatiallyIndexedSkeletonNode {
+    id: number;
+    parent_id: number | null;
+    x: number;
+    y: number;
+    z: number;
+    radius: number;
+    confidence: number;
+    skeleton_id: number;
+}
+
+
+export interface SpatiallyIndexedSkeletonSource {
+    listSkeletons(): Promise<number[]>;
+    getSkeleton(skeletonId: number): Promise<SpatiallyIndexedSkeletonNode[]>;
+    getDimensions(): Promise<{ min: { x: number; y: number; z: number }; max: { x: number; y: number; z: number } } | null>;
+    getResolution(): Promise<{ x: number; y: number; z: number } | null>;
+    getGridCellSizes(): Promise<Array<{ x: number; y: number; z: number }>>;
+    fetchNodes(boundingBox: { min: { x: number, y: number, z: number }, max: { x: number, y: number, z: number } }, lod?: number): Promise<SpatiallyIndexedSkeletonNode[]>;
+    addNode(
+        skeletonId: number,
+        x: number,
+        y: number,
+        z: number,
+        parentId?: number,
+    ): Promise<number>;
+    moveNode(nodeId: number, x: number, y: number, z: number): Promise<void>;
+    deleteNode(nodeId: number): Promise<void>;
+
+    mergeSkeletons(skeletonId1: number, skeletonId2: number): Promise<void>;
+    splitSkeleton(nodeId: number): Promise<void>;
+}

--- a/src/skeleton/backend.ts
+++ b/src/skeleton/backend.ts
@@ -548,9 +548,14 @@ export class SpatiallyIndexedSkeletonSliceViewRenderLayerBackend extends SliceVi
     this.registerDisposer(
       this.skeletonGridLevel.changed.add(scheduleUpdateChunkPriorities),
     );
+    // Debounce LOD changes to avoid making requests for every slider value.
+    const debouncedLodUpdate = debounce(() => {
+      scheduleUpdateChunkPriorities();
+    }, SPATIALLY_INDEXED_SKELETON_LOD_DEBOUNCE_MS);
+    
     this.registerDisposer(
       this.skeletonLod.changed.add(() => {
-        scheduleUpdateChunkPriorities();
+        debouncedLodUpdate();
       }),
     );
   }

--- a/src/skeleton/backend.ts
+++ b/src/skeleton/backend.ts
@@ -79,6 +79,7 @@ export interface SpatiallyIndexedSkeletonChunkSpecification extends SliceViewChu
 }
 
 const SKELETON_CHUNK_PRIORITY = 60;
+const SPATIALLY_INDEXED_SKELETON_LOD_DEBOUNCE_MS = 300;
 
 registerRPC(
   SPATIALLY_INDEXED_SKELETON_RENDER_LAYER_UPDATE_SOURCES_RPC_ID,
@@ -292,7 +293,7 @@ export class SpatiallyIndexedSkeletonRenderLayerBackend extends withChunkManager
     // Debounce LOD changes to avoid making requests for every slider value
     const debouncedLodUpdate = debounce(() => {
       scheduleUpdateChunkPriorities();
-    }, 300);
+    }, SPATIALLY_INDEXED_SKELETON_LOD_DEBOUNCE_MS);
     
     this.registerDisposer(
       this.skeletonLod.changed.add(() => {

--- a/src/skeleton/backend.ts
+++ b/src/skeleton/backend.ts
@@ -73,7 +73,6 @@ import { registerRPC, registerSharedObject } from "#src/worker_rpc.js";
 import { deserializeTransformedSources } from "#src/sliceview/backend.js";
 import { debounce } from "lodash-es";
 
-const DEBUG_SPATIALLY_INDEXED_SKELETON_SCALES = true;
 
 export interface SpatiallyIndexedSkeletonChunkSpecification extends SliceViewChunkSpecification {
   chunkLayout: any;
@@ -505,17 +504,6 @@ export class SpatiallyIndexedSkeletonRenderLayerBackend extends withChunkManager
       const lodValue = this.skeletonLod.value;
       for (const scales of transformedSources) {
         const selectedScales = selectScales(scales);
-        if (DEBUG_SPATIALLY_INDEXED_SKELETON_SCALES) {
-          console.debug("[SKELETON-SCALES] selection", {
-            pixelSize: resolvedPixelSize,
-            renderScaleTarget,
-            totalScales: scales.length,
-            selectedScaleIndices: selectedScales.map((s) => s.scaleIndex),
-            selectedChunkSizes: selectedScales.map(
-              (s) => s.tsource.chunkLayout.size,
-            ),
-          });
-        }
         for (const { tsource, scaleIndex } of selectedScales) {
           const source =
             tsource.source as SpatiallyIndexedSkeletonSourceBackend;

--- a/src/skeleton/backend.ts
+++ b/src/skeleton/backend.ts
@@ -173,6 +173,8 @@ export class SpatiallyIndexedSkeletonChunk extends SliceViewChunk implements Ske
   vertexPositions: Float32Array | null = null;
   vertexAttributes: TypedNumberArray[] | null = null;
   indices: Uint32Array | null = null;
+  missingConnections: Array<{ nodeId: number; parentId: number; vertexIndex: number; skeletonId: number }> = [];
+  nodeMap: Map<number, number> = new Map(); // Maps node ID to vertex index
 
   freeSystemMemory() {
     freeSkeletonChunkSystemMemory(this);

--- a/src/skeleton/base.ts
+++ b/src/skeleton/base.ts
@@ -22,6 +22,8 @@ export const SPATIALLY_INDEXED_SKELETON_RENDER_LAYER_RPC_ID =
   "skeleton/SpatiallyIndexedSkeletonRenderLayer";
 export const SPATIALLY_INDEXED_SKELETON_RENDER_LAYER_UPDATE_SOURCES_RPC_ID =
   "skeleton/SpatiallyIndexedSkeletonRenderLayer.updateSources";
+export const SPATIALLY_INDEXED_SKELETON_SLICEVIEW_RENDER_LAYER_RPC_ID =
+  "skeleton/SpatiallyIndexedSkeletonSliceViewRenderLayer";
 
 export interface VertexAttributeInfo {
   dataType: DataType;

--- a/src/skeleton/base.ts
+++ b/src/skeleton/base.ts
@@ -18,6 +18,11 @@ import type { DataType } from "#src/util/data_type.js";
 
 export const SKELETON_LAYER_RPC_ID = "skeleton/SkeletonLayer";
 
+export const SPATIALLY_INDEXED_SKELETON_RENDER_LAYER_RPC_ID =
+  "skeleton/SpatiallyIndexedSkeletonRenderLayer";
+export const SPATIALLY_INDEXED_SKELETON_RENDER_LAYER_UPDATE_SOURCES_RPC_ID =
+  "skeleton/SpatiallyIndexedSkeletonRenderLayer.updateSources";
+
 export interface VertexAttributeInfo {
   dataType: DataType;
   numComponents: number;

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -1091,6 +1091,10 @@ export class SpatiallyIndexedSkeletonLayer extends RefCounted implements Skeleto
       SharedWatchableValue.makeFromExisting(rpc, displayState.renderScaleTarget),
     );
     
+    const skeletonLodWatchable = this.registerDisposer(
+      SharedWatchableValue.makeFromExisting(rpc, (displayState as any).skeletonLod),
+    );
+    
     sharedObject.initializeCounterpart(rpc, {
       chunkManager: chunkManager.rpcId,
       localPosition: this.registerDisposer(
@@ -1100,6 +1104,7 @@ export class SpatiallyIndexedSkeletonLayer extends RefCounted implements Skeleto
         ),
       ).rpcId,
       renderScaleTarget: renderScaleTargetWatchable.rpcId,
+      skeletonLod: skeletonLodWatchable.rpcId,
     });
     this.backend = sharedObject;
   }

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -1239,16 +1239,20 @@ export class SpatiallyIndexedSkeletonLayer extends RefCounted implements Skeleto
         for (const [segmentId, segmentIndicesList] of segmentIndicesMap) {
           const bigintId = BigInt(segmentId);
           
+          // Determine if this segment is visible
+          const visibleSegments = getVisibleSegments(displayState.segmentationGroupState.value);
+          const isSegmentVisible = visibleSegments.has(bigintId);
+          
           // Skip visible segments if regular skeleton layer is also active
-          if (hasRegularSkeletonLayer) {
-            const visibleSegments = getVisibleSegments(displayState.segmentationGroupState.value);
-            if (visibleSegments.has(bigintId)) {
-              continue; // Skip this segment, let regular skeleton layer render it
-            }
+          if (hasRegularSkeletonLayer && isSegmentVisible) {
+            continue; // Skip this segment, let regular skeleton layer render it
           }
           
           const color = getBaseObjectColor(displayState, bigintId, tempColor);
-          const alphaForSegment = displayState.objectAlpha.value;
+          // Use hiddenObjectAlpha for non-visible segments, objectAlpha for visible ones
+          const alphaForSegment = isSegmentVisible ? 
+            displayState.objectAlpha.value : 
+            (displayState.hiddenObjectAlpha?.value ?? 0);
           color[0] *= alphaForSegment;
           color[1] *= alphaForSegment;
           color[2] *= alphaForSegment;

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -477,10 +477,6 @@ void emitDefault() {
         this.targetIsSliceView ? 1.0 : 0.0,
       );
       drawLines(gl, 1, skeletonChunk.numIndices / 2);
-      const glError = gl.getError();
-      if (glError !== gl.NO_ERROR) {
-        console.error('[SKELETON-RENDER] WebGL error after drawLines:', glError);
-      }
       gl.vertexAttribDivisor(aVertexIndex, 0);
       gl.disableVertexAttribArray(aVertexIndex);
     }

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -170,6 +170,7 @@ const segmentColorTextureFormat = computeTextureFormat(
 
 interface SkeletonLayerInterface {
   vertexAttributes: VertexAttributeRenderInfo[];
+  segmentColorAttributeIndex?: number;
   gl: GL;
   fallbackShaderParameters: WatchableValue<ShaderControlsBuilderState>;
   displayState: SkeletonLayerDisplayState;
@@ -227,11 +228,7 @@ class RenderHelper extends RefCounted {
   ) {
     super();
     this.vertexIdHelper = this.registerDisposer(VertexIdHelper.get(this.gl));
-    const segmentColorIndex = this.vertexAttributes.findIndex(
-      (info) => info.name === "segmentColorAttr",
-    );
-    this.segmentColorAttributeIndex =
-      segmentColorIndex > 0 ? segmentColorIndex : undefined;
+    this.segmentColorAttributeIndex = base.segmentColorAttributeIndex;
     this.edgeShaderGetter = parameterizedEmitterDependentShaderGetter(
       this,
       this.gl,
@@ -619,6 +616,7 @@ export class SkeletonLayer extends RefCounted {
   redrawNeeded = new NullarySignal();
   private sharedObject: SegmentationLayerSharedObject;
   vertexAttributes: VertexAttributeRenderInfo[];
+  segmentColorAttributeIndex: number | undefined = undefined;
   fallbackShaderParameters = new WatchableValue(
     getFallbackBuilderState(parseShaderUiControls(DEFAULT_FRAGMENT_MAIN)),
   );
@@ -1344,6 +1342,7 @@ export class SpatiallyIndexedSkeletonLayer extends RefCounted implements Skeleto
   layerChunkProgressInfo = new LayerChunkProgressInfo();
   redrawNeeded = new NullarySignal();
   vertexAttributes: VertexAttributeRenderInfo[];
+  segmentColorAttributeIndex: number | undefined;
   fallbackShaderParameters = new WatchableValue(
     getFallbackBuilderState(parseShaderUiControls(DEFAULT_FRAGMENT_MAIN)),
   );
@@ -1427,6 +1426,7 @@ export class SpatiallyIndexedSkeletonLayer extends RefCounted implements Skeleto
       ...this.source.vertexAttributes,
       segmentColorAttribute,
     ];
+    this.segmentColorAttributeIndex = this.vertexAttributes.length - 1;
     const markDirty = () => this.markFilteredDataDirty();
     // Monitor visible segment changes to update filtered buffers.
     this.registerDisposer(

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -1081,28 +1081,17 @@ export class SpatiallyIndexedSkeletonLayer extends RefCounted implements Skeleto
       nodeShaderParameters.parseResult.controls,
     );
 
-    // Filter logic
-    const { visibleSegments } = displayState.segmentationGroupState.value as { visibleSegments: Uint64Set };
-
+    // Draw all nodes without filtering
     const chunks = source.chunks;
     for (const chunk of chunks.values()) {
-      if (chunk.state === ChunkState.GPU_MEMORY) {
-        this.updateChunkFilteredBuffer(chunk, visibleSegments);
-
-        if (chunk.filteredIndexBuffer && chunk.numFilteredIndices > 0) {
-          const chunkWrapper = {
-            ...chunk,
-            indexBuffer: chunk.filteredIndexBuffer,
-            numIndices: chunk.numFilteredIndices
-          };
-          renderHelper.drawSkeleton(
-            gl,
-            edgeShader,
-            nodeShader,
-            chunkWrapper,
-            renderContext.projectionParameters,
-          );
-        }
+      if (chunk.state === ChunkState.GPU_MEMORY && chunk.numIndices > 0) {
+        renderHelper.drawSkeleton(
+          gl,
+          edgeShader,
+          nodeShader,
+          chunk,
+          renderContext.projectionParameters,
+        );
       }
     }
 

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -2018,6 +2018,30 @@ export class PerspectiveViewSpatiallyIndexedSkeletonLayer extends PerspectiveVie
       ThreeDimensionalRenderLayerAttachmentState
     >,
   ) {
+    const pixelSizeWatchable = (this.base.displayState as any)
+      .spatialSkeletonGridPixelSize3d as WatchableValueInterface<number>
+      | undefined;
+    if (pixelSizeWatchable !== undefined) {
+      const voxelPhysicalScales =
+        renderContext.projectionParameters.displayDimensionRenderInfo
+          ?.voxelPhysicalScales;
+      if (voxelPhysicalScales !== undefined) {
+        const { invViewMatrix } = renderContext.projectionParameters;
+        let computedPixelSize = 0;
+        for (let i = 0; i < 3; ++i) {
+          const s = voxelPhysicalScales[i];
+          const x = invViewMatrix[i];
+          computedPixelSize += (s * x) ** 2;
+        }
+        const pixelSize = Math.sqrt(computedPixelSize);
+        if (
+          Number.isFinite(pixelSize) &&
+          pixelSizeWatchable.value !== pixelSize
+        ) {
+          pixelSizeWatchable.value = pixelSize;
+        }
+      }
+    }
     if (!renderContext.emitColor && renderContext.alreadyEmittedPickID) {
       return;
     }
@@ -2104,6 +2128,16 @@ export class SliceViewPanelSpatiallyIndexedSkeletonLayer extends SliceViewPanelR
       ThreeDimensionalRenderLayerAttachmentState
     >,
   ) {
+    const pixelSizeWatchable = (this.base.displayState as any)
+      .spatialSkeletonGridPixelSize2d as WatchableValueInterface<number>
+      | undefined;
+    if (pixelSizeWatchable !== undefined) {
+      const pixelSize =
+        renderContext.sliceView.projectionParameters.value.pixelSize;
+      if (Number.isFinite(pixelSize) && pixelSizeWatchable.value !== pixelSize) {
+        pixelSizeWatchable.value = pixelSize;
+      }
+    }
     this.base.draw(
       renderContext,
       this,

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -1793,10 +1793,8 @@ export class SpatiallyIndexedSkeletonLayer extends RefCounted implements Skeleto
         skipVisibleSegments && isVisible ? 0 : alphaForSegment;
       const color = new Float32Array(4);
       getBaseObjectColor(this.displayState, segmentBigInt, color);
-      color[0] *= effectiveAlpha;
-      color[1] *= effectiveAlpha;
-      color[2] *= effectiveAlpha;
-      color[3] = 1.0;
+      // Encode effectiveAlpha into the alpha channel; do not pre-scale RGB here.
+      color[3] = effectiveAlpha;
       const include = effectiveAlpha > 0;
       info = { include, color };
       segmentInfo.set(segmentId, info);

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -902,7 +902,6 @@ export class SpatiallyIndexedSkeletonChunk extends SliceViewChunk implements Ske
     this.numVertices = chunkData.numVertices;
     this.numIndices = indices.length;
     this.vertexAttributeOffsets = chunkData.vertexAttributeOffsets;
-    console.log(`[SKELETON-FRONTEND] SpatiallyIndexedSkeletonChunk created with ${this.numVertices} vertices and ${this.numIndices / 2} edges`);
 
     const gl = source.gl;
     this.indexBuffer = GLBuffer.fromData(
@@ -1130,19 +1129,6 @@ export class SpatiallyIndexedSkeletonLayer extends RefCounted implements Skeleto
         for (const [segmentId, segmentIndicesList] of segmentIndicesMap) {
           const bigintId = BigInt(segmentId);
           const color = getBaseObjectColor(displayState, bigintId, tempColor);
-          
-          // Log verification info for first vertex of this segment
-          const firstVertexIdx = segmentIndicesList[0];
-          const positionOffset = chunk.vertexAttributeOffsets[0];
-          const vertexPositions = new Float32Array(
-            chunk.vertexAttributes.buffer,
-            chunk.vertexAttributes.byteOffset + positionOffset,
-            chunk.numVertices * 3,
-          );
-          const x = vertexPositions[firstVertexIdx * 3];
-          const y = vertexPositions[firstVertexIdx * 3 + 1];
-          const z = vertexPositions[firstVertexIdx * 3 + 2];
-          console.log(`[SKELETON] Segment ${segmentId} at (${x.toFixed(0)}, ${y.toFixed(0)}, ${z.toFixed(0)}) -> RGB(${(color[0]*255).toFixed(0)}, ${(color[1]*255).toFixed(0)}, ${(color[2]*255).toFixed(0)})`);
           
           // Set color for this segment
           edgeShader.bind();

--- a/src/skeleton/gpu_upload_utils.ts
+++ b/src/skeleton/gpu_upload_utils.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { GL } from "#src/webgl/context.js";
+import {
+  setOneDimensionalTextureData,
+  type TextureFormat,
+} from "#src/webgl/texture_access.js";
+
+/**
+ * Uploads vertex attribute data to GPU as 1D textures.
+ * 
+ * This function takes contiguous packed vertex attribute data and creates separate
+ * GPU textures for each attribute type (e.g., positions, segment IDs, etc.).
+ * 
+ * @param gl - WebGL rendering context
+ * @param vertexAttributes - Packed byte array containing all vertex attributes
+ * @param vertexAttributeOffsets - Byte offsets marking the start of each attribute in the packed array
+ * @param attributeTextureFormats - Texture format specifications for each attribute
+ * @returns Array of WebGL textures, one per attribute
+ */
+export function uploadVertexAttributesToGPU(
+  gl: GL,
+  vertexAttributes: Uint8Array,
+  vertexAttributeOffsets: Uint32Array,
+  attributeTextureFormats: TextureFormat[],
+): (WebGLTexture | null)[] {
+  const vertexAttributeTextures: (WebGLTexture | null)[] = [];
+  const numAttributes = vertexAttributeOffsets.length;
+  
+  for (let i = 0; i < numAttributes; ++i) {
+    const texture = gl.createTexture();
+    gl.bindTexture(WebGL2RenderingContext.TEXTURE_2D, texture);
+    setOneDimensionalTextureData(
+      gl,
+      attributeTextureFormats[i],
+      vertexAttributes.subarray(
+        vertexAttributeOffsets[i],
+        i + 1 !== numAttributes
+          ? vertexAttributeOffsets[i + 1]
+          : vertexAttributes.length,
+      ),
+    );
+    vertexAttributeTextures[i] = texture;
+  }
+  gl.bindTexture(WebGL2RenderingContext.TEXTURE_2D, null);
+  
+  return vertexAttributeTextures;
+}

--- a/src/skeleton/skeleton_chunk_serialization.ts
+++ b/src/skeleton/skeleton_chunk_serialization.ts
@@ -108,6 +108,6 @@ export function serializeSkeletonChunkData(
  */
 export function freeSkeletonChunkSystemMemory(data: SkeletonChunkData): void {
   data.vertexPositions = data.indices = data.vertexAttributes = null;
-  data.missingConnections = [];
-  data.nodeMap = new Map();
+  data.missingConnections = undefined;
+  data.nodeMap = undefined;
 }

--- a/src/skeleton/skeleton_chunk_serialization.ts
+++ b/src/skeleton/skeleton_chunk_serialization.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { TypedNumberArray } from "#src/util/array.js";
+
+export interface SkeletonChunkData {
+  vertexPositions: Float32Array | null;
+  vertexAttributes: TypedNumberArray[] | null;
+  indices: Uint32Array | null;
+}
+
+/**
+ * Calculates the total byte size of vertex attributes including positions.
+ */
+export function getVertexAttributeBytes(data: SkeletonChunkData): number {
+  let total = data.vertexPositions!.byteLength;
+  const { vertexAttributes } = data;
+  if (vertexAttributes != null) {
+    vertexAttributes.forEach((a) => {
+      total += a.byteLength;
+    });
+  }
+  return total;
+}
+
+/**
+ * Serializes skeleton chunk data for transfer to frontend.
+ * Packs vertex positions and attributes into a single Uint8Array for efficient transfer.
+ */
+export function serializeSkeletonChunkData(
+  data: SkeletonChunkData,
+  msg: any,
+  transfers: any[],
+): void {
+  const vertexPositions = data.vertexPositions!;
+  const indices = data.indices!;
+  msg.numVertices = vertexPositions.length / 3;
+  msg.indices = indices;
+  transfers.push(indices.buffer);
+
+  const { vertexAttributes } = data;
+  if (vertexAttributes != null && vertexAttributes.length > 0) {
+    const vertexData = new Uint8Array(getVertexAttributeBytes(data));
+    vertexData.set(
+      new Uint8Array(
+        vertexPositions.buffer,
+        vertexPositions.byteOffset,
+        vertexPositions.byteLength,
+      ),
+    );
+    const vertexAttributeOffsets = (msg.vertexAttributeOffsets =
+      new Uint32Array(vertexAttributes.length + 1));
+    vertexAttributeOffsets[0] = 0;
+    let offset = vertexPositions.byteLength;
+    vertexAttributes.forEach((a, i) => {
+      vertexAttributeOffsets[i + 1] = offset;
+      vertexData.set(
+        new Uint8Array(a.buffer, a.byteOffset, a.byteLength),
+        offset,
+      );
+      offset += a.byteLength;
+    });
+    transfers.push(vertexData.buffer);
+    msg.vertexAttributes = vertexData;
+  } else {
+    msg.vertexAttributes = new Uint8Array(
+      vertexPositions.buffer,
+      vertexPositions.byteOffset,
+      vertexPositions.byteLength,
+    );
+    msg.vertexAttributeOffsets = Uint32Array.of(0);
+    if (vertexPositions.buffer !== transfers[0]) {
+      transfers.push(vertexPositions.buffer);
+    }
+  }
+}
+
+/**
+ * Clears skeleton chunk data from memory.
+ */
+export function freeSkeletonChunkSystemMemory(data: SkeletonChunkData): void {
+  data.vertexPositions = data.indices = data.vertexAttributes = null;
+}

--- a/src/skeleton/skeleton_chunk_serialization.ts
+++ b/src/skeleton/skeleton_chunk_serialization.ts
@@ -20,6 +20,8 @@ export interface SkeletonChunkData {
   vertexPositions: Float32Array | null;
   vertexAttributes: TypedNumberArray[] | null;
   indices: Uint32Array | null;
+  missingConnections?: Array<{ nodeId: number; parentId: number; vertexIndex: number; skeletonId: number }>;
+  nodeMap?: Map<number, number>;
 }
 
 /**
@@ -86,6 +88,15 @@ export function serializeSkeletonChunkData(
       transfers.push(vertexPositions.buffer);
     }
   }
+
+  // Serialize inter-chunk connection data
+  if (data.missingConnections) {
+    msg.missingConnections = data.missingConnections;
+  }
+  if (data.nodeMap) {
+    // Convert Map to array of [key, value] pairs for serialization
+    msg.nodeMap = Array.from(data.nodeMap.entries());
+  }
 }
 
 /**
@@ -93,4 +104,6 @@ export function serializeSkeletonChunkData(
  */
 export function freeSkeletonChunkSystemMemory(data: SkeletonChunkData): void {
   data.vertexPositions = data.indices = data.vertexAttributes = null;
+  data.missingConnections = [];
+  data.nodeMap = new Map();
 }

--- a/src/skeleton/skeleton_chunk_serialization.ts
+++ b/src/skeleton/skeleton_chunk_serialization.ts
@@ -20,6 +20,7 @@ export interface SkeletonChunkData {
   vertexPositions: Float32Array | null;
   vertexAttributes: TypedNumberArray[] | null;
   indices: Uint32Array | null;
+  lod?: number;
   missingConnections?: Array<{ nodeId: number; parentId: number; vertexIndex: number; skeletonId: number }>;
   nodeMap?: Map<number, number>;
 }
@@ -47,6 +48,9 @@ export function serializeSkeletonChunkData(
   msg: any,
   transfers: any[],
 ): void {
+  if (data.lod !== undefined) {
+    msg.lod = data.lod;
+  }
   const vertexPositions = data.vertexPositions!;
   const indices = data.indices!;
   msg.numVertices = vertexPositions.length / 3;

--- a/src/sliceview/backend.ts
+++ b/src/sliceview/backend.ts
@@ -158,6 +158,7 @@ export class SliceViewBackend extends SliceViewIntermediateBase {
         ++i
       ) {
         const tsource = visibleSources[i];
+        layer.prepareChunkSourceForRequest(tsource.source);
         const prefetchOffsets = chunkManager.queueManager.enablePrefetch.value
           ? getPrefetchChunkOffsets(this.velocityEstimator, tsource)
           : [];
@@ -430,6 +431,10 @@ export class SliceViewRenderLayerBackend
     this.numPrefetchChunksAvailable = 0;
     this.numPrefetchChunksNeeded = 0;
     this.chunkManagerGeneration = -1;
+  }
+
+  prepareChunkSourceForRequest(_source: SliceViewChunkSourceBackend) {
+    // Override in subclasses to set per-request source state (e.g. LOD).
   }
 
   filterVisibleSources(

--- a/src/widget/render_scale_widget.css
+++ b/src/widget/render_scale_widget.css
@@ -43,6 +43,16 @@
   height: 12px;
 }
 
+.neuroglancer-render-scale-widget-grid .neuroglancer-render-scale-widget-legend {
+  width: auto;
+  min-width: 22ch;
+  flex: 0 0 auto;
+}
+
+.neuroglancer-render-scale-widget-grid .neuroglancer-render-scale-widget-legend > div {
+  white-space: nowrap;
+}
+
 .neuroglancer-render-scale-widget-relative {
   display: inline-flex;
   align-items: center;

--- a/src/widget/render_scale_widget.css
+++ b/src/widget/render_scale_widget.css
@@ -43,15 +43,14 @@
   height: 12px;
 }
 
-.neuroglancer-spatial-skeleton-grid-widget
-  .neuroglancer-render-scale-widget-legend {
-  width: 22ch;
+.neuroglancer-render-scale-widget-relative {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+  margin-right: 4px;
 }
 
-.neuroglancer-spatial-skeleton-grid-widget
-  .neuroglancer-render-scale-widget-legend
-  > div {
-  height: 14px;
-  line-height: 14px;
-  white-space: nowrap;
+.neuroglancer-render-scale-widget-relative-checkbox {
+  margin: 0;
 }

--- a/src/widget/render_scale_widget.css
+++ b/src/widget/render_scale_widget.css
@@ -44,13 +44,41 @@
 }
 
 .neuroglancer-render-scale-widget-grid .neuroglancer-render-scale-widget-legend {
-  width: auto;
-  min-width: 22ch;
-  flex: 0 0 auto;
+  width: 100%;
+  min-width: 0;
+  flex: 1 1 100%;
+  display: flex;
+  column-gap: 8px;
+  text-align: left;
 }
 
 .neuroglancer-render-scale-widget-grid .neuroglancer-render-scale-widget-legend > div {
   white-space: nowrap;
+  flex: 1 1 0;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.neuroglancer-render-scale-widget-grid {
+  align-items: center;
+  flex-wrap: wrap;
+  column-gap: 4px;
+}
+
+.neuroglancer-render-scale-widget-grid > canvas {
+  order: 3;
+  width: 100%;
+  flex: 1 1 100%;
+}
+
+.neuroglancer-render-scale-widget-grid .neuroglancer-render-scale-widget-prompt {
+  order: 1;
+}
+
+.neuroglancer-render-scale-widget-grid .neuroglancer-render-scale-widget-legend {
+  order: 2;
+  font-size: 10px;
 }
 
 .neuroglancer-render-scale-widget-relative {

--- a/src/widget/render_scale_widget.css
+++ b/src/widget/render_scale_widget.css
@@ -42,3 +42,16 @@
 .neuroglancer-render-scale-widget-legend > div {
   height: 12px;
 }
+
+.neuroglancer-spatial-skeleton-grid-widget
+  .neuroglancer-render-scale-widget-legend {
+  width: 22ch;
+}
+
+.neuroglancer-spatial-skeleton-grid-widget
+  .neuroglancer-render-scale-widget-legend
+  > div {
+  height: 14px;
+  line-height: 14px;
+  white-space: nowrap;
+}

--- a/src/widget/render_scale_widget.ts
+++ b/src/widget/render_scale_widget.ts
@@ -26,7 +26,7 @@ import {
   renderScaleHistogramBinSize,
   renderScaleHistogramOrigin,
 } from "#src/render_scale_statistics.js";
-import type { TrackableValueInterface } from "#src/trackable_value.js";
+import type { TrackableValueInterface, WatchableValueInterface } from "#src/trackable_value.js";
 import { WatchableValue } from "#src/trackable_value.js";
 import { serializeColor } from "#src/util/color.js";
 import { hsvToRgb } from "#src/util/colorspace.js";
@@ -62,6 +62,16 @@ function formatPixelNumber(x: number) {
 
 export interface RenderScaleWidgetOptions {
   histogram: RenderScaleHistogram;
+  target: TrackableValueInterface<number>;
+}
+
+type SpatialSkeletonGridLevel = {
+  size: { x: number; y: number; z: number };
+  lod: number;
+};
+
+export interface SpatialSkeletonGridResolutionWidgetOptions {
+  levels: WatchableValueInterface<SpatialSkeletonGridLevel[]>;
   target: TrackableValueInterface<number>;
 }
 
@@ -384,6 +394,240 @@ export class VolumeRenderingRenderScaleWidget extends RenderScaleWidget {
   }
 }
 
+const gridInputEventMap = EventActionMap.fromObject({
+  mousedown0: { action: "set" },
+  wheel: { action: "adjust-via-wheel" },
+  dblclick0: { action: "reset" },
+});
+
+export class SpatialSkeletonGridResolutionWidget extends RefCounted {
+  label = document.createElement("div");
+  element = document.createElement("div");
+  canvas = document.createElement("canvas");
+  legend = document.createElement("div");
+  legendGrid = document.createElement("div");
+  legendSize = document.createElement("div");
+  legendLod = document.createElement("div");
+  hoverIndex = new WatchableValue<number | undefined>(undefined);
+  private ctx = this.canvas.getContext("2d")!;
+  private binOffsets: number[] = [];
+  private binBoundaries: number[] = [];
+  private lastLevelCount = -1;
+  private throttledUpdateView = this.registerCancellable(
+    throttle(() => this.debouncedUpdateView(), updateInterval, {
+      leading: true,
+      trailing: true,
+    }),
+  );
+  private debouncedUpdateView = this.registerCancellable(
+    debounce(() => this.updateView(), 0),
+  );
+
+  constructor(
+    public levels: WatchableValueInterface<SpatialSkeletonGridLevel[]>,
+    public target: TrackableValueInterface<number>,
+  ) {
+    super();
+    const { canvas, label, element, legend, legendGrid, legendSize, legendLod } =
+      this;
+    label.className = "neuroglancer-render-scale-widget-prompt";
+    element.className = "neuroglancer-render-scale-widget";
+    element.classList.add("neuroglancer-spatial-skeleton-grid-widget");
+    element.title = gridInputEventMap.describe();
+    legend.className = "neuroglancer-render-scale-widget-legend";
+    element.appendChild(label);
+    element.appendChild(canvas);
+    element.appendChild(legend);
+    legend.appendChild(legendGrid);
+    legend.appendChild(legendSize);
+    legend.appendChild(legendLod);
+    this.registerDisposer(levels.changed.add(this.throttledUpdateView));
+    this.registerDisposer(target.changed.add(this.debouncedUpdateView));
+    this.registerDisposer(this.hoverIndex.changed.add(this.debouncedUpdateView));
+    this.registerDisposer(new MouseEventBinder(canvas, gridInputEventMap));
+
+    const getTargetIndex = (event: MouseEvent) => {
+      const levelCount = this.levels.value.length;
+      if (levelCount <= 0) return 0;
+      this.ensureBins(levelCount);
+      const binPosition =
+        (event.offsetX / canvas.width) * numRenderScaleHistogramBins;
+      for (let i = 0; i < levelCount; ++i) {
+        const start = this.binBoundaries[i];
+        const end = this.binBoundaries[i + 1];
+        if (binPosition >= start && binPosition < end) {
+          return i;
+        }
+      }
+      return levelCount - 1;
+    };
+
+    this.registerEventListener(canvas, "pointermove", (event: MouseEvent) => {
+      const levelCount = this.levels.value.length;
+      if (levelCount === 0) {
+        this.hoverIndex.value = undefined;
+        return;
+      }
+      this.hoverIndex.value = getTargetIndex(event);
+    });
+
+    this.registerEventListener(canvas, "pointerleave", () => {
+      this.hoverIndex.value = undefined;
+    });
+
+    this.registerDisposer(
+      registerActionListener<MouseEvent>(canvas, "set", (actionEvent) => {
+        this.target.value = getTargetIndex(actionEvent.detail);
+      }),
+    );
+
+    this.registerDisposer(
+      registerActionListener<WheelEvent>(
+        canvas,
+        "adjust-via-wheel",
+        (actionEvent) => {
+          this.adjustViaWheel(actionEvent.detail);
+        },
+      ),
+    );
+
+    this.registerDisposer(
+      registerActionListener(canvas, "reset", (event) => {
+        this.reset();
+        event.preventDefault();
+      }),
+    );
+
+    const resizeObserver = new ResizeObserver(() => this.debouncedUpdateView());
+    resizeObserver.observe(canvas);
+    this.registerDisposer(() => resizeObserver.disconnect());
+    this.updateView();
+  }
+
+  adjustViaWheel(event: WheelEvent) {
+    const levelCount = this.levels.value.length;
+    if (levelCount === 0) return;
+    const delta = Math.sign(event.deltaY);
+    if (delta === 0) return;
+    const current = this.target.value;
+    const next = Math.min(
+      Math.max(current + delta, 0),
+      levelCount - 1,
+    );
+    this.target.value = next;
+    event.preventDefault();
+  }
+
+  reset() {
+    this.hoverIndex.value = undefined;
+    const target = this.target as TrackableValueInterface<number> & {
+      reset?: () => void;
+    };
+    if (typeof target.reset === "function") {
+      target.reset();
+    } else {
+      this.target.value = 0;
+    }
+  }
+
+  private ensureBins(levelCount: number) {
+    if (levelCount === this.lastLevelCount) return;
+    this.lastLevelCount = levelCount;
+    this.binOffsets = [];
+    this.binBoundaries = [];
+    if (levelCount <= 0) return;
+    if (levelCount === 1) {
+      this.binOffsets = [(numRenderScaleHistogramBins - 1) / 2];
+      this.binBoundaries = [0, numRenderScaleHistogramBins];
+      return;
+    }
+    const scale = (numRenderScaleHistogramBins - 1) / (levelCount - 1);
+    for (let i = 0; i < levelCount; ++i) {
+      this.binOffsets.push(i * scale);
+    }
+    this.binBoundaries = new Array(levelCount + 1);
+    this.binBoundaries[0] = 0;
+    for (let i = 1; i < levelCount; ++i) {
+      this.binBoundaries[i] = (this.binOffsets[i - 1] + this.binOffsets[i]) / 2;
+    }
+    this.binBoundaries[levelCount] = numRenderScaleHistogramBins;
+  }
+
+  updateView() {
+    const { ctx, canvas } = this;
+    const width = (canvas.width = canvas.offsetWidth);
+    const height = (canvas.height = canvas.offsetHeight);
+    ctx.clearRect(0, 0, width, height);
+
+    const levels = this.levels.value;
+    const levelCount = levels.length;
+    if (levelCount === 0) {
+      this.legendGrid.textContent = "grid -";
+      this.legendSize.textContent = "size -";
+      this.legendLod.textContent = "lod -";
+      return;
+    }
+    this.ensureBins(levelCount);
+
+    const selectedIndex = Math.min(
+      Math.max(Math.round(this.target.value), 0),
+      levelCount - 1,
+    );
+    const hoverIndex =
+      this.hoverIndex.value !== undefined
+        ? Math.min(Math.max(this.hoverIndex.value, 0), levelCount - 1)
+        : undefined;
+    const displayIndex = hoverIndex ?? selectedIndex;
+    const level = levels[displayIndex];
+    this.legendGrid.textContent = `grid ${displayIndex + 1}/${levelCount}`;
+    this.legendSize.textContent = `size ${Math.round(level.size.x)}x${Math.round(
+      level.size.y,
+    )}x${Math.round(level.size.z)}`;
+    this.legendLod.textContent = `lod ${level.lod.toFixed(2)}`;
+
+    const tempColor = vec3.create();
+    const binToCanvasX = (bin: number) =>
+      (bin * width) / numRenderScaleHistogramBins;
+    const barTop = Math.round(height * 0.1);
+    const barHeight = Math.max(4, height - barTop * 2);
+
+    for (let i = 0; i < levelCount; ++i) {
+      const spatialScale = Math.min(
+        levels[i].size.x,
+        levels[i].size.y,
+        levels[i].size.z,
+      );
+      const saturation = hoverIndex !== undefined && i === hoverIndex ? 0.5 : 1;
+      let hue = 0;
+      if (Number.isFinite(spatialScale)) {
+        hue = (((Math.log2(spatialScale) * 0.1) % 1) + 1) % 1;
+      }
+      hsvToRgb(tempColor, hue, saturation, 1);
+      ctx.fillStyle = serializeColor(tempColor);
+      const xStart = Math.round(binToCanvasX(this.binBoundaries[i]));
+      const xEnd = Math.round(binToCanvasX(this.binBoundaries[i + 1]));
+      ctx.fillRect(xStart, barTop, xEnd - xStart, barHeight);
+    }
+
+    {
+      const targetOffset = this.binOffsets[selectedIndex];
+      const x = Math.round(binToCanvasX(targetOffset));
+      ctx.fillStyle = "#fff";
+      ctx.fillRect(x, 0, 1, height);
+    }
+    if (hoverIndex !== undefined) {
+      const hoverOffset = this.binOffsets[hoverIndex];
+      const x = Math.round(binToCanvasX(hoverOffset));
+      ctx.fillStyle = "#888";
+      ctx.fillRect(x, 0, 1, height);
+    }
+  }
+}
+
+export class SpatialSkeletonGridRenderScaleWidget extends RenderScaleWidget {
+  protected unitOfTarget = "grid";
+}
+
 const TOOL_INPUT_EVENT_MAP = EventActionMap.fromObject({
   "at:shift+wheel": { action: "adjust-via-wheel" },
   "at:shift+dblclick0": { action: "reset" },
@@ -407,6 +651,38 @@ export function renderScaleLayerControl<
       const { histogram, target } = getter(layer);
       const control = context.registerDisposer(
         new widgetClass(histogram, target),
+      );
+      return { control, controlElement: control.element };
+    },
+    activateTool: (activation, control) => {
+      activation.bindInputEventMap(TOOL_INPUT_EVENT_MAP);
+      activation.bindAction(
+        "adjust-via-wheel",
+        (event: ActionEvent<WheelEvent>) => {
+          event.stopPropagation();
+          event.preventDefault();
+          control.adjustViaWheel(event.detail);
+        },
+      );
+      activation.bindAction("reset", (event: ActionEvent<WheelEvent>) => {
+        event.stopPropagation();
+        event.preventDefault();
+        control.reset();
+      });
+    },
+  };
+}
+
+export function spatialSkeletonGridResolutionLayerControl<
+  LayerType extends UserLayer,
+>(
+  getter: (layer: LayerType) => SpatialSkeletonGridResolutionWidgetOptions,
+): LayerControlFactory<LayerType, SpatialSkeletonGridResolutionWidget> {
+  return {
+    makeControl: (layer, context) => {
+      const { levels, target } = getter(layer);
+      const control = context.registerDisposer(
+        new SpatialSkeletonGridResolutionWidget(levels, target),
       );
       return { control, controlElement: control.element };
     },

--- a/src/widget/render_scale_widget.ts
+++ b/src/widget/render_scale_widget.ts
@@ -447,6 +447,7 @@ export class SpatialSkeletonGridResolutionWidget extends RefCounted {
     } = this;
     label.className = "neuroglancer-render-scale-widget-prompt";
     element.className = "neuroglancer-render-scale-widget";
+    element.classList.add("neuroglancer-render-scale-widget-grid");
     element.title = gridInputEventMap.describe();
     legend.className = "neuroglancer-render-scale-widget-legend";
     element.appendChild(label);
@@ -481,6 +482,14 @@ export class SpatialSkeletonGridResolutionWidget extends RefCounted {
       this.hoverSpacing.changed.add(this.debouncedUpdateView),
     );
     this.registerDisposer(new MouseEventBinder(canvas, gridInputEventMap));
+    this.registerEventListener(element, "click", (event: MouseEvent) => {
+      if (event.target === relativeCheckbox.element) {
+        return;
+      }
+      // Prevent the layer-control <label> from toggling the relative checkbox
+      // when interacting with the widget outside the checkbox itself.
+      event.preventDefault();
+    });
 
     const getSpacingFromEvent = (event: MouseEvent) => {
       const position =


### PR DESCRIPTION
Closes:
- https://metacell.atlassian.net/browse/NA-546
- https://metacell.atlassian.net/browse/NA-545
- https://metacell.atlassian.net/browse/NA-550
- https://metacell.atlassian.net/browse/NA-560
- https://metacell.atlassian.net/browse/NA-562
- https://metacell.atlassian.net/browse/NA-561

# CATMAID Datasource and Spatially Indexed Skeletons

This document explains how the CATMAID datasource is wired up and how spatially
indexed skeletons are loaded, serialized, and rendered.

## CATMAID datasource implementation (`src/datasource/catmaid/`)

### Entry points and registration
- `register_default.ts` registers the provider under the `catmaid` scheme. The
  URL format is expected to be `catmaid://<base_url>/<project_id>`.

### Credentials flow
- `credentials_provider.ts` defines `CatmaidCredentialsProvider`, which fetches
  an anonymous API token from `<serverUrl>/accounts/anonymous-api-token`.
- This provider is used via `fetchOkWithCredentials` in the API client to retry
  on 401/403 and request a refreshed token when needed.

### API client (`api.ts`)
`CatmaidClient` wraps all CATMAID endpoints used by the data source.

Key operations:
- `listSkeletons()` -> list of skeleton IDs
- `getSkeleton(skeletonId)` -> full skeleton as nodes from
  `skeletons/<id>/compact-detail`
- `fetchNodes(boundingBox, lod)` -> spatially indexed nodes from
  `node/list` using msgpack; supports multi-LOD data in the response
- `getDimensions()` and `getResolution()` -> stack metadata, including voxel
  size and translation
- `getGridCellSizes()` -> grid cache configurations (from custom metadata object); defaults to the hard-coded
  grid size if none is present

### Provider wiring (`frontend.ts`)
`CatmaidDataSourceProvider.get()` resolves the source, builds the coordinate
space, and creates the sub-sources:

1. **Parse URL**
   - Strips `catmaid://`.
   - Splits base URL and project id.
   - Ensures `http` prefix.

2. **Create `CatmaidClient`** and fetch metadata in parallel:
   - `dimensions`, `resolution`, `gridCellSizes`, `skeletonIds`.

3. **Coordinate space setup**
   - Converts `resolution` (nm per voxel) to meters.
   - Uses stack `translation` and `dimension` to establish voxel-space bounds.

4. **Create skeleton sources**
   - **Spatially indexed**: `CatmaidMultiscaleSpatiallyIndexedSkeletonSource`
     provides a multiscale slice-view chunk source for spatially indexed
     skeleton data.
   - **Complete**: `CatmaidSkeletonSource` loads full skeletons by ID.

5. **Create segment properties** for skeleton labels
   - Skeleton IDs are converted to `BigInt` and stored in a
     `SegmentPropertyMap`.

6. **Subsources returned**
   - `skeletons-chunked` (spatially indexed)
   - `skeletons` (full skeletons)
   - `properties` (segment labels)
   - `bounds` (data bounds)

### Multiscale grid mapping
`CatmaidMultiscaleSpatiallyIndexedSkeletonSource.getSources()`:
- Sorts CATMAID cache grid cell sizes from smallest to largest.
- For each grid size, builds a `ChunkLayout` and `SliceViewChunkSpecification`.
- Builds a `chunkToMultiscaleTransform` that scales each grid size relative to
  the smallest grid size.
- Sets `useChunkSizeForScaleSelection = true` so the backend can bias scale
  selection based on chunk sizes (rather than voxel size alone).

## Spatially indexed skeletons (`src/skeleton/`)

### Data model and chunk serialization
The spatially indexed path uses slice-view chunking but renders as a mesh-like
edge list.

Key data types:
- `SpatiallyIndexedSkeletonChunk` (frontend and backend)
  - `vertexPositions` (Float32 vec3)
  - `vertexAttributes` (packed bytes)
  - `indices` (Uint32 pairs, each edge is two vertex indices)
  - `missingConnections` (parent edges that cross chunk boundaries)
  - `nodeMap` (nodeId -> vertexIndex mapping)
- `SkeletonChunkData` serialization packs vertex positions and attributes into a
  single `Uint8Array` with `vertexAttributeOffsets` for GPU upload.

Serialization (`skeleton_chunk_serialization.ts`):
- Positions are always the first attribute.
- `vertexAttributeOffsets` describes byte offsets of each attribute.
- `missingConnections` and `nodeMap` are serialized alongside.

### Chunk download (CATMAID backend)
`CatmaidSpatiallyIndexedSkeletonSourceBackend.download()`:
- Computes a chunk-aligned bounding box from `chunkGridPosition` and
  `chunkDataSize`.
- Calls `CatmaidClient.fetchNodes(bbox, currentLod)`.
- Builds:
  - `vertexPositions`: XYZ for each node.
  - `vertexAttributes`: segment ID only (stored as float).
  - `indices`: edge pairs from parent-child relations.
  - `nodeMap`: maps CATMAID node IDs to vertex indices.

### Backend chunk scheduling and LOD
`SpatiallyIndexedSkeletonRenderLayerBackend`:
- Maintains `skeletonLod` as a shared watchable value.
- Debounces LOD changes (300 ms) to avoid invalidating the source cache on every
  slider move.
- Uses a multi-scale selection algorithm in `recomputeChunkPriorities()`:
  - Derives pixel size from slice view parameters.
  - Selects which scales to load based on:
    - `renderScaleTarget`,
    - `effectiveVoxelSize`,
    - and optionally `chunkLayout.size` if
      `useChunkSizeForScaleSelection` is enabled.
  - Requests chunks using `forEachVisibleVolumetricChunk` and applies a scale
    priority offset (`SCALE_PRIORITY_MULTIPLIER`).

### Rendering pipeline overview
Rendering is split into two paths:

1. **Regular skeleton layer** (`SkeletonLayer`)
   - Draws full skeletons (one chunk per skeleton) using the same shader stack.
   - Each chunk renders all visible segments using a single draw call per chunk.

2. **Spatially indexed skeleton layer** (`SpatiallyIndexedSkeletonLayer`)
   - Draws skeletons that are chunked spatially across the volume.
   - Supports multi-scale sources and renders each chunk per segment to ensure
     consistent color usage and visibility filtering.

### Spatially indexed draw algorithm (per chunk, per segment)
`SpatiallyIndexedSkeletonLayer.draw()` performs per-segment rendering to ensure
correct color assignment and visibility filtering:

1. **Build a global node map** across all loaded chunks to resolve inter-chunk
   parent references.

2. **For each chunk**:
   - Read the segment ID attribute from the packed attribute buffer.
   - Group edge indices by segment ID.
   - For each segment in the chunk:
     - Check visibility (`getVisibleSegments`).
     - Apply `objectAlpha` or `hiddenObjectAlpha` based on visibility.
     - Build a compacted vertex list for just that segment.
     - Remap indices to the compact list.
     - Upload compacted attribute textures.
     - Draw edges and (optionally) nodes with `uColor` set to the segment color.

3. **Per-segment caching**
   - The filtered vertex textures are cached per chunk per segment by
     `generation`, so repeated frames can reuse GPU textures.

4. **Inter-chunk edges**
   - `missingConnections` are tracked but not rendered yet.
   - There is a TODO to build combined buffers to render those edges.

## Improvements:
### 1) Per-draw global node map construction
**Detail:** `SpatiallyIndexedSkeletonLayer.draw()` rebuilds a global node map
every frame across all loaded chunks.

**Risk:** This scales with total loaded vertices and can become expensive.

### 2) Per-segment compaction and buffer swapping
**Detail:** For each segment in each chunk, the code:
- Filters vertices,
- Remaps indices,
- Builds compact textures,
- Creates a new GL buffer,
- Draws,
- Then restores the original buffers.

**Risk:** This is CPU-heavy and generates many short-lived GL buffers, which can
cause stalls and GC pressure for large skeleton sets.


### 3) Inter-chunk edges are not rendered
**Detail:** `missingConnections` are tracked, but the renderer does not draw
edges that cross chunk boundaries.

**Risk:** Skeletons that cross chunk boundaries appear disconnected.

