### PR TITLE
feat: change co-ord display to be in units

### DIFF
--- a/src/layer/segmentation/index.ts
+++ b/src/layer/segmentation/index.ts
@@ -239,14 +239,18 @@ function getSpatialSkeletonNodeTypeLabel(
   }
 }
 
-function formatSpatialSkeletonPosition(position: ArrayLike<number>) {
-  const x = Math.round(Number(position[0]));
-  const y = Math.round(Number(position[1]));
-  const z = Math.round(Number(position[2]));
+function formatSpatialSkeletonPosition(
+  modelPosition: ArrayLike<number>,
+  names?: readonly string[],
+) {
+  const x = Math.round(Number(modelPosition[0]));
+  const y = Math.round(Number(modelPosition[1]));
+  const z = Math.round(Number(modelPosition[2]));
+  const n = names ?? ["x", "y", "z"];
   return {
     copyText: `${x}, ${y}, ${z}`,
     displayText: `${x} ${y} ${z}`,
-    fullText: `x ${x} y ${y} z ${z}`,
+    fullText: `${n[0]}: ${x} ${n[1]}: ${y} ${n[2]}: ${z}`,
     x,
     y,
     z,
@@ -1396,10 +1400,7 @@ export class SegmentationUserLayer extends Base {
 
   selectAndMoveToSpatialSkeletonNode(
     node:
-      | Pick<
-          SpatiallyIndexedSkeletonNode,
-          "nodeId" | "segmentId" | "position"
-        >
+      | Pick<SpatiallyIndexedSkeletonNode, "nodeId" | "segmentId" | "position">
       | undefined,
     pin: boolean | "toggle" = this.manager.root.selectionState.pin.value,
   ) {
@@ -1854,9 +1855,8 @@ export class SegmentationUserLayer extends Base {
     if (action === SpatialSkeletonActions.inspect) {
       return getSpatiallyIndexedSkeletonSource(skeletonLayer) !== undefined;
     }
-    const editableSource = getEditableSpatiallyIndexedSkeletonSource(
-      skeletonLayer,
-    );
+    const editableSource =
+      getEditableSpatiallyIndexedSkeletonSource(skeletonLayer);
     if (editableSource === undefined) {
       return false;
     }
@@ -1883,8 +1883,9 @@ export class SegmentationUserLayer extends Base {
   }
 
   getSpatialSkeletonActionsDisabledReason(
-    requiredActions: SpatialSkeletonAction | readonly SpatialSkeletonAction[] =
-      DEFAULT_SPATIAL_SKELETON_EDIT_ACTIONS,
+    requiredActions:
+      | SpatialSkeletonAction
+      | readonly SpatialSkeletonAction[] = DEFAULT_SPATIAL_SKELETON_EDIT_ACTIONS,
     options: {
       requireVisibleChunks?: boolean;
     } = {},
@@ -1972,9 +1973,7 @@ export class SegmentationUserLayer extends Base {
     };
   }
 
-  getSpatialSkeletonNodeDisplayDescription(
-    node: SpatiallyIndexedSkeletonNode,
-  ) {
+  getSpatialSkeletonNodeDisplayDescription(node: SpatiallyIndexedSkeletonNode) {
     return node.description?.length ? node.description : undefined;
   }
 
@@ -2936,7 +2935,34 @@ export class SegmentationUserLayer extends Base {
     );
     summaryRow.appendChild(icon);
 
-    const position = formatSpatialSkeletonPosition(nodeInfo.position);
+    const skeletonDisplayTransform =
+      skeletonLayer?.displayState.transform.value;
+    let displayPosition: ArrayLike<number> = nodeInfo.position;
+    let displayNames: readonly string[] | undefined;
+    if (
+      skeletonDisplayTransform !== undefined &&
+      skeletonDisplayTransform.error === undefined
+    ) {
+      const rank = skeletonDisplayTransform.rank;
+      const modelPos = new Float32Array(rank);
+      for (let i = 0; i < Math.min(nodeInfo.position.length, rank); i++) {
+        modelPos[i] = Number(nodeInfo.position[i]);
+      }
+      const layerPos = new Float32Array(rank);
+      matrix.transformPoint(
+        layerPos,
+        skeletonDisplayTransform.modelToRenderLayerTransform,
+        rank + 1,
+        modelPos,
+        rank,
+      );
+      displayPosition = layerPos;
+      displayNames = skeletonDisplayTransform.layerDimensionNames;
+    }
+    const position = formatSpatialSkeletonPosition(
+      displayPosition,
+      displayNames,
+    );
     const summaryCoordinates = document.createElement("span");
     summaryCoordinates.className =
       "neuroglancer-spatial-skeleton-selection-summary-coordinates";
@@ -3281,12 +3307,13 @@ export class SegmentationUserLayer extends Base {
     radiusInput.addEventListener("change", commitProperties);
     confidenceControl.addEventListener("change", commitProperties);
     updatePropertyEditorState();
-    const descriptionText = cachedNodeInfo?.description ?? nodeInfo.description ?? "";
+    const descriptionText =
+      cachedNodeInfo?.description ?? nodeInfo.description ?? "";
     const descriptionEditingDisabledReason =
       skeletonSource === undefined
         ? "Unable to resolve editable skeleton source for the active layer."
-      : cachedNodeInfo === undefined
-        ? "Load the active skeleton in the Skeleton tab before editing description."
+        : cachedNodeInfo === undefined
+          ? "Load the active skeleton in the Skeleton tab before editing description."
           : this.getSpatialSkeletonActionsDisabledReason(
               SpatialSkeletonActions.editNodeDescription,
             );

--- a/src/layer/segmentation/style.css
+++ b/src/layer/segmentation/style.css
@@ -547,9 +547,20 @@
 
 .neuroglancer-spatial-skeleton-node-coordinates {
   overflow: hidden;
+  color: #d7d7d7;
+}
+
+.neuroglancer-spatial-skeleton-coordinates-flex {
+  display: flex;
+  flex-direction: row;
+}
+
+.neuroglancer-spatial-skeleton-coord-dim {
+  flex: 1 1 0;
+  min-width: 0;
+  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: #d7d7d7;
 }
 
 .neuroglancer-spatial-skeleton-node-description {

--- a/src/layer/segmentation/style.css
+++ b/src/layer/segmentation/style.css
@@ -242,8 +242,8 @@
 }
 
 .neuroglancer-spatial-skeleton-section {
-  --neuroglancer-skeleton-actions-width: 3.3em;
-  --neuroglancer-skeleton-type-width: 1.55em;
+  --neuroglancer-skeleton-actions-width: 44px;
+  --neuroglancer-skeleton-type-width: 21px;
   border: 1px solid #2f2f2f;
   display: flex;
   flex-direction: column;
@@ -415,11 +415,11 @@
   grid-template-columns:
     var(--neuroglancer-skeleton-actions-width)
     var(--neuroglancer-skeleton-type-width)
-    minmax(4.5em, 8em)
+    minmax(58px, 104px)
     minmax(0, 1fr);
   align-items: center;
-  column-gap: 0.2em;
-  padding: 0 0.3em;
+  column-gap: 3px;
+  padding: 0 4px;
 }
 
 .neuroglancer-spatial-skeleton-list-header {

--- a/src/ui/spatial_skeleton_edit_tab.spec.ts
+++ b/src/ui/spatial_skeleton_edit_tab.spec.ts
@@ -61,12 +61,20 @@ describe("spatial skeleton edit tab render state", () => {
     expect(state.rows.map((row) => row.node.nodeId)).toEqual([4]);
   });
 
-  it("does not match segment ids or true-end state in the search filter", () => {
+  it("does not match coordinates, segment ids, or true-end state in the search filter", () => {
     const graph = buildSpatiallyIndexedSkeletonNavigationGraph([
       makeNode(101, undefined, { isTrueEnd: true }),
       makeNode(102, 101),
     ]);
 
+    const byCoordinates = buildSpatialSkeletonSegmentRenderState(20380, graph, {
+      filterText: "101 102 103",
+      nodeFilterType: SpatialSkeletonNodeFilterType.NONE,
+      collapseRegularNodes: false,
+      getNodeDescription() {
+        return undefined;
+      },
+    });
     const bySegmentId = buildSpatialSkeletonSegmentRenderState(20380, graph, {
       filterText: "20380",
       nodeFilterType: SpatialSkeletonNodeFilterType.NONE,
@@ -84,6 +92,8 @@ describe("spatial skeleton edit tab render state", () => {
       },
     });
 
+    expect(byCoordinates.matchedNodeCount).toBe(0);
+    expect(byCoordinates.displayedNodeCount).toBe(0);
     expect(bySegmentId.matchedNodeCount).toBe(0);
     expect(bySegmentId.displayedNodeCount).toBe(0);
     expect(byTrueEndText.matchedNodeCount).toBe(0);

--- a/src/ui/spatial_skeleton_edit_tab.ts
+++ b/src/ui/spatial_skeleton_edit_tab.ts
@@ -232,7 +232,7 @@ export class SpatialSkeletonEditTab extends Tab {
     collapseButton.type = "button";
     const filterInput = document.createElement("input");
     filterInput.type = "text";
-    filterInput.placeholder = "Enter node ID, coordinates or description";
+    filterInput.placeholder = "Enter node ID or description";
     filterInput.className = "neuroglancer-spatial-skeleton-filter";
     const nodeFilterTypeModel = new TrackableEnum(
       SpatialSkeletonNodeFilterType,

--- a/src/ui/spatial_skeleton_edit_tab.ts
+++ b/src/ui/spatial_skeleton_edit_tab.ts
@@ -83,6 +83,8 @@ import {
 } from "#src/ui/spatial_skeleton_edit_tool.js";
 import { makeToolButton } from "#src/ui/tool.js";
 import { isAbortError } from "#src/util/abort.js";
+import * as matrix from "#src/util/matrix.js";
+import { formatScaleWithUnitAsString } from "#src/util/si_units.js";
 import { TrackableEnum } from "#src/util/trackable_enum.js";
 import { EnumSelectWidget } from "#src/widget/enum_widget.js";
 import { makeIcon } from "#src/widget/icon.js";
@@ -148,13 +150,6 @@ const NODE_TYPE_LABELS: Record<SkeletonNodeType, string> = {
   regular: "regular",
   virtualEnd: "virtual end",
 };
-
-function formatNodeCoordinates(position: ArrayLike<number>) {
-  const x = Number(position[0]);
-  const y = Number(position[1]);
-  const z = Number(position[2]);
-  return `${Math.round(x)} ${Math.round(y)} ${Math.round(z)}`;
-}
 
 export class SpatialSkeletonEditTab extends Tab {
   constructor(public layer: SegmentationUserLayer) {
@@ -331,6 +326,65 @@ export class SpatialSkeletonEditTab extends Tab {
     >();
     const segmentColorScratch = new Float32Array(4);
 
+    const getSkeletonTransform = () => {
+      const transform =
+        layer.getSpatiallyIndexedSkeletonLayer()?.displayState.transform.value;
+      return transform !== undefined && transform.error === undefined
+        ? transform
+        : undefined;
+    };
+
+    const getCoordinateDimensionHeaders = (): string[] => {
+      const transform = getSkeletonTransform();
+      if (transform === undefined) return ["x", "y", "z"];
+      const globalCoordSpace = layer.manager.root.coordinateSpace.value;
+      const localCoordSpace = layer.localCoordinateSpace.value;
+      return transform.layerDimensionNames.map((name, renderDim) => {
+        for (
+          let g = 0;
+          g < transform.globalToRenderLayerDimensions.length;
+          g++
+        ) {
+          if (transform.globalToRenderLayerDimensions[g] === renderDim) {
+            return `${name} (${formatScaleWithUnitAsString(globalCoordSpace.scales[g], globalCoordSpace.units[g], { precision: 2 })})`;
+          }
+        }
+        for (
+          let l = 0;
+          l < transform.localToRenderLayerDimensions.length;
+          l++
+        ) {
+          if (transform.localToRenderLayerDimensions[l] === renderDim) {
+            return `${name} (${formatScaleWithUnitAsString(localCoordSpace.scales[l], localCoordSpace.units[l], { precision: 2 })})`;
+          }
+        }
+        return name;
+      });
+    };
+
+    const formatNodeCoordinates = (position: ArrayLike<number>): string[] => {
+      const transform = getSkeletonTransform();
+      if (transform !== undefined) {
+        const rank = transform.rank;
+        const modelPos = new Float32Array(rank);
+        for (let i = 0; i < Math.min(position.length, rank); i++) {
+          modelPos[i] = Number(position[i]);
+        }
+        const layerPos = new Float32Array(rank);
+        matrix.transformPoint(
+          layerPos,
+          transform.modelToRenderLayerTransform,
+          rank + 1,
+          modelPos,
+          rank,
+        );
+        return Array.from({ length: rank }, (_, i) =>
+          String(Math.round(layerPos[i])),
+        );
+      }
+      return [0, 1, 2].map((i) => String(Math.round(Number(position[i]))));
+    };
+
     const getSelectedNode = () => {
       const selectedId = layer.selectedSpatialSkeletonNodeId.value;
       if (selectedId === undefined) return undefined;
@@ -353,9 +407,7 @@ export class SpatialSkeletonEditTab extends Tab {
     };
 
     const ensureActionsAllowed = (
-      requiredActions:
-        | SpatialSkeletonAction
-        | readonly SpatialSkeletonAction[],
+      requiredActions: SpatialSkeletonAction | readonly SpatialSkeletonAction[],
       options: {
         requireVisibleChunks?: boolean;
       } = {},
@@ -1068,8 +1120,13 @@ export class SpatialSkeletonEditTab extends Tab {
         headerId.textContent = "id";
         const headerCoordinates = document.createElement("span");
         headerCoordinates.className =
-          "neuroglancer-spatial-skeleton-list-header-cell";
-        headerCoordinates.textContent = "coordinates";
+          "neuroglancer-spatial-skeleton-list-header-cell neuroglancer-spatial-skeleton-coordinates-flex";
+        for (const dimLabel of getCoordinateDimensionHeaders()) {
+          const dimSpan = document.createElement("span");
+          dimSpan.className = "neuroglancer-spatial-skeleton-coord-dim";
+          dimSpan.textContent = dimLabel;
+          headerCoordinates.appendChild(dimSpan);
+        }
         listHeader.appendChild(headerActionsSpacer);
         listHeader.appendChild(headerTypeSpacer);
         listHeader.appendChild(headerId);
@@ -1260,8 +1317,13 @@ export class SpatialSkeletonEditTab extends Tab {
             "neuroglancer-spatial-skeleton-node-coordinate-cell";
           const coordinatesLine = document.createElement("div");
           coordinatesLine.className =
-            "neuroglancer-spatial-skeleton-node-coordinates";
-          coordinatesLine.textContent = formatNodeCoordinates(node.position);
+            "neuroglancer-spatial-skeleton-node-coordinates neuroglancer-spatial-skeleton-coordinates-flex";
+          for (const val of formatNodeCoordinates(node.position)) {
+            const valSpan = document.createElement("span");
+            valSpan.className = "neuroglancer-spatial-skeleton-coord-dim";
+            valSpan.textContent = val;
+            coordinatesLine.appendChild(valSpan);
+          }
           coordinatesCell.appendChild(coordinatesLine);
           const description = getNodeDescriptionText(node);
           if (description !== undefined) {
@@ -1508,13 +1570,11 @@ export class SpatialSkeletonEditTab extends Tab {
       const nextTrueEndEditingAllowed =
         layer.getSpatialSkeletonActionsDisabledReason(
           SpatialSkeletonActions.editNodeTrueEnd,
-        ) ===
-        undefined;
+        ) === undefined;
       const nextNodeDeletionAllowed =
         layer.getSpatialSkeletonActionsDisabledReason(
           SpatialSkeletonActions.deleteNodes,
-        ) ===
-        undefined;
+        ) === undefined;
       const nextNodeRerootAllowed =
         layer.getSpatialSkeletonActionsDisabledReason(
           SpatialSkeletonActions.reroot,
@@ -1680,6 +1740,16 @@ export class SpatialSkeletonEditTab extends Tab {
     this.registerDisposer(
       layer.spatialSkeletonNodeDataVersion.changed.add(() => {
         refreshNodes();
+      }),
+    );
+    this.registerDisposer(
+      layer.manager.root.coordinateSpace.changed.add(() => {
+        updateDisplay();
+      }),
+    );
+    this.registerDisposer(
+      layer.localCoordinateSpace.changed.add(() => {
+        updateDisplay();
       }),
     );
     updateCollapseButton();

--- a/src/ui/spatial_skeleton_edit_tab_render_state.ts
+++ b/src/ui/spatial_skeleton_edit_tab_render_state.ts
@@ -33,11 +33,6 @@ function nodeMatchesFilter(
 ) {
   if (filterText.length === 0) return true;
   if (String(node.nodeId).includes(filterText)) return true;
-  const x = Math.round(Number(node.position[0]));
-  const y = Math.round(Number(node.position[1]));
-  const z = Math.round(Number(node.position[2]));
-  if (`${x} ${y} ${z}`.includes(filterText)) return true;
-  if (`x ${x} y ${y} z ${z}`.includes(filterText)) return true;
   return description?.toLowerCase().includes(filterText) ?? false;
 }
 


### PR DESCRIPTION
This is in both the skeletons tab and the selection details, but to be honest I think we could consider to remove the repeat of the position from the details, since it's available at the top. For now I'll leave this at just changing the dims though to help scope the PR
<img width="492" height="352" alt="image" src="https://github.com/user-attachments/assets/f359482c-f9e5-45bb-b878-d99713f7d4d7" />
