### PR TITLE
fix: hovering nodes in viewer shows the seg ID in the viewer selection value for seg layer

### DIFF
--- a/src/layer/segmentation/index.ts
+++ b/src/layer/segmentation/index.ts
@@ -2486,21 +2486,6 @@ export class SegmentationUserLayer extends Base {
     return maybeAugmentSegmentId(this.displayState, value);
   }
 
-  captureSelectionState(
-    state: this["selectionState"],
-    mouseState: MouseSelectionState,
-  ) {
-    super.captureSelectionState(state, mouseState);
-    if (
-      getSpatialSkeletonNodeIdFromViewerHover(mouseState, this) === undefined
-    ) {
-      return;
-    }
-    // The skeleton tab reads mouse hover directly for row highlighting; do not
-    // propagate the node/segment ID into the persistent selection state.
-    state.spatialSkeletonNodeId = undefined;
-    state.spatialSkeletonSegmentId = undefined;
-  }
 
   handleAction(action: string, context: SegmentationActionContext) {
     switch (action) {

--- a/src/layer/segmentation/index.ts
+++ b/src/layer/segmentation/index.ts
@@ -2496,11 +2496,10 @@ export class SegmentationUserLayer extends Base {
     ) {
       return;
     }
-    // Viewer hover should not mutate global selection for spatial skeleton
-    // nodes; the skeleton tab reads mouse hover directly for row highlighting.
+    // The skeleton tab reads mouse hover directly for row highlighting; do not
+    // propagate the node/segment ID into the persistent selection state.
     state.spatialSkeletonNodeId = undefined;
     state.spatialSkeletonSegmentId = undefined;
-    state.value = undefined;
   }
 
   handleAction(action: string, context: SegmentationActionContext) {


### PR DESCRIPTION
Fix: don't set state.value to undefined after super.captureSelectionState

However, with this removed I don't think we need the `captureSelectionState` override in the segmentation layer that was introduced for the skeletons. 

Really I think the fix is actually to listen to something other than the mouse state in the skeleton edit tab but compared to everything else it's low prio.