### PR TITLE
Fix: Inputting a non-existent ID and then going to skeleton tab fills screen with errors

### DIFF
--- a/src/datasource/catmaid/api.ts
+++ b/src/datasource/catmaid/api.ts
@@ -73,6 +73,13 @@ export interface CatmaidSplitSkeletonResult {
   newSkeletonId: number | undefined;
 }
 
+export class CatmaidNotFoundError extends Error {
+  constructor(detail?: string) {
+    super(detail ?? "CATMAID resource not found.");
+    this.name = "CatmaidNotFoundError";
+  }
+}
+
 export class CatmaidStateValidationError extends Error {
   constructor(detail?: string) {
     super(
@@ -128,6 +135,15 @@ function getCatmaidErrorMessage(payload: unknown): string | undefined {
   }
   const value = payload as { error?: unknown };
   return typeof value.error === "string" ? value.error.trim() : undefined;
+}
+
+function isCatmaidNotFoundPayload(payload: unknown): boolean {
+  if (payload === null || typeof payload !== "object" || Array.isArray(payload))
+    return false;
+  const value = payload as { detail?: unknown };
+  return (
+    typeof value.detail === "string" && value.detail.includes("doesn't exist")
+  );
 }
 
 function isCatmaidStateMatchingErrorPayload(payload: unknown): boolean {
@@ -762,6 +778,10 @@ export class CatmaidClient implements EditableSpatiallyIndexedSkeletonSource {
     if (isCatmaidStateMatchingErrorPayload(payload)) {
       return new CatmaidStateValidationError(getCatmaidErrorMessage(payload));
     }
+    if (error.status === 404 && isCatmaidNotFoundPayload(payload)) {
+      const detail = (payload as { detail: string }).detail;
+      return new CatmaidNotFoundError(detail);
+    }
     return error;
   }
 
@@ -943,10 +963,19 @@ export class CatmaidClient implements EditableSpatiallyIndexedSkeletonSource {
     skeletonId: number,
     options: { signal?: AbortSignal } = {},
   ): Promise<SpatiallyIndexedSkeletonNode[]> {
-    const data = await this.fetch(
-      `skeletons/${skeletonId}/compact-detail?with_tags=true&with_history=true`,
-      { signal: options.signal },
-    );
+    let data: any;
+    try {
+      data = await this.fetch(
+        `skeletons/${skeletonId}/compact-detail?with_tags=true&with_history=true`,
+        { signal: options.signal },
+      );
+    } catch (error) {
+      if (error instanceof CatmaidNotFoundError) {
+        return [];
+      } else {
+        throw error;
+      }
+    }
     const rawNodes = Array.isArray(data?.[0]) ? data[0] : [];
     const labelsByNodeId = parseCatmaidNodeLabels(data?.[2]);
     const liveNodes = new Map<number, any[]>();

--- a/src/skeleton/state.spec.ts
+++ b/src/skeleton/state.spec.ts
@@ -614,4 +614,25 @@ describe("skeleton/state", () => {
     expect(getSkeletonRootNode(graph).nodeId).toBe(3);
     expect(getFlatListNodeIds(graph)).toEqual([3, 2, 4, 1, 5]);
   });
+
+  it("stores empty segments in the cache if nothing present for that segment in cache", () => {
+    const state = new SpatialSkeletonState();
+    (state as any).replaceCachedSegmentNodes(1, []);
+    expect(state.getCachedSegmentNodes(1)?.length).toBe(0);
+  });
+
+  it("deletes segment from cache if the segment becomes empty", () => {
+    const state = new SpatialSkeletonState();
+    const node = {
+      nodeId: 1,
+      segmentId: 1,
+      position: new Float32Array([1, 1, 1]),
+    };
+    (state as any).replaceCachedSegmentNodes(1, [node]);
+    expect(state.getCachedSegmentNodes(1)).toStrictEqual([node]);
+    expect(state.getCachedNode(1)).toBe(node);
+    (state as any).replaceCachedSegmentNodes(1, []);
+    expect(state.getCachedSegmentNodes(1)).toBeUndefined();
+    expect(state.getCachedNode(1)).toBeUndefined();
+  });
 });

--- a/src/skeleton/state.ts
+++ b/src/skeleton/state.ts
@@ -934,7 +934,14 @@ export class SpatialSkeletonState extends RefCounted {
         this.pendingFullSegmentNodeFetches.get(segmentId)?.promise ===
           pendingFetch.promise
       ) {
-        this.replaceCachedSegmentNodes(segmentId, normalizedNodes);
+        if (normalizedNodes.length > 0) {
+          this.replaceCachedSegmentNodes(segmentId, normalizedNodes);
+        } else {
+          // Explicitly cache the empty result so that non-existent skeletons
+          // don't trigger repeated fetches. replaceCachedSegmentNodes treats
+          // an empty array as a delete, so we write directly here.
+          this.fullSegmentNodeCache.set(segmentId, []);
+        }
         this.markNodeDataChanged({ invalidateFullSkeletonCache: false });
       }
       return normalizedNodes;

--- a/src/skeleton/state.ts
+++ b/src/skeleton/state.ts
@@ -486,9 +486,12 @@ export class SpatialSkeletonState extends RefCounted {
     }
     if (nextSegmentNodes.length === 0) {
       if (previousSegmentNodes === undefined) {
-        return false;
+        // No previous entry, assume this is an empty segment
+        this.fullSegmentNodeCache.set(segmentId, []);
+      } else {
+        // Previous entry exists, this is a segment being cleared
+        this.fullSegmentNodeCache.delete(segmentId);
       }
-      this.fullSegmentNodeCache.delete(segmentId);
       return true;
     }
     const normalizedSegmentNodes = [...nextSegmentNodes];
@@ -500,7 +503,16 @@ export class SpatialSkeletonState extends RefCounted {
   }
 
   private deleteCachedSegment(segmentId: number) {
-    return this.replaceCachedSegmentNodes(segmentId, []);
+    const previousSegmentNodes = this.fullSegmentNodeCache.get(segmentId);
+    if (previousSegmentNodes === undefined) return false;
+    for (const node of previousSegmentNodes) {
+      if (this.cachedNodesById.get(node.nodeId) === node) {
+        this.cachedNodesById.delete(node.nodeId);
+      }
+    }
+
+    this.fullSegmentNodeCache.delete(segmentId);
+    return true;
   }
 
   private abortPendingFullSegmentNodeFetch(segmentId: number, message: string) {
@@ -934,14 +946,7 @@ export class SpatialSkeletonState extends RefCounted {
         this.pendingFullSegmentNodeFetches.get(segmentId)?.promise ===
           pendingFetch.promise
       ) {
-        if (normalizedNodes.length > 0) {
-          this.replaceCachedSegmentNodes(segmentId, normalizedNodes);
-        } else {
-          // Explicitly cache the empty result so that non-existent skeletons
-          // don't trigger repeated fetches. replaceCachedSegmentNodes treats
-          // an empty array as a delete, so we write directly here.
-          this.fullSegmentNodeCache.set(segmentId, []);
-        }
+        this.replaceCachedSegmentNodes(segmentId, normalizedNodes);
         this.markNodeDataChanged({ invalidateFullSkeletonCache: false });
       }
       return normalizedNodes;


### PR DESCRIPTION
See https://metacell.atlassian.net/browse/NA-691

The main thing happening here was as follows. Starting at the spatial skeleton edit tab:
1. We call `skeletonState.getFullSegmentNodes` for each segment ID within a try except.
2. For a non existent segment ID, we try to get a full skeleton for a segment ID by calling `getSkeleton` in the neuroglancer catmaid `api.ts`. However, this fetch fails. And so the try except block catches the fetch failure and shows the temporary message, "Failed to load full skeleton data ... ".
3. Every time `refreshNodes` is called in the spatial skeleton edit tab, the exact same message shows, since fetching that ID will fail again. So if something triggers `refreshNodes` quickly, the screen will fill with messages.

To avoid this, I think our best bet is to explicitly handle fetch failures due to non-existent data. That is the first part of the change suggested here, which is in the catmaid `api.ts` to extend the `fetch` function there to have a new error type that can be returned by the `normalizeFetchError` function. 

The second part is to have `getSkeleton` handle the new `CatmaidNotFoundError` to return an empty skeleton. Could also return undefined or null, don't feel strongly here on what we return.

The last part is the change in `state.ts`. Right now, any segment ID which doesn't exist will never get put into the cache, and so neuroglancer will try to fetch it over and over again. Changed `replaceCachedSegmentNodes` to consider an empty list as something to store in the cache if there is no entry in the cache already. Otherwise it does the old behaviour and removes it. Changed `deleteCachedSegment` since it used to directly call `replaceCachedSegmentNodes` with empty list, but now it can't because `replaceCachedSegmentNodes` behaves differently with an empty list.

Also we arguably might want to protect against repeated fetches more generally from other failures, but think that would be out of scope here - aiming to fix it specifically for the case that the user tries to fetch skeletons for one or more non-existent IDs.