### PR TITLE
fix: transform points between model space and global space

### DIFF
--- a/src/layer/segmentation/index.ts
+++ b/src/layer/segmentation/index.ts
@@ -1408,8 +1408,6 @@ export class SegmentationUserLayer extends Base {
       this.getSpatiallyIndexedSkeletonLayer()?.displayState.transform.value;
     if (transform === undefined || transform.error !== undefined) return;
     const rank = transform.rank;
-    // Skeleton positions are in model space; apply modelToRenderLayerTransform
-    // to convert to render layer space before mapping to global/local positions.
     const modelPosition = new Float32Array(rank);
     for (let i = 0; i < Math.min(position.length, rank); ++i) {
       modelPosition[i] = Number(position[i]);

--- a/src/layer/segmentation/index.ts
+++ b/src/layer/segmentation/index.ts
@@ -1393,6 +1393,9 @@ export class SegmentationUserLayer extends Base {
     return new Float32Array(layerPosition);
   }
 
+  // TODO (skm) might be able to be more integrated with the setLayerPosition
+  // e.g. the base UserLayer class provides this ability and the setLayerPosition
+  // just calls it - either way, the function is good
   private mapLayerPositionToGlobalSelectionPosition(
     transform: RenderLayerTransform,
     layerPosition: ArrayLike<number>,
@@ -1407,27 +1410,25 @@ export class SegmentationUserLayer extends Base {
   }
 
   moveViewToSpatialSkeletonNodePosition(position: ArrayLike<number>) {
-    const globalPosition = this.manager.root.globalPosition;
-    const nextGlobal = globalPosition.value.slice();
-    const globalRank = Math.min(nextGlobal.length, 3);
-    for (let i = 0; i < globalRank; ++i) {
-      const value = Number(position[i]);
-      if (Number.isFinite(value)) {
-        nextGlobal[i] = value;
-      }
+    const transform =
+      this.getSpatiallyIndexedSkeletonLayer()?.displayState.transform.value;
+    if (transform === undefined || transform.error !== undefined) return;
+    const rank = transform.rank;
+    // Skeleton positions are in model space; apply modelToRenderLayerTransform
+    // to convert to render layer space before mapping to global/local positions.
+    const modelPosition = new Float32Array(rank);
+    for (let i = 0; i < Math.min(position.length, rank); ++i) {
+      modelPosition[i] = Number(position[i]);
     }
-    globalPosition.value = nextGlobal;
-
-    const localPosition = this.localPosition;
-    const nextLocal = localPosition.value.slice();
-    const localRank = Math.min(nextLocal.length, 3);
-    for (let i = 0; i < localRank; ++i) {
-      const value = Number(position[i]);
-      if (Number.isFinite(value)) {
-        nextLocal[i] = value;
-      }
-    }
-    localPosition.value = nextLocal;
+    const layerPosition = new Float32Array(rank);
+    matrix.transformPoint(
+      layerPosition,
+      transform.modelToRenderLayerTransform,
+      rank + 1,
+      modelPosition,
+      rank,
+    );
+    this.setLayerPosition(transform, layerPosition);
   }
 
   selectSpatialSkeletonNode = (

--- a/src/layer/segmentation/index.ts
+++ b/src/layer/segmentation/index.ts
@@ -60,7 +60,6 @@ import {
   MultiscaleMeshLayer,
   MultiscaleMeshSource,
 } from "#src/mesh/frontend.js";
-import type { RenderLayerTransform } from "#src/render_coordinate_transform.js";
 import {
   RenderScaleHistogram,
   numRenderScaleHistogramBins,
@@ -180,6 +179,7 @@ import { Uint64Map } from "#src/uint64_map.js";
 import { Uint64OrderedSet } from "#src/uint64_ordered_set.js";
 import { Uint64Set } from "#src/uint64_set.js";
 import { gatherUpdate } from "#src/util/array.js";
+import * as matrix from "#src/util/matrix.js";
 import {
   packColor,
   parseRGBColorSpecification,
@@ -1373,33 +1373,27 @@ export class SegmentationUserLayer extends Base {
     };
   }
 
-  private getGlobalSelectionPositionFromLayerPosition(
-    layerPosition: ArrayLike<number> | undefined,
+  private getGlobalSelectionPositionFromModelPosition(
+    modelPosition: ArrayLike<number> | undefined,
   ) {
-    if (layerPosition === undefined) return undefined;
-    const coordinateSpace =
-      this.manager.root.selectionState.coordinateSpace.value;
+    if (modelPosition === undefined) return undefined;
     const transform =
       this.getSpatiallyIndexedSkeletonLayer()?.displayState.transform.value;
-    if (transform !== undefined && transform.error === undefined) {
-      return this.mapLayerPositionToGlobalSelectionPosition(
-        transform,
-        layerPosition,
-      );
-    }
-    if (coordinateSpace.rank !== layerPosition.length) {
+    if (transform === undefined || transform.error !== undefined)
       return undefined;
+    const rank = transform.rank;
+    const paddedModelPosition = new Float32Array(rank);
+    for (let i = 0; i < Math.min(modelPosition.length, rank); ++i) {
+      paddedModelPosition[i] = Number(modelPosition[i]);
     }
-    return new Float32Array(layerPosition);
-  }
-
-  // TODO (skm) might be able to be more integrated with the setLayerPosition
-  // e.g. the base UserLayer class provides this ability and the setLayerPosition
-  // just calls it - either way, the function is good
-  private mapLayerPositionToGlobalSelectionPosition(
-    transform: RenderLayerTransform,
-    layerPosition: ArrayLike<number>,
-  ) {
+    const layerPosition = new Float32Array(rank);
+    matrix.transformPoint(
+      layerPosition,
+      transform.modelToRenderLayerTransform,
+      rank + 1,
+      paddedModelPosition,
+      rank,
+    );
     const result = this.manager.root.globalPosition.value.slice();
     gatherUpdate(
       result,
@@ -1450,7 +1444,7 @@ export class SegmentationUserLayer extends Base {
         : Math.round(Number(requestedSegmentId));
     const selectedNodePosition = options.position ?? selectedNodeInfo?.position;
     const selectedGlobalPosition =
-      this.getGlobalSelectionPositionFromLayerPosition(selectedNodePosition);
+      this.getGlobalSelectionPositionFromModelPosition(selectedNodePosition);
     this.captureSpatialSkeletonSelectionState(
       (state) => {
         const segmentId =

--- a/src/layer/segmentation/selection.ts
+++ b/src/layer/segmentation/selection.ts
@@ -179,6 +179,7 @@ export function getSpatialSkeletonNodeIdFromViewerHover<TRenderLayer>(
       return undefined;
     }
   }
+  // TODO (SKM): I think we can inline this function
   return normalizeSpatialSkeletonViewerHoverNodeId(
     mouseState.pickedSpatialSkeletonNodeId,
   );

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -70,6 +70,7 @@ import type {
   ThreeDimensionalRenderLayerAttachmentState,
 } from "#src/renderlayer.js";
 import { update3dRenderLayerAttachment } from "#src/renderlayer.js";
+import type { RenderLayerTransform } from "#src/render_coordinate_transform.js";
 import { RenderScaleHistogram } from "#src/render_scale_statistics.js";
 import { Uint64Set } from "#src/uint64_set.js";
 import {
@@ -129,9 +130,11 @@ import {
   WatchableValueInterface,
   registerNested,
 } from "#src/trackable_value.js";
+import { gatherUpdate } from "#src/util/array.js";
 import { DATA_TYPE_SIGNED, DataType } from "#src/util/data_type.js";
 import { RefCounted } from "#src/util/disposable.js";
 import { mat4 } from "#src/util/geom.js";
+import * as matrix from "#src/util/matrix.js";
 import { verifyFinitePositiveFloat } from "#src/util/json.js";
 import { getObjectId } from "#src/util/object_id.js";
 import { NullarySignal } from "#src/util/signal.js";
@@ -1004,31 +1007,36 @@ function getSkeletonNodeDiameter(
   return lineWidth;
 }
 
-function snapMouseStateToSpatialSkeletonNode(
+function setMouseStatePositionFromSpatialSkeletonNode(
   mouseState: MouseSelectionState,
-  nodePositions: Float32Array,
-  pickedOffset: number,
+  nodePosition: Float32Array,
+  transform: RenderLayerTransform,
 ) {
-  const sourceOffset = pickedOffset * 3;
-  if (sourceOffset + 2 >= nodePositions.length) {
-    return;
-  }
-  const x = nodePositions[sourceOffset];
-  const y = nodePositions[sourceOffset + 1];
-  const z = nodePositions[sourceOffset + 2];
+  if (nodePosition.length < 3) return;
+  const x = nodePosition[0];
+  const y = nodePosition[1];
+  const z = nodePosition[2];
   if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
     return;
   }
-  const { position } = mouseState;
-  if (position.length > 0) {
-    position[0] = x;
-  }
-  if (position.length > 1) {
-    position[1] = y;
-  }
-  if (position.length > 2) {
-    position[2] = z;
-  }
+  const rank = transform.rank;
+  const modelPosition = new Float32Array(rank);
+  modelPosition[0] = x;
+  if (rank > 1) modelPosition[1] = y;
+  if (rank > 2) modelPosition[2] = z;
+  const layerPosition = new Float32Array(rank);
+  matrix.transformPoint(
+    layerPosition,
+    transform.modelToRenderLayerTransform,
+    rank + 1,
+    modelPosition,
+    rank,
+  );
+  gatherUpdate(
+    mouseState.position,
+    layerPosition,
+    transform.globalToRenderLayerDimensions
+  );
 }
 
 export interface ViewSpecificSkeletonRenderingOptions {
@@ -3514,11 +3522,14 @@ export class PerspectiveViewSpatiallyIndexedSkeletonLayer extends PerspectiveVie
       const nodeId = pickData.nodeIds[pickedOffset];
       if (!Number.isSafeInteger(nodeId) || nodeId <= 0) return;
       mouseState.pickedSpatialSkeletonNodeId = nodeId;
-      snapMouseStateToSpatialSkeletonNode(
-        mouseState,
-        pickData.nodePositions,
-        pickedOffset,
+      const nodePosition = pickData.nodePositions.subarray(
+        pickedOffset * 3,
+        pickedOffset * 3 + 3,
       );
+      const transform = this.base.displayState.transform.value;
+      if (transform.error === undefined) {
+        setMouseStatePositionFromSpatialSkeletonNode(mouseState, nodePosition, transform);
+      }
       return;
     }
     if (pickData.kind === "edge") {
@@ -3816,11 +3827,14 @@ export class SliceViewPanelSpatiallyIndexedSkeletonLayer extends SliceViewPanelR
       const nodeId = pickData.nodeIds[pickedOffset];
       if (!Number.isSafeInteger(nodeId) || nodeId <= 0) return;
       mouseState.pickedSpatialSkeletonNodeId = nodeId;
-      snapMouseStateToSpatialSkeletonNode(
-        mouseState,
-        pickData.nodePositions,
-        pickedOffset,
+      const nodePosition = pickData.nodePositions.subarray(
+        pickedOffset * 3,
+        pickedOffset * 3 + 3,
       );
+      const transform = this.base.displayState.transform.value;
+      if (transform.error === undefined) {
+        setMouseStatePositionFromSpatialSkeletonNode(mouseState, nodePosition, transform);
+      }
       return;
     }
     if (pickData.kind === "edge") {

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -70,7 +70,11 @@ import type {
   ThreeDimensionalRenderLayerAttachmentState,
 } from "#src/renderlayer.js";
 import { update3dRenderLayerAttachment } from "#src/renderlayer.js";
-import type { RenderLayerTransform } from "#src/render_coordinate_transform.js";
+import type {
+  ChunkTransformParameters,
+  RenderLayerTransform,
+} from "#src/render_coordinate_transform.js";
+import { getChunkTransformParameters } from "#src/render_coordinate_transform.js";
 import { RenderScaleHistogram } from "#src/render_scale_statistics.js";
 import { Uint64Set } from "#src/uint64_set.js";
 import {
@@ -125,11 +129,14 @@ import {
 } from "#src/sliceview/base.js";
 import { ChunkLayout } from "#src/sliceview/chunk_layout.js";
 import {
+  makeCachedLazyDerivedWatchableValue,
   TrackableValue,
   WatchableValue,
   WatchableValueInterface,
   registerNested,
 } from "#src/trackable_value.js";
+import type { ValueOrError } from "#src/util/error.js";
+import { makeValueOrError, valueOrThrow } from "#src/util/error.js";
 import { gatherUpdate } from "#src/util/array.js";
 import { DATA_TYPE_SIGNED, DataType } from "#src/util/data_type.js";
 import { RefCounted } from "#src/util/disposable.js";
@@ -2089,6 +2096,9 @@ export class SpatiallyIndexedSkeletonLayer
   );
   backend: ChunkRenderLayerFrontend;
   localPosition: WatchableValueInterface<Float32Array>;
+  readonly chunkTransform: WatchableValueInterface<
+    ValueOrError<ChunkTransformParameters>
+  >;
   rpc: RPC | undefined;
 
   private overlayAttributeTextureFormats = [
@@ -2492,6 +2502,15 @@ export class SpatiallyIndexedSkeletonLayer
     this.sources2d = sources2d;
     this.source = sources3d[0].chunkSource;
     this.localPosition = displayState.localPosition;
+    this.chunkTransform = this.registerDisposer(
+      makeCachedLazyDerivedWatchableValue(
+        (modelTransform) =>
+          makeValueOrError(() =>
+            getChunkTransformParameters(valueOrThrow(modelTransform)),
+          ),
+        this.displayState.transform,
+      ),
+    );
     this.gridLevel =
       options.gridLevel ??
       (displayState as any).spatialSkeletonGridLevel3d ??

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -1012,18 +1012,13 @@ function setMouseStatePositionFromSpatialSkeletonNode(
   nodePosition: Float32Array,
   transform: RenderLayerTransform,
 ) {
-  if (nodePosition.length < 3) return;
-  const x = nodePosition[0];
-  const y = nodePosition[1];
-  const z = nodePosition[2];
-  if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
-    return;
-  }
   const rank = transform.rank;
   const modelPosition = new Float32Array(rank);
-  modelPosition[0] = x;
-  if (rank > 1) modelPosition[1] = y;
-  if (rank > 2) modelPosition[2] = z;
+  for (let i = 0; i < Math.min(nodePosition.length, rank); ++i) {
+    const v = nodePosition[i];
+    if (!Number.isFinite(v)) return;
+    modelPosition[i] = v;
+  }
   const layerPosition = new Float32Array(rank);
   matrix.transformPoint(
     layerPosition,

--- a/src/ui/spatial_skeleton_edit_tab.ts
+++ b/src/ui/spatial_skeleton_edit_tab.ts
@@ -360,27 +360,7 @@ export class SpatialSkeletonEditTab extends Tab {
     };
 
     const moveViewToNodePosition = (position: ArrayLike<number>) => {
-      const globalPosition = layer.manager.root.globalPosition;
-      const nextGlobal = globalPosition.value.slice();
-      const globalRank = Math.min(nextGlobal.length, 3);
-      for (let i = 0; i < globalRank; ++i) {
-        const value = Number(position[i]);
-        if (Number.isFinite(value)) {
-          nextGlobal[i] = value;
-        }
-      }
-      globalPosition.value = nextGlobal;
-
-      const localPosition = layer.localPosition;
-      const nextLocal = localPosition.value.slice();
-      const localRank = Math.min(nextLocal.length, 3);
-      for (let i = 0; i < localRank; ++i) {
-        const value = Number(position[i]);
-        if (Number.isFinite(value)) {
-          nextLocal[i] = value;
-        }
-      }
-      localPosition.value = nextLocal;
+      layer.moveViewToSpatialSkeletonNodePosition(position);
     };
 
     const getNavigationNode = (nodeId: number) => {

--- a/src/ui/spatial_skeleton_edit_tool.ts
+++ b/src/ui/spatial_skeleton_edit_tool.ts
@@ -117,13 +117,13 @@ const SPATIAL_SKELETON_PICK_AUX_INPUT_EVENT_MAP = EventActionMap.fromObject({
 });
 
 const DRAG_START_DISTANCE_PX = 4;
-const SPATIAL_SKELETON_EDIT_DEBUG_LOGS = true;
+const DEBUG_SKELETON_EDIT = true;
 
 function logSpatialSkeletonEdit(
   label: string,
   data: Record<string, unknown> = {},
 ) {
-  if (!SPATIAL_SKELETON_EDIT_DEBUG_LOGS) return;
+  if (!DEBUG_SKELETON_EDIT) return;
   console.debug(`[SpatialSkeletonEdit] ${label}`, data);
 }
 

--- a/src/ui/spatial_skeleton_edit_tool.ts
+++ b/src/ui/spatial_skeleton_edit_tool.ts
@@ -65,7 +65,7 @@ import { getChunkPositionFromCombinedGlobalLocalPositions } from "#src/render_co
 import type { ActionEvent } from "#src/util/event_action_map.js";
 import { EventActionMap } from "#src/util/event_action_map.js";
 import { removeChildren } from "#src/util/dom.js";
-import type { vec3 } from "#src/util/geom.js";
+import { vec3 } from "#src/util/geom.js";
 import { startRelativeMouseDrag } from "#src/util/mouse_drag.js";
 
 export const SPATIAL_SKELETON_EDIT_MODE_TOOL_ID = "spatialSkeletonEditMode";
@@ -319,9 +319,9 @@ abstract class SpatialSkeletonToolBase extends LayerTool<SegmentationUserLayer> 
       const anchorSegmentId =
         mergeAnchorNodeId === undefined
           ? undefined
-          : skeletonLayer?.getNode(mergeAnchorNodeId)?.segmentId ??
+          : (skeletonLayer?.getNode(mergeAnchorNodeId)?.segmentId ??
             this.layer.spatialSkeletonState.getCachedNode(mergeAnchorNodeId)
-              ?.segmentId;
+              ?.segmentId);
       if (anchorSegmentId === pickedSegmentId) {
         this.layer.clearSpatialSkeletonMergeAnchor();
       }
@@ -395,8 +395,7 @@ abstract class SpatialSkeletonToolBase extends LayerTool<SegmentationUserLayer> 
     if (nodeHit === undefined) {
       return undefined;
     }
-    const resolvedNodeInfo =
-      skeletonLayer.getNode(nodeHit.nodeId);
+    const resolvedNodeInfo = skeletonLayer.getNode(nodeHit.nodeId);
     return {
       nodeId: nodeHit.nodeId,
       segmentId: nodeHit.segmentId ?? resolvedNodeInfo?.segmentId,
@@ -657,6 +656,9 @@ export class SpatialSkeletonEditModeTool extends SpatialSkeletonToolBase {
 
   private curChunkRank = -1;
   private tempChunkPosition = new Float32Array(0);
+  private readonly dragModelSpacePosition = vec3.create();
+  private readonly dragGlobalAnchorPosition = vec3.create();
+  private readonly dragGlobalPosition = vec3.create();
 
   private handleRankChanged(rank: number) {
     if (rank === this.curChunkRank) return;
@@ -664,19 +666,17 @@ export class SpatialSkeletonEditModeTool extends SpatialSkeletonToolBase {
     this.tempChunkPosition = new Float32Array(rank);
   }
 
-  private getMousePositionInSkeletonCoordinates(
+  private globalToSkeletonCoordinates(
+    globalPosition: Float32Array,
     skeletonLayer: SpatiallyIndexedSkeletonLayer,
   ): Float32Array | undefined {
-    if (!this.mouseState.updateUnconditionally() || !this.mouseState.active) {
-      return undefined;
-    }
     const chunkTransform = skeletonLayer.chunkTransform.value;
     if (chunkTransform.error !== undefined) return undefined;
     this.handleRankChanged(chunkTransform.modelTransform.unpaddedRank);
     if (
       !getChunkPositionFromCombinedGlobalLocalPositions(
         this.tempChunkPosition,
-        this.mouseState.unsnappedPosition,
+        globalPosition,
         skeletonLayer.localPosition.value,
         chunkTransform.layerRank,
         chunkTransform.combinedGlobalLocalToChunkTransform,
@@ -685,6 +685,18 @@ export class SpatialSkeletonEditModeTool extends SpatialSkeletonToolBase {
       return undefined;
     }
     return this.tempChunkPosition;
+  }
+
+  private getMousePositionInSkeletonCoordinates(
+    skeletonLayer: SpatiallyIndexedSkeletonLayer,
+  ): Float32Array | undefined {
+    if (!this.mouseState.updateUnconditionally() || !this.mouseState.active) {
+      return undefined;
+    }
+    return this.globalToSkeletonCoordinates(
+      this.mouseState.unsnappedPosition,
+      skeletonLayer,
+    );
   }
 
   private getSelectedParentNodeForAdd(
@@ -1152,7 +1164,8 @@ export class SpatialSkeletonEditModeTool extends SpatialSkeletonToolBase {
             return;
           }
         }
-        const clickStartPosition = this.getMousePositionInSkeletonCoordinates(skeletonLayer);
+        const clickStartPosition =
+          this.getMousePositionInSkeletonCoordinates(skeletonLayer);
         if (clickStartPosition === undefined) {
           StatusMessage.showTemporaryMessage(
             "Unable to resolve add-node position for this click.",
@@ -1310,17 +1323,13 @@ export class SpatialSkeletonEditModeTool extends SpatialSkeletonToolBase {
           Number.isFinite(pickedPosition[0]) &&
           Number.isFinite(pickedPosition[1]) &&
           Number.isFinite(pickedPosition[2]);
-        const nodeInfo = hasPickedPosition
-          ? {
-              nodeId: pickedNode.nodeId,
-              segmentId: pickedNode.segmentId ?? 0,
-              position: new Float32Array([
-                Number(pickedPosition[0]),
-                Number(pickedPosition[1]),
-                Number(pickedPosition[2]),
-              ]),
-            }
-          : skeletonLayer.getNode(pickedNode.nodeId);
+        if (!hasPickedPosition) {
+          debugLog("drag-node-no-global-position", {
+            nodeId: pickedNode.nodeId,
+          });
+          return;
+        }
+        const nodeInfo = skeletonLayer.getNode(pickedNode.nodeId);
         if (nodeInfo === undefined) {
           debugLog("drag-node-not-found", {
             nodeId: pickedNode.nodeId,
@@ -1338,15 +1347,13 @@ export class SpatialSkeletonEditModeTool extends SpatialSkeletonToolBase {
         setDebug("hitPos", formatVec3(nodeInfo.position));
         setDebug("dragPanel", dragPanel.constructor?.name ?? "none");
         let moved = false;
-        const lastPosition = new Float32Array(
-          nodeInfo.position,
-        ) as unknown as vec3;
-        const dragAnchorPosition = new Float32Array(
-          nodeInfo.position,
-        ) as unknown as vec3;
-        const panelTranslatedPosition = new Float32Array(
-          nodeInfo.position,
-        ) as unknown as vec3;
+        this.dragModelSpacePosition.set(nodeInfo.position);
+        vec3.set(
+          this.dragGlobalAnchorPosition,
+          Number(pickedPosition[0]),
+          Number(pickedPosition[1]),
+          Number(pickedPosition[2]),
+        );
         let moveEvents = 0;
         let totalDeltaX = 0;
         let totalDeltaY = 0;
@@ -1368,35 +1375,36 @@ export class SpatialSkeletonEditModeTool extends SpatialSkeletonToolBase {
             ++moveEvents;
             totalDeltaX += deltaX;
             totalDeltaY += deltaY;
-            panelTranslatedPosition[0] = dragAnchorPosition[0];
-            panelTranslatedPosition[1] = dragAnchorPosition[1];
-            panelTranslatedPosition[2] = dragAnchorPosition[2];
+            vec3.copy(this.dragGlobalPosition, this.dragGlobalAnchorPosition);
             dragPanel.translateDataPointByViewportPixels(
-              panelTranslatedPosition,
-              dragAnchorPosition,
+              this.dragGlobalPosition,
+              this.dragGlobalAnchorPosition,
               totalDeltaX,
               totalDeltaY,
             );
             if (
-              !Number.isFinite(panelTranslatedPosition[0]) ||
-              !Number.isFinite(panelTranslatedPosition[1]) ||
-              !Number.isFinite(panelTranslatedPosition[2])
+              !Number.isFinite(this.dragGlobalPosition[0]) ||
+              !Number.isFinite(this.dragGlobalPosition[1]) ||
+              !Number.isFinite(this.dragGlobalPosition[2])
             ) {
               return;
             }
+            const modelPosition = this.globalToSkeletonCoordinates(
+              this.dragGlobalPosition,
+              skeletonLayer,
+            );
+            if (modelPosition === undefined) return;
             const previewChanged =
               layer.spatialSkeletonState.setPendingNodePosition(
                 pickedNode.nodeId,
-                panelTranslatedPosition,
+                modelPosition,
               );
             if (!previewChanged) return;
             moved = true;
-            lastPosition[0] = panelTranslatedPosition[0];
-            lastPosition[1] = panelTranslatedPosition[1];
-            lastPosition[2] = panelTranslatedPosition[2];
+            this.dragModelSpacePosition.set(modelPosition);
             setDebug("draggingNode", String(pickedNode.nodeId));
             setDebug("dragMoves", String(moveEvents));
-            setDebug("lastAppliedPos", formatVec3(lastPosition));
+            setDebug("lastAppliedPos", formatVec3(this.dragModelSpacePosition));
           },
           (_finishEvent) => {
             if (!dragActive) {
@@ -1411,13 +1419,13 @@ export class SpatialSkeletonEditModeTool extends SpatialSkeletonToolBase {
               nodeId: pickedNode.nodeId,
               moved,
               moveEvents,
-              finalPosition: formatVec3(lastPosition),
+              finalPosition: formatVec3(this.dragModelSpacePosition),
             });
             if (moved) {
               void this.commitMoveNode(
                 skeletonLayer,
                 pickedNode.nodeId,
-                lastPosition,
+                this.dragModelSpacePosition,
               )
                 .then(() => {
                   layer.spatialSkeletonState.clearPendingNodePosition(
@@ -1434,7 +1442,7 @@ export class SpatialSkeletonEditModeTool extends SpatialSkeletonToolBase {
                   debugLog("move-node-commit-failed", {
                     nodeId: pickedNode.nodeId,
                     error: String(error),
-                    position: formatVec3(lastPosition),
+                    position: formatVec3(this.dragModelSpacePosition),
                   });
                 });
               return;

--- a/src/ui/spatial_skeleton_edit_tool.ts
+++ b/src/ui/spatial_skeleton_edit_tool.ts
@@ -660,6 +660,13 @@ export class SpatialSkeletonEditModeTool extends SpatialSkeletonToolBase {
   private readonly dragGlobalAnchorPosition = vec3.create();
   private readonly dragGlobalPosition = vec3.create();
 
+  // TODO (skm): really we can't handle a rank change right now
+  // and heavily assume rank 3. This is likely mostly fine
+  // but need to test a little more how it works if embedded in
+  // higher dim spaces or alongside images with a t dim / channel dim
+  // can also possibly remove this and just set tempChunkPosition 
+  // to be vec3 instead of Float32Array
+  // will verify and clean up
   private handleRankChanged(rank: number) {
     if (rank === this.curChunkRank) return;
     this.curChunkRank = rank;

--- a/src/ui/spatial_skeleton_edit_tool.ts
+++ b/src/ui/spatial_skeleton_edit_tool.ts
@@ -1209,7 +1209,8 @@ export class SpatialSkeletonEditModeTool extends SpatialSkeletonToolBase {
                 ? 0
                 : selectedParentNode.segmentId;
             const clickPosition =
-              this.getMousePositionInSkeletonCoordinates(skeletonLayer) ?? new Float32Array(clickStartPosition);
+              this.getMousePositionInSkeletonCoordinates(skeletonLayer);
+            if (clickPosition === undefined) return;
             debugLog("ctrl-add-attempt", {
               selectedParentNodeId,
               selectedParentSegmentId: selectedParentNode?.segmentId,

--- a/src/ui/spatial_skeleton_edit_tool.ts
+++ b/src/ui/spatial_skeleton_edit_tool.ts
@@ -117,13 +117,13 @@ const SPATIAL_SKELETON_PICK_AUX_INPUT_EVENT_MAP = EventActionMap.fromObject({
 });
 
 const DRAG_START_DISTANCE_PX = 4;
-const DEBUG_SPATIAL_SKELETON_EDIT = true;
+const SPATIAL_SKELETON_EDIT_DEBUG_LOGS = true;
 
 function logSpatialSkeletonEdit(
   label: string,
   data: Record<string, unknown> = {},
 ) {
-  if (!DEBUG_SPATIAL_SKELETON_EDIT) return;
+  if (!SPATIAL_SKELETON_EDIT_DEBUG_LOGS) return;
   console.debug(`[SpatialSkeletonEdit] ${label}`, data);
 }
 
@@ -365,30 +365,6 @@ abstract class SpatialSkeletonToolBase extends LayerTool<SegmentationUserLayer> 
         this.togglePickedSpatialSkeletonVisibility();
       },
     );
-  }
-
-  protected moveViewToNodePosition(position: ArrayLike<number>) {
-    const globalPosition = this.layer.manager.root.globalPosition;
-    const nextGlobal = globalPosition.value.slice();
-    const globalRank = Math.min(nextGlobal.length, 3);
-    for (let i = 0; i < globalRank; ++i) {
-      const value = Number(position[i]);
-      if (Number.isFinite(value)) {
-        nextGlobal[i] = value;
-      }
-    }
-    globalPosition.value = nextGlobal;
-
-    const localPosition = this.layer.localPosition;
-    const nextLocal = localPosition.value.slice();
-    const localRank = Math.min(nextLocal.length, 3);
-    for (let i = 0; i < localRank; ++i) {
-      const value = Number(position[i]);
-      if (Number.isFinite(value)) {
-        nextLocal[i] = value;
-      }
-    }
-    localPosition.value = nextLocal;
   }
 
   protected resolvePickedNodeForAction(
@@ -883,7 +859,7 @@ export class SpatialSkeletonEditModeTool extends SpatialSkeletonToolBase {
         position: newNode.position,
       },
     );
-    this.moveViewToNodePosition(newNode.position);
+    this.layer.moveViewToSpatialSkeletonNodePosition(newNode.position);
     // Match move-node semantics: update the overlay/cache immediately and let
     // browse chunks reconcile later through explicit invalidation paths.
     if (parentNodeId !== undefined) {

--- a/src/ui/spatial_skeleton_edit_tool.ts
+++ b/src/ui/spatial_skeleton_edit_tool.ts
@@ -117,13 +117,13 @@ const SPATIAL_SKELETON_PICK_AUX_INPUT_EVENT_MAP = EventActionMap.fromObject({
 });
 
 const DRAG_START_DISTANCE_PX = 4;
-const SPATIAL_SKELETON_EDIT_DEBUG_LOGS = true;
+const DEBUG_SPATIAL_SKELETON_EDIT = true;
 
 function logSpatialSkeletonEdit(
   label: string,
   data: Record<string, unknown> = {},
 ) {
-  if (!SPATIAL_SKELETON_EDIT_DEBUG_LOGS) return;
+  if (!DEBUG_SPATIAL_SKELETON_EDIT) return;
   console.debug(`[SpatialSkeletonEdit] ${label}`, data);
 }
 

--- a/src/ui/spatial_skeleton_edit_tool.ts
+++ b/src/ui/spatial_skeleton_edit_tool.ts
@@ -61,6 +61,7 @@ import {
   getSpatialSkeletonMergeBannerMessage,
   getSpatialSkeletonToolPointStatusFields,
 } from "#src/ui/spatial_skeleton_tool_messages.js";
+import { getChunkPositionFromCombinedGlobalLocalPositions } from "#src/render_coordinate_transform.js";
 import type { ActionEvent } from "#src/util/event_action_map.js";
 import { EventActionMap } from "#src/util/event_action_map.js";
 import { removeChildren } from "#src/util/dom.js";
@@ -654,19 +655,29 @@ export class SpatialSkeletonEditModeTool extends SpatialSkeletonToolBase {
     return "skeleton edit mode";
   }
 
-  private getMousePosition() {
+  private getMousePositionInSkeletonCoordinates(
+    skeletonLayer: SpatiallyIndexedSkeletonLayer,
+  ): Float32Array | undefined {
     if (!this.mouseState.updateUnconditionally() || !this.mouseState.active) {
       return undefined;
     }
-    const pos = this.mouseState.unsnappedPosition;
-    if (pos.length < 3) return undefined;
-    const x = Number(pos[0]);
-    const y = Number(pos[1]);
-    const z = Number(pos[2]);
-    if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
+    const chunkTransform = skeletonLayer.chunkTransform.value;
+    if (chunkTransform.error !== undefined) return undefined;
+    const chunkPosition = new Float32Array(
+      chunkTransform.modelTransform.unpaddedRank,
+    );
+    if (
+      !getChunkPositionFromCombinedGlobalLocalPositions(
+        chunkPosition,
+        this.mouseState.unsnappedPosition,
+        skeletonLayer.localPosition.value,
+        chunkTransform.layerRank,
+        chunkTransform.combinedGlobalLocalToChunkTransform,
+      )
+    ) {
       return undefined;
     }
-    return new Float32Array([x, y, z]);
+    return chunkPosition;
   }
 
   private getSelectedParentNodeForAdd(
@@ -1134,7 +1145,7 @@ export class SpatialSkeletonEditModeTool extends SpatialSkeletonToolBase {
             return;
           }
         }
-        const clickStartPosition = this.getMousePosition();
+        const clickStartPosition = this.getMousePositionInSkeletonCoordinates(skeletonLayer);
         if (clickStartPosition === undefined) {
           StatusMessage.showTemporaryMessage(
             "Unable to resolve add-node position for this click.",
@@ -1156,6 +1167,8 @@ export class SpatialSkeletonEditModeTool extends SpatialSkeletonToolBase {
           (_finishEvent) => {
             const thresholdSquared =
               DRAG_START_DISTANCE_PX * DRAG_START_DISTANCE_PX;
+            // Block adding nodes if the mouse release position
+            // is too far from the click position
             if (dragDistanceSquared > thresholdSquared) {
               setReadyStatus();
               setDebug("dragState", "ignored-ctrl-drag");
@@ -1189,7 +1202,7 @@ export class SpatialSkeletonEditModeTool extends SpatialSkeletonToolBase {
                 ? 0
                 : selectedParentNode.segmentId;
             const clickPosition =
-              this.getMousePosition() ?? new Float32Array(clickStartPosition);
+              this.getMousePositionInSkeletonCoordinates(skeletonLayer) ?? new Float32Array(clickStartPosition);
             debugLog("ctrl-add-attempt", {
               selectedParentNodeId,
               selectedParentSegmentId: selectedParentNode?.segmentId,

--- a/src/ui/spatial_skeleton_edit_tool.ts
+++ b/src/ui/spatial_skeleton_edit_tool.ts
@@ -1221,14 +1221,14 @@ export class SpatialSkeletonEditModeTool extends SpatialSkeletonToolBase {
               selectedParentNode === undefined
                 ? 0
                 : selectedParentNode.segmentId;
-            const clickPosition =
+            const clickPositionInModelSpace =
               this.getMousePositionInSkeletonCoordinates(skeletonLayer);
-            if (clickPosition === undefined) return;
+            if (clickPositionInModelSpace === undefined) return;
             debugLog("ctrl-add-attempt", {
               selectedParentNodeId,
               selectedParentSegmentId: selectedParentNode?.segmentId,
               targetSkeletonId,
-              clickPosition: formatVec3(clickPosition),
+              clickPosition: formatVec3(clickPositionInModelSpace),
             });
             void (async () => {
               let committedNode: SpatiallyIndexedSkeletonAddNodeResult;
@@ -1237,7 +1237,7 @@ export class SpatialSkeletonEditModeTool extends SpatialSkeletonToolBase {
                   skeletonLayer,
                   targetSkeletonId,
                   selectedParentNodeId,
-                  clickPosition,
+                  clickPositionInModelSpace,
                 );
               } catch (error) {
                 StatusMessage.showTemporaryMessage(
@@ -1250,7 +1250,7 @@ export class SpatialSkeletonEditModeTool extends SpatialSkeletonToolBase {
                 debugLog("add-node-commit-failed", {
                   ...errorInfo,
                   parentNodeId: selectedParentNodeId,
-                  clickPosition: formatVec3(clickPosition),
+                  clickPosition: formatVec3(clickPositionInModelSpace),
                 });
                 return;
               }
@@ -1258,13 +1258,13 @@ export class SpatialSkeletonEditModeTool extends SpatialSkeletonToolBase {
                 skeletonLayer,
                 committedNode,
                 selectedParentNodeId,
-                clickPosition,
+                clickPositionInModelSpace,
               );
               debugLog("add-node-committed", {
                 nodeId: committedNode.treenodeId,
                 segmentId: committedNode.skeletonId,
                 parentNodeId: selectedParentNodeId,
-                position: formatVec3(clickPosition),
+                position: formatVec3(clickPositionInModelSpace),
               });
               setReadyStatus();
             })();

--- a/src/ui/spatial_skeleton_edit_tool.ts
+++ b/src/ui/spatial_skeleton_edit_tool.ts
@@ -655,6 +655,15 @@ export class SpatialSkeletonEditModeTool extends SpatialSkeletonToolBase {
     return "skeleton edit mode";
   }
 
+  private curChunkRank = -1;
+  private tempChunkPosition = new Float32Array(0);
+
+  private handleRankChanged(rank: number) {
+    if (rank === this.curChunkRank) return;
+    this.curChunkRank = rank;
+    this.tempChunkPosition = new Float32Array(rank);
+  }
+
   private getMousePositionInSkeletonCoordinates(
     skeletonLayer: SpatiallyIndexedSkeletonLayer,
   ): Float32Array | undefined {
@@ -663,12 +672,10 @@ export class SpatialSkeletonEditModeTool extends SpatialSkeletonToolBase {
     }
     const chunkTransform = skeletonLayer.chunkTransform.value;
     if (chunkTransform.error !== undefined) return undefined;
-    const chunkPosition = new Float32Array(
-      chunkTransform.modelTransform.unpaddedRank,
-    );
+    this.handleRankChanged(chunkTransform.modelTransform.unpaddedRank);
     if (
       !getChunkPositionFromCombinedGlobalLocalPositions(
-        chunkPosition,
+        this.tempChunkPosition,
         this.mouseState.unsnappedPosition,
         skeletonLayer.localPosition.value,
         chunkTransform.layerRank,
@@ -677,7 +684,7 @@ export class SpatialSkeletonEditModeTool extends SpatialSkeletonToolBase {
     ) {
       return undefined;
     }
-    return chunkPosition;
+    return this.tempChunkPosition;
   }
 
   private getSelectedParentNodeForAdd(

--- a/src/ui/spatial_skeleton_edit_tool.ts
+++ b/src/ui/spatial_skeleton_edit_tool.ts
@@ -1382,7 +1382,6 @@ export class SpatialSkeletonEditModeTool extends SpatialSkeletonToolBase {
             ++moveEvents;
             totalDeltaX += deltaX;
             totalDeltaY += deltaY;
-            vec3.copy(this.dragGlobalPosition, this.dragGlobalAnchorPosition);
             dragPanel.translateDataPointByViewportPixels(
               this.dragGlobalPosition,
               this.dragGlobalAnchorPosition,


### PR DESCRIPTION
Was missing a number of transforms between model space and global space. These included on:
* Adding a node
* Moving a node
* Setting the mouse state position
* Moving to a node on pick
* Moving to a node from the skeleton tab

This meant that if the viewer global dims were not 1nm, or the skeleton source dims were not 1nm (or both), the behavior was incorrect on the above operations. This sets up handling for what is in model space or not. We may also find at some point that some items could stay in model space, or global space, to reduce number of transforms back and forth but for now my guess is that this is sufficient.

Also starting to improve some small efficiency pieces. Neuroglancer usually tries to cache arrays and vectors as in a rapid operation like a mouse move, or an operation like drawing every frame, these start to stack up. A similar thing happens for map accesses. As we see them we can likely improve this.
Related to this, cache some transform information to avoid redoing calculations. Again a pattern in place where possible.

See also NA-645