### PR TITLE
feat: Allow merge with non-visible node

### DIFF
--- a/src/datasource/catmaid/api.spec.ts
+++ b/src/datasource/catmaid/api.spec.ts
@@ -69,12 +69,42 @@ describe("CatmaidClient skeleton editing methods", () => {
         max: { x: 25, y: 66, z: 127 },
       },
       resolution: { x: 2, y: 3, z: 4 },
-      gridCellSizes: [{ x: 25000, y: 25000, z: 40 }],
+      gridCellSizes: [{ x: 15, y: 15, z: 15 }],
     });
 
     expect((client as any).listStacks).toHaveBeenCalledTimes(2);
     expect((client as any).getStackInfo).toHaveBeenCalledTimes(1);
     warnSpy.mockRestore();
+  });
+
+  it("reads spatial skeleton chunk sizes from stack metadata", async () => {
+    const client = new CatmaidClient("https://example.invalid", 1);
+    (client as any).listStacks = vi.fn().mockResolvedValue([{ id: 7 }]);
+    (client as any).getStackInfo = vi.fn().mockResolvedValue({
+      dimension: { x: 10, y: 20, z: 30 },
+      resolution: { x: 2, y: 3, z: 4 },
+      translation: { x: 5, y: 6, z: 7 },
+      metadata: {
+        spatial_skeleton_chunk_sizes: [
+          [120, 120, 120],
+          [60, 60, 60],
+          [30, 30, 30],
+        ],
+      },
+    });
+
+    await expect(client.getSpatialIndexMetadata()).resolves.toEqual({
+      bounds: {
+        min: { x: 5, y: 6, z: 7 },
+        max: { x: 25, y: 66, z: 127 },
+      },
+      resolution: { x: 2, y: 3, z: 4 },
+      gridCellSizes: [
+        { x: 120, y: 120, z: 120 },
+        { x: 60, y: 60, z: 60 },
+        { x: 30, y: 30, z: 30 },
+      ],
+    });
   });
 
   it("parses live compact-detail history rows and label maps", async () => {

--- a/src/datasource/catmaid/api.spec.ts
+++ b/src/datasource/catmaid/api.spec.ts
@@ -254,6 +254,66 @@ describe("CatmaidClient skeleton editing methods", () => {
     );
   });
 
+  it("parses browse node/list rows with revision tokens", async () => {
+    const client = new CatmaidClient("https://example.invalid", 1);
+    const fetchMock = vi.fn().mockResolvedValue([
+      [
+        [101, null, 1, 2, 3, 5, 2000, 11, "2026-03-29T11:50:00Z", 2],
+        [102, 101, 4, 5, 6, 5, 2000, 17, "2026-03-29T11:51:00Z", 2],
+      ],
+      [],
+      {},
+      false,
+      [],
+      [],
+    ]);
+    (client as any).fetch = fetchMock;
+
+    await expect(
+      client.fetchNodes({
+        min: { x: 0, y: 0, z: 0 },
+        max: { x: 10, y: 10, z: 10 },
+      }),
+    ).resolves.toEqual([
+      {
+        nodeId: 101,
+        parentNodeId: undefined,
+        position: new Float32Array([1, 2, 3]),
+        segmentId: 11,
+        revisionToken: "2026-03-29T11:50:00Z",
+      },
+      {
+        nodeId: 102,
+        parentNodeId: 101,
+        position: new Float32Array([4, 5, 6]),
+        segmentId: 17,
+        revisionToken: "2026-03-29T11:51:00Z",
+      },
+    ]);
+
+    expect(getFetchPath(fetchMock)).toMatch(/^node\/list\?/);
+  });
+
+  it("fetches skeleton root targets", async () => {
+    const client = new CatmaidClient("https://example.invalid", 1);
+    const fetchMock = vi.fn().mockResolvedValue({
+      root_id: 303,
+      x: 1,
+      y: 2,
+      z: 3,
+    });
+    (client as any).fetch = fetchMock;
+
+    await expect(client.getSkeletonRootNode(17)).resolves.toEqual({
+      nodeId: 303,
+      x: 1,
+      y: 2,
+      z: 3,
+    });
+
+    expect(getFetchPath(fetchMock)).toBe("skeletons/17/root");
+  });
+
   it("rejects merge state when the provided node ids do not match the request", async () => {
     const client = new CatmaidClient("https://example.invalid", 1);
     const fetchMock = vi.fn();

--- a/src/datasource/catmaid/api.ts
+++ b/src/datasource/catmaid/api.ts
@@ -444,49 +444,28 @@ function getCatmaidHistoryRevisionToken(
 function parseCatmaidSkeletonRootTarget(
   response: any,
 ): SpatiallyIndexedSkeletonNavigationTarget {
-  if (Array.isArray(response) && response.length >= 4) {
-    const nodeId = Number(response[0]);
-    const x = Number(response[1]);
-    const y = Number(response[2]);
-    const z = Number(response[3]);
-    if (
-      Number.isSafeInteger(Math.round(nodeId)) &&
-      Math.round(nodeId) > 0 &&
-      Number.isFinite(x) &&
-      Number.isFinite(y) &&
-      Number.isFinite(z)
-    ) {
-      return {
-        nodeId: Math.round(nodeId),
-        x,
-        y,
-        z,
-      };
-    }
+  if (!response || typeof response !== "object" || Array.isArray(response)) {
+    throw new Error(
+      "CATMAID skeleton root endpoint returned an unexpected response format.",
+    );
   }
-  const nodeId = Number(
-    response?.root_id ??
-      response?.node_id ??
-      response?.treenode_id ??
-      response?.id,
-  );
-  const x = Number(response?.x ?? response?.location_x);
-  const y = Number(response?.y ?? response?.location_y);
-  const z = Number(response?.z ?? response?.location_z);
+
+  const { root_id, x, y, z } = response as Record<string, unknown>;
+  const nodeId = Number(root_id);
+  const px = Number(x);
+  const py = Number(y);
+  const pz = Number(z);
+
   if (
-    Number.isSafeInteger(Math.round(nodeId)) &&
-    Math.round(nodeId) > 0 &&
-    Number.isFinite(x) &&
-    Number.isFinite(y) &&
-    Number.isFinite(z)
+    Number.isSafeInteger(nodeId) &&
+    nodeId > 0 &&
+    Number.isFinite(px) &&
+    Number.isFinite(py) &&
+    Number.isFinite(pz)
   ) {
-    return {
-      nodeId: Math.round(nodeId),
-      x,
-      y,
-      z,
-    };
+    return { nodeId, x: px, y: py, z: pz };
   }
+
   throw new Error(
     "CATMAID skeleton root endpoint returned an unexpected response format.",
   );

--- a/src/datasource/catmaid/api.ts
+++ b/src/datasource/catmaid/api.ts
@@ -26,6 +26,7 @@ import type {
   SpatiallyIndexedSkeletonInsertNodeResult,
   SpatiallyIndexedSkeletonMergeResult,
   SpatiallyIndexedSkeletonMetadata,
+  SpatiallyIndexedSkeletonNavigationTarget,
   SpatiallyIndexedSkeletonNode,
   SpatiallyIndexedSkeletonNodeRevisionResult,
   SpatiallyIndexedSkeletonNodeRevisionUpdate,
@@ -445,6 +446,57 @@ function getCatmaidHistoryRevisionToken(
   row: readonly unknown[],
 ): string | undefined {
   return normalizeCatmaidRevisionToken(row[8]);
+}
+
+function parseCatmaidSkeletonRootTarget(
+  response: any,
+): SpatiallyIndexedSkeletonNavigationTarget {
+  if (Array.isArray(response) && response.length >= 4) {
+    const nodeId = Number(response[0]);
+    const x = Number(response[1]);
+    const y = Number(response[2]);
+    const z = Number(response[3]);
+    if (
+      Number.isSafeInteger(Math.round(nodeId)) &&
+      Math.round(nodeId) > 0 &&
+      Number.isFinite(x) &&
+      Number.isFinite(y) &&
+      Number.isFinite(z)
+    ) {
+      return {
+        nodeId: Math.round(nodeId),
+        x,
+        y,
+        z,
+      };
+    }
+  }
+  const nodeId = Number(
+    response?.root_id ??
+      response?.node_id ??
+      response?.treenode_id ??
+      response?.id,
+  );
+  const x = Number(response?.x ?? response?.location_x);
+  const y = Number(response?.y ?? response?.location_y);
+  const z = Number(response?.z ?? response?.location_z);
+  if (
+    Number.isSafeInteger(Math.round(nodeId)) &&
+    Math.round(nodeId) > 0 &&
+    Number.isFinite(x) &&
+    Number.isFinite(y) &&
+    Number.isFinite(z)
+  ) {
+    return {
+      nodeId: Math.round(nodeId),
+      x,
+      y,
+      z,
+    };
+  }
+  throw new Error(
+    "CATMAID skeleton root endpoint returned an unexpected response format.",
+  );
 }
 
 function requireCatmaidRevisionToken(
@@ -1106,6 +1158,7 @@ export class CatmaidClient implements EditableSpatiallyIndexedSkeletonSource {
         parentNodeId: n[1] ?? undefined,
         position: new Float32Array([n[2], n[3], n[4]]),
         segmentId: n[7],
+        revisionToken: normalizeCatmaidRevisionToken(n[8]),
       }),
     );
 
@@ -1126,6 +1179,7 @@ export class CatmaidClient implements EditableSpatiallyIndexedSkeletonSource {
               parentNodeId: n[1] ?? undefined,
               position: new Float32Array([n[2], n[3], n[4]]),
               segmentId: n[7],
+              revisionToken: normalizeCatmaidRevisionToken(n[8]),
             });
           }
         }
@@ -1156,6 +1210,13 @@ export class CatmaidClient implements EditableSpatiallyIndexedSkeletonSource {
     return getCatmaidSingleNodeRevisionResult(
       parseCatmaidMoveRevisionToken(response, nodeId),
     );
+  }
+
+  async getSkeletonRootNode(
+    skeletonId: number,
+  ): Promise<SpatiallyIndexedSkeletonNavigationTarget> {
+    const response = await this.fetch(`skeletons/${skeletonId}/root`);
+    return parseCatmaidSkeletonRootTarget(response);
   }
 
   async rerootSkeleton(

--- a/src/datasource/catmaid/api.ts
+++ b/src/datasource/catmaid/api.ts
@@ -37,14 +37,10 @@ import type {
 import {
   SPATIALLY_INDEXED_SKELETON_CONFIDENCE_VALUES,
 } from "#src/skeleton/api.js";
+import {
+  getDefaultSpatiallyIndexedSkeletonChunkSize,
+} from "#src/skeleton/spatial_chunk_sizing.js";
 import { HttpError } from "#src/util/http_request.js";
-
-interface CatmaidCacheConfiguration {
-  cache_type: string;
-  cell_width: number;
-  cell_height: number;
-  cell_depth: number;
-}
 
 interface CatmaidStackInfo {
   dimension: { x: number; y: number; z: number };
@@ -52,7 +48,7 @@ interface CatmaidStackInfo {
   translation: { x: number; y: number; z: number };
   metadata?: {
     cache_provider?: string;
-    cache_configurations?: CatmaidCacheConfiguration[];
+    spatial_skeleton_chunk_sizes?: Array<readonly [number, number, number]>;
   };
 }
 
@@ -61,9 +57,6 @@ export interface CatmaidToken {
 }
 
 export const credentialsKey = "CATMAID";
-const DEFAULT_CACHE_GRID_CELL_WIDTH = 25000;
-const DEFAULT_CACHE_GRID_CELL_HEIGHT = 25000;
-const DEFAULT_CACHE_GRID_CELL_DEPTH = 40;
 const CATMAID_NO_MATCHING_NODE_PROVIDER_ERROR =
   "Could not find matching node provider for request";
 const CATMAID_STATE_MATCHING_ERROR_TYPE = "StateMatchingError";
@@ -993,30 +986,32 @@ export class CatmaidClient implements EditableSpatiallyIndexedSkeletonSource {
   }
 
   private getGridCellSizesFromMetadataInfo(
-    info: CatmaidStackInfo | null,
+    info: CatmaidStackInfo,
+    bounds = getCatmaidProjectSpaceBounds(info),
   ): Array<{ x: number; y: number; z: number }> {
     const gridSizes: Array<{ x: number; y: number; z: number }> = [];
 
-    // Try to get all grid cell sizes from metadata
-    if (info?.metadata?.cache_configurations) {
-      for (const config of info.metadata.cache_configurations) {
-        if (config.cache_type === "grid") {
+    // Try to get all allowed spatial skeleton chunk sizes from metadata.
+    if (info.metadata?.spatial_skeleton_chunk_sizes) {
+      for (const chunkSize of info.metadata.spatial_skeleton_chunk_sizes) {
+        if (
+          chunkSize.length === 3 &&
+          Number.isFinite(chunkSize[0]) &&
+          Number.isFinite(chunkSize[1]) &&
+          Number.isFinite(chunkSize[2])
+        ) {
           gridSizes.push({
-            x: config.cell_width,
-            y: config.cell_height,
-            z: config.cell_depth,
+            x: chunkSize[0],
+            y: chunkSize[1],
+            z: chunkSize[2],
           });
         }
       }
     }
 
-    // If no grid configs found, use default
+    // If no chunk sizes are specified, use the bounds-derived default.
     if (gridSizes.length === 0) {
-      gridSizes.push({
-        x: DEFAULT_CACHE_GRID_CELL_WIDTH,
-        y: DEFAULT_CACHE_GRID_CELL_HEIGHT,
-        z: DEFAULT_CACHE_GRID_CELL_DEPTH,
-      });
+      gridSizes.push(getDefaultSpatiallyIndexedSkeletonChunkSize(bounds));
     }
 
     return gridSizes;
@@ -1027,10 +1022,11 @@ export class CatmaidClient implements EditableSpatiallyIndexedSkeletonSource {
     if (info === null) {
       return null;
     }
+    const bounds = getCatmaidProjectSpaceBounds(info);
     return {
-      bounds: getCatmaidProjectSpaceBounds(info),
+      bounds,
       resolution: info.resolution,
-      gridCellSizes: this.getGridCellSizesFromMetadataInfo(info),
+      gridCellSizes: this.getGridCellSizesFromMetadataInfo(info, bounds),
     };
   }
 

--- a/src/datasource/catmaid/backend.ts
+++ b/src/datasource/catmaid/backend.ts
@@ -96,7 +96,8 @@ export class CatmaidSpatiallyIndexedSkeletonSourceBackend extends WithParameters
 
     // Pack only segment IDs into vertexAttributes (positions are in vertexPositions)
     chunk.vertexAttributes = [packed.segmentIds];
-    chunk.nodeMap = packed.nodeMap;
+    chunk.nodeIds = packed.nodeIds;
+    chunk.nodeRevisionTokens = packed.revisionTokens;
   }
 }
 

--- a/src/datasource/catmaid/frontend.ts
+++ b/src/datasource/catmaid/frontend.ts
@@ -125,6 +125,10 @@ export class CatmaidSpatiallyIndexedSkeletonSource
     return this.client.fetchNodes(boundingBox, lod, options);
   }
 
+  getSkeletonRootNode(skeletonId: number) {
+    return this.client.getSkeletonRootNode(skeletonId);
+  }
+
   addNode(
     skeletonId: number,
     x: number,

--- a/src/datasource/catmaid/skeleton_packing.spec.ts
+++ b/src/datasource/catmaid/skeleton_packing.spec.ts
@@ -4,7 +4,7 @@ import { packCatmaidSkeletonNodes } from "#src/datasource/catmaid/skeleton_packi
 import type { SpatiallyIndexedSkeletonNodeBase } from "#src/skeleton/api.js";
 
 describe("datasource/catmaid/skeleton_packing", () => {
-  it("packs vertex, segment, index, and node-map data", () => {
+  it("packs vertex, segment, index, and pick-node data", () => {
     const nodes: SpatiallyIndexedSkeletonNodeBase[] = [
       {
         nodeId: 1,
@@ -33,11 +33,7 @@ describe("datasource/catmaid/skeleton_packing", () => {
     );
     expect(packed.segmentIds).toEqual(Uint32Array.of(10, 10, 11));
     expect(packed.indices).toEqual(Uint32Array.of(1, 0));
-    expect(Array.from(packed.nodeMap.entries())).toEqual([
-      [1, 0],
-      [2, 1],
-      [3, 2],
-    ]);
+    expect(packed.nodeIds).toEqual(Int32Array.of(1, 2, 3));
   });
 
   it("preserves large segment ids exactly", () => {

--- a/src/datasource/catmaid/skeleton_packing.ts
+++ b/src/datasource/catmaid/skeleton_packing.ts
@@ -20,7 +20,8 @@ interface PackedCatmaidSkeletonData {
   vertexPositions: Float32Array;
   segmentIds: Uint32Array;
   indices: Uint32Array;
-  nodeMap: Map<number, number>;
+  nodeIds: Int32Array;
+  revisionTokens: Array<string | undefined>;
 }
 
 export function packCatmaidSkeletonNodes(
@@ -29,16 +30,20 @@ export function packCatmaidSkeletonNodes(
   const numVertices = nodes.length;
   const vertexPositions = new Float32Array(numVertices * 3);
   const segmentIds = new Uint32Array(numVertices);
+  const nodeIds = new Int32Array(numVertices);
+  const revisionTokens = new Array<string | undefined>(numVertices);
   const indices: number[] = [];
   const nodeMap = new Map<number, number>();
 
   for (let i = 0; i < numVertices; ++i) {
     const node = nodes[i];
     nodeMap.set(node.nodeId, i);
+    nodeIds[i] = node.nodeId;
     vertexPositions[i * 3] = node.position[0];
     vertexPositions[i * 3 + 1] = node.position[1];
     vertexPositions[i * 3 + 2] = node.position[2];
     segmentIds[i] = node.segmentId;
+    revisionTokens[i] = node.revisionToken;
   }
 
   for (let i = 0; i < numVertices; ++i) {
@@ -54,6 +59,7 @@ export function packCatmaidSkeletonNodes(
     vertexPositions,
     segmentIds,
     indices: new Uint32Array(indices),
-    nodeMap,
+    nodeIds,
+    revisionTokens,
   };
 }

--- a/src/layer/index.ts
+++ b/src/layer/index.ts
@@ -76,6 +76,7 @@ import {
   SELECTED_LAYER_SIDE_PANEL_DEFAULT_LOCATION,
   UserLayerSidePanelsState,
 } from "#src/ui/layer_side_panel_state.js";
+import { formatErrorMessage } from "#src/util/error.js";
 import {
   DEFAULT_SIDE_PANEL_LOCATION,
   TrackableSidePanelLocation,
@@ -209,7 +210,7 @@ export class UserLayer extends RefCounted {
 
   pick = new TrackableBoolean(true, true);
 
-  selectionState: UserLayerSelectionState;
+  selectionState!: UserLayerSelectionState;
 
   messages = new MessageList();
 
@@ -1158,12 +1159,18 @@ export class LayerManager extends RefCounted {
   }
 }
 
+export interface PickedSpatialSkeletonState {
+  nodeId?: number;
+  segmentId?: number;
+  position?: Float32Array;
+  revisionToken?: string;
+}
+
 export interface PickState {
   pickedRenderLayer: RenderLayer | null;
   pickedValue: bigint;
   pickedOffset: number;
-  pickedSpatialSkeletonNodeId: number | undefined;
-  pickedSpatialSkeletonSegmentId: number | undefined;
+  pickedSpatialSkeleton: PickedSpatialSkeletonState | undefined;
   pickedAnnotationLayer: AnnotationLayerState | undefined;
   pickedAnnotationId: string | undefined;
   pickedAnnotationBuffer: ArrayBuffer | undefined;
@@ -1185,8 +1192,7 @@ export class MouseSelectionState implements PickState {
   pickedRenderLayer: RenderLayer | null = null;
   pickedValue = 0n;
   pickedOffset = 0;
-  pickedSpatialSkeletonNodeId: number | undefined = undefined;
-  pickedSpatialSkeletonSegmentId: number | undefined = undefined;
+  pickedSpatialSkeleton: PickedSpatialSkeletonState | undefined = undefined;
   pickedAnnotationLayer: AnnotationLayerState | undefined = undefined;
   pickedAnnotationId: string | undefined = undefined;
   pickedAnnotationBuffer: ArrayBuffer | undefined = undefined;
@@ -2267,10 +2273,7 @@ export class TopLevelLayerListSpecification extends LayerListSpecification {
         managedLayer.dispose();
         const msg = new StatusMessage();
         msg.setErrorMessage(
-          `Error creating layer ${JSON.stringify(name)}: ` +
-            (e instanceof Error)
-            ? e.message
-            : "" + e,
+          `Error creating layer ${JSON.stringify(name)}: ${formatErrorMessage(e)}`,
         );
       }
     }
@@ -2280,10 +2283,7 @@ export class TopLevelLayerListSpecification extends LayerListSpecification {
       } catch (e) {
         const msg = new StatusMessage();
         msg.setErrorMessage(
-          `Error creating layer ${JSON.stringify(name)}: ` +
-            (e instanceof Error)
-            ? e.message
-            : "" + e,
+          `Error creating layer ${JSON.stringify(name)}: ${formatErrorMessage(e)}`,
         );
       }
     }

--- a/src/layer/segmentation/selection.spec.ts
+++ b/src/layer/segmentation/selection.spec.ts
@@ -145,7 +145,7 @@ describe("layer/segmentation/selection", () => {
         {
           active: true,
           pickedRenderLayer: renderLayerA,
-          pickedSpatialSkeletonNodeId: 31,
+          pickedSpatialSkeleton: { nodeId: 31 },
         },
         layer,
       ),
@@ -155,7 +155,7 @@ describe("layer/segmentation/selection", () => {
         {
           active: true,
           pickedRenderLayer: renderLayerB,
-          pickedSpatialSkeletonNodeId: 31,
+          pickedSpatialSkeleton: { nodeId: 31 },
         },
         layer,
       ),
@@ -165,7 +165,7 @@ describe("layer/segmentation/selection", () => {
         {
           active: false,
           pickedRenderLayer: renderLayerA,
-          pickedSpatialSkeletonNodeId: 31,
+          pickedSpatialSkeleton: { nodeId: 31 },
         },
         layer,
       ),
@@ -175,7 +175,7 @@ describe("layer/segmentation/selection", () => {
         {
           active: true,
           pickedRenderLayer: renderLayerA,
-          pickedSpatialSkeletonNodeId: -1,
+          pickedSpatialSkeleton: { nodeId: -1 },
         },
         layer,
       ),

--- a/src/layer/segmentation/selection.ts
+++ b/src/layer/segmentation/selection.ts
@@ -24,7 +24,11 @@ interface SpatialSkeletonSelectionStateLike {
 interface SpatialSkeletonViewerHoverMouseStateLike<TRenderLayer> {
   active: boolean;
   pickedRenderLayer: TRenderLayer | null | undefined;
-  pickedSpatialSkeletonNodeId?: unknown;
+  pickedSpatialSkeleton?:
+    | {
+        nodeId?: unknown;
+      }
+    | undefined;
 }
 
 interface SpatialSkeletonViewerHoverLayerLike<TRenderLayer> {
@@ -174,6 +178,6 @@ export function getSpatialSkeletonNodeIdFromViewerHover<TRenderLayer>(
   }
   // TODO (SKM): I think we can inline this function
   return normalizeSpatialSkeletonViewerHoverNodeId(
-    mouseState.pickedSpatialSkeletonNodeId,
+    mouseState.pickedSpatialSkeleton?.nodeId,
   );
 }

--- a/src/layer/segmentation/spatial_skeleton_commands.spec.ts
+++ b/src/layer/segmentation/spatial_skeleton_commands.spec.ts
@@ -76,6 +76,9 @@ function suppressStatusMessages() {
   vi.spyOn(StatusMessage, "showTemporaryMessage").mockImplementation(
     (_message: string, _closeAfter?: number) => fakeStatusMessage,
   );
+  vi.spyOn(StatusMessage, "showMessage").mockImplementation(
+    (_message: string) => fakeStatusMessage,
+  );
 }
 
 describe("spatial_skeleton_commands", () => {
@@ -1176,5 +1179,129 @@ describe("spatial_skeleton_commands", () => {
       secondAttachNode.nodeId,
       expect.any(Object),
     );
+  });
+
+  it("shows and clears a pending status while a merge is in flight", async () => {
+    const pendingStatus = {
+      dispose: vi.fn(),
+    } as unknown as StatusMessage;
+    const showMessage = vi
+      .spyOn(StatusMessage, "showMessage")
+      .mockReturnValue(pendingStatus);
+    vi.spyOn(StatusMessage, "showTemporaryMessage").mockImplementation(
+      () => ({ dispose() {} }) as unknown as StatusMessage,
+    );
+
+    let resolveMerge:
+      | ((value: {
+          resultSkeletonId: number;
+          deletedSkeletonId: number;
+          stableAnnotationSwap: boolean;
+        }) => void)
+      | undefined;
+    const mergeSkeletons = vi.fn(
+      () =>
+        new Promise<{
+          resultSkeletonId: number;
+          deletedSkeletonId: number;
+          stableAnnotationSwap: boolean;
+        }>((resolve) => {
+          resolveMerge = resolve;
+        }),
+    );
+    const firstNode: SpatiallyIndexedSkeletonNode = {
+      nodeId: 101,
+      segmentId: 11,
+      position: new Float32Array([1, 2, 3]),
+      isTrueEnd: false,
+      revisionToken: "first-before",
+    };
+    const secondNode: SpatiallyIndexedSkeletonNode = {
+      nodeId: 202,
+      segmentId: 17,
+      position: new Float32Array([4, 5, 6]),
+      isTrueEnd: false,
+      revisionToken: "second-before",
+    };
+    const skeletonLayer = {
+      source: makeEditableSkeletonSource({ mergeSkeletons }),
+      getNode: vi.fn((nodeId: number) => {
+        if (nodeId === firstNode.nodeId) return firstNode;
+        if (nodeId === secondNode.nodeId) return secondNode;
+        return undefined;
+      }),
+      suppressBrowseSegment: vi.fn(),
+      invalidateSourceCaches: vi.fn(),
+    };
+    const layer = {
+      displayState: {
+        segmentationGroupState: {
+          value: {
+            visibleSegments: new Set<bigint>([11n, 17n]),
+            selectedSegments: new Set<bigint>(),
+            segmentEquivalences: {},
+            temporaryVisibleSegments: new Set<bigint>(),
+            temporarySegmentEquivalences: {},
+            useTemporaryVisibleSegments: { value: false },
+            useTemporarySegmentEquivalences: { value: false },
+          },
+        },
+        segmentStatedColors: {
+          value: {
+            delete: vi.fn(),
+          },
+        },
+      },
+      spatialSkeletonState: {
+        commandHistory: new SpatialSkeletonCommandHistory(),
+        getCachedNode: vi.fn((nodeId: number) => {
+          if (nodeId === firstNode.nodeId) return firstNode;
+          if (nodeId === secondNode.nodeId) return secondNode;
+          return undefined;
+        }),
+        getCachedSegmentNodes: vi.fn((segmentId: number) => {
+          if (segmentId === firstNode.segmentId) return [firstNode];
+          if (segmentId === secondNode.segmentId) return [secondNode];
+          return undefined;
+        }),
+        getFullSegmentNodes: vi.fn(async () => []),
+        invalidateCachedSegments: vi.fn(),
+      },
+      getSpatiallyIndexedSkeletonLayer: () => skeletonLayer,
+      selectSegment: vi.fn(),
+      selectSpatialSkeletonNode: vi.fn(),
+      markSpatialSkeletonNodeDataChanged: vi.fn(),
+      clearSpatialSkeletonMergeAnchor: vi.fn(),
+      manager: {
+        root: {
+          selectionState: {
+            pin: {
+              value: true,
+            },
+          },
+        },
+      },
+    };
+
+    const mergePromise = executeSpatialSkeletonMerge(
+      layer as any,
+      { nodeId: firstNode.nodeId, segmentId: firstNode.segmentId },
+      { nodeId: secondNode.nodeId, segmentId: secondNode.segmentId },
+    );
+
+    expect(showMessage).toHaveBeenCalledWith("Merging skeletons...");
+    expect(pendingStatus.dispose).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(mergeSkeletons).toHaveBeenCalledTimes(1);
+    });
+
+    resolveMerge?.({
+      resultSkeletonId: firstNode.segmentId,
+      deletedSkeletonId: secondNode.segmentId,
+      stableAnnotationSwap: false,
+    });
+    await mergePromise;
+
+    expect(pendingStatus.dispose).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/layer/segmentation/spatial_skeleton_commands.spec.ts
+++ b/src/layer/segmentation/spatial_skeleton_commands.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  executeSpatialSkeletonMerge,
   executeSpatialSkeletonMoveNode,
   executeSpatialSkeletonSplit,
   undoSpatialSkeletonCommand,
@@ -51,6 +52,7 @@ function makeEditableSkeletonSource(overrides: Record<string, unknown> = {}) {
     getSkeleton: vi.fn(),
     fetchNodes: vi.fn(),
     getSpatialIndexMetadata: vi.fn(),
+    getSkeletonRootNode: vi.fn(),
     addNode: vi.fn(),
     insertNode: vi.fn(),
     moveNode: vi.fn(),
@@ -538,5 +540,641 @@ describe("spatial_skeleton_commands", () => {
         parentNodeId: formerParentNode.nodeId,
       },
     ]);
+  });
+
+  it("preserves full merge undo behavior for a hidden second pick via the root endpoint", async () => {
+    suppressStatusMessages();
+
+    const visibleSegmentId = 11;
+    const hiddenSegmentId = 17;
+    const visibleRootNode: SpatiallyIndexedSkeletonNode = {
+      nodeId: 101,
+      segmentId: visibleSegmentId,
+      position: new Float32Array([1, 2, 3]),
+      isTrueEnd: false,
+      revisionToken: "visible-root-before",
+    };
+    const visibleAnchorNode: SpatiallyIndexedSkeletonNode = {
+      nodeId: 102,
+      segmentId: visibleSegmentId,
+      parentNodeId: visibleRootNode.nodeId,
+      position: new Float32Array([4, 5, 6]),
+      isTrueEnd: false,
+      revisionToken: "visible-anchor-before",
+    };
+    const hiddenRootNode: SpatiallyIndexedSkeletonNode = {
+      nodeId: 201,
+      segmentId: hiddenSegmentId,
+      position: new Float32Array([7, 8, 9]),
+      isTrueEnd: false,
+      revisionToken: "hidden-root-before",
+    };
+    const hiddenAttachNodeBefore: SpatiallyIndexedSkeletonNode = {
+      nodeId: 202,
+      segmentId: hiddenSegmentId,
+      parentNodeId: hiddenRootNode.nodeId,
+      position: new Float32Array([10, 11, 12]),
+      isTrueEnd: false,
+      revisionToken: "hidden-attach-before",
+    };
+    const mergedNodes: SpatiallyIndexedSkeletonNode[] = [
+      cloneNode(visibleRootNode),
+      cloneNode(visibleAnchorNode),
+      {
+        ...cloneNode(hiddenAttachNodeBefore),
+        segmentId: visibleSegmentId,
+        parentNodeId: visibleAnchorNode.nodeId,
+      },
+      {
+        ...cloneNode(hiddenRootNode),
+        segmentId: visibleSegmentId,
+        parentNodeId: hiddenAttachNodeBefore.nodeId,
+      },
+    ];
+    const splitOnlyRestoredNodes: SpatiallyIndexedSkeletonNode[] = [
+      {
+        ...cloneNode(hiddenAttachNodeBefore),
+        parentNodeId: undefined,
+        revisionToken: "hidden-attach-split",
+      },
+      {
+        ...cloneNode(hiddenRootNode),
+        parentNodeId: hiddenAttachNodeBefore.nodeId,
+        revisionToken: "hidden-root-split",
+      },
+    ];
+    const rerootedHiddenNodes: SpatiallyIndexedSkeletonNode[] = [
+      {
+        ...cloneNode(hiddenRootNode),
+        parentNodeId: undefined,
+        revisionToken: "hidden-root-rerooted",
+      },
+      {
+        ...cloneNode(hiddenAttachNodeBefore),
+        parentNodeId: hiddenRootNode.nodeId,
+        revisionToken: "hidden-attach-rerooted",
+      },
+    ];
+
+    const serverSegments = new Map<number, SpatiallyIndexedSkeletonNode[]>();
+    const cacheBySegment = new Map<number, SpatiallyIndexedSkeletonNode[]>();
+    const cacheByNode = new Map<number, SpatiallyIndexedSkeletonNode>();
+    const hiddenSegmentVisibleDuringFetches: boolean[] = [];
+
+    const syncCacheFromServer = (segmentId: number) => {
+      setSegmentNodes(
+        cacheBySegment,
+        cacheByNode,
+        segmentId,
+        serverSegments.get(segmentId) ?? [],
+      );
+      return cacheBySegment.get(segmentId) ?? [];
+    };
+
+    serverSegments.set(visibleSegmentId, [
+      cloneNode(visibleRootNode),
+      cloneNode(visibleAnchorNode),
+    ]);
+    serverSegments.set(hiddenSegmentId, [
+      cloneNode(hiddenRootNode),
+      cloneNode(hiddenAttachNodeBefore),
+    ]);
+    syncCacheFromServer(visibleSegmentId);
+
+    const skeletonSource = makeEditableSkeletonSource({
+      getSkeletonRootNode: vi.fn(async () => ({
+        nodeId: hiddenRootNode.nodeId,
+        x: hiddenRootNode.position[0],
+        y: hiddenRootNode.position[1],
+        z: hiddenRootNode.position[2],
+      })),
+      mergeSkeletons: vi.fn(async () => {
+        serverSegments.set(visibleSegmentId, mergedNodes.map(cloneNode));
+        serverSegments.delete(hiddenSegmentId);
+        return {
+          resultSkeletonId: visibleSegmentId,
+          deletedSkeletonId: hiddenSegmentId,
+          stableAnnotationSwap: false,
+        };
+      }),
+      splitSkeleton: vi.fn(async () => {
+        serverSegments.set(visibleSegmentId, [
+          cloneNode(visibleRootNode),
+          cloneNode(visibleAnchorNode),
+        ]);
+        serverSegments.set(hiddenSegmentId, splitOnlyRestoredNodes.map(cloneNode));
+        return {
+          existingSkeletonId: visibleSegmentId,
+          newSkeletonId: hiddenSegmentId,
+        };
+      }),
+      rerootSkeleton: vi.fn(async () => {
+        serverSegments.set(hiddenSegmentId, rerootedHiddenNodes.map(cloneNode));
+        return {};
+      }),
+    });
+
+    const invalidateCachedSegments = vi.fn((segmentIds: Iterable<number>) => {
+      for (const segmentId of segmentIds) {
+        setSegmentNodes(cacheBySegment, cacheByNode, segmentId, []);
+      }
+    });
+    let layer: any;
+    const getFullSegmentNodes = vi.fn(
+      async (_skeletonLayer: unknown, segmentId: number) => {
+        if (segmentId === hiddenSegmentId) {
+          hiddenSegmentVisibleDuringFetches.push(
+            layer.displayState.segmentationGroupState.value.visibleSegments.has(
+              BigInt(hiddenSegmentId),
+            ),
+          );
+        }
+        return syncCacheFromServer(segmentId);
+      },
+    );
+    const skeletonLayer = {
+      source: skeletonSource,
+      getNode: vi.fn((nodeId: number) => cacheByNode.get(nodeId)),
+      invalidateSourceCaches: vi.fn(),
+      suppressBrowseSegment: vi.fn(),
+    };
+    layer = {
+      displayState: {
+        segmentationGroupState: {
+          value: {
+            visibleSegments: new Set<bigint>([BigInt(visibleSegmentId)]),
+            selectedSegments: new Set<bigint>(),
+            segmentEquivalences: {},
+            temporaryVisibleSegments: new Set<bigint>(),
+            temporarySegmentEquivalences: {},
+            useTemporaryVisibleSegments: { value: false },
+            useTemporarySegmentEquivalences: { value: false },
+          },
+        },
+        segmentStatedColors: {
+          value: {
+            delete: vi.fn(),
+          },
+        },
+      },
+      manager: {
+        root: {
+          selectionState: {
+            pin: {
+              value: true,
+            },
+          },
+        },
+      },
+      spatialSkeletonState: {
+        commandHistory: new SpatialSkeletonCommandHistory(),
+        getCachedNode: (nodeId: number) => cacheByNode.get(nodeId),
+        getCachedSegmentNodes: (segmentId: number) =>
+          cacheBySegment.get(segmentId),
+        getFullSegmentNodes,
+        invalidateCachedSegments,
+      },
+      getSpatiallyIndexedSkeletonLayer: () => skeletonLayer,
+      selectSegment: vi.fn(),
+      selectSpatialSkeletonNode: vi.fn(),
+      markSpatialSkeletonNodeDataChanged: vi.fn(),
+      clearSpatialSkeletonMergeAnchor: vi.fn(),
+    };
+
+    await executeSpatialSkeletonMerge(
+      layer as any,
+      {
+        nodeId: visibleAnchorNode.nodeId,
+        segmentId: visibleSegmentId,
+      },
+      {
+        nodeId: hiddenAttachNodeBefore.nodeId,
+        segmentId: hiddenSegmentId,
+        revisionToken: hiddenAttachNodeBefore.revisionToken,
+      },
+    );
+
+    expect(skeletonSource.getSkeletonRootNode).toHaveBeenCalledWith(
+      hiddenSegmentId,
+    );
+    expect(skeletonSource.mergeSkeletons).toHaveBeenCalledWith(
+      visibleAnchorNode.nodeId,
+      hiddenAttachNodeBefore.nodeId,
+      expect.any(Object),
+    );
+    expect(getFullSegmentNodes).toHaveBeenCalledTimes(2);
+    expect(skeletonSource.mergeSkeletons.mock.invocationCallOrder[0]).toBeLessThan(
+      getFullSegmentNodes.mock.invocationCallOrder[0],
+    );
+
+    skeletonSource.rerootSkeleton.mockClear();
+    hiddenSegmentVisibleDuringFetches.length = 0;
+
+    await undoSpatialSkeletonCommand(layer as any);
+
+    expect(skeletonSource.splitSkeleton).toHaveBeenCalledWith(
+      hiddenAttachNodeBefore.nodeId,
+      expect.any(Object),
+    );
+    expect(skeletonSource.rerootSkeleton).toHaveBeenCalledWith(
+      hiddenRootNode.nodeId,
+      expect.any(Object),
+    );
+    expect(hiddenSegmentVisibleDuringFetches.length).toBeGreaterThan(0);
+    expect(hiddenSegmentVisibleDuringFetches.every(Boolean)).toBe(true);
+    expect(
+      cacheBySegment.get(hiddenSegmentId)?.map((node) => ({
+        nodeId: node.nodeId,
+        parentNodeId: node.parentNodeId,
+      })),
+    ).toEqual([
+      {
+        nodeId: hiddenRootNode.nodeId,
+        parentNodeId: undefined,
+      },
+      {
+        nodeId: hiddenAttachNodeBefore.nodeId,
+        parentNodeId: hiddenRootNode.nodeId,
+      },
+    ]);
+  });
+
+  it("reports reroot failure during merge undo as a split-only undo", async () => {
+    const fakeStatusMessage = {
+      dispose() {},
+    } as unknown as StatusMessage;
+    const statusSpy = vi
+      .spyOn(StatusMessage, "showTemporaryMessage")
+      .mockImplementation(
+        (_message: string, _closeAfter?: number) => fakeStatusMessage,
+      );
+
+    const visibleSegmentId = 11;
+    const hiddenSegmentId = 17;
+    const visibleRootNode: SpatiallyIndexedSkeletonNode = {
+      nodeId: 101,
+      segmentId: visibleSegmentId,
+      position: new Float32Array([1, 2, 3]),
+      isTrueEnd: false,
+      revisionToken: "visible-root-before",
+    };
+    const visibleAnchorNode: SpatiallyIndexedSkeletonNode = {
+      nodeId: 102,
+      segmentId: visibleSegmentId,
+      parentNodeId: visibleRootNode.nodeId,
+      position: new Float32Array([4, 5, 6]),
+      isTrueEnd: false,
+      revisionToken: "visible-anchor-before",
+    };
+    const hiddenRootNode: SpatiallyIndexedSkeletonNode = {
+      nodeId: 201,
+      segmentId: hiddenSegmentId,
+      position: new Float32Array([7, 8, 9]),
+      isTrueEnd: false,
+      revisionToken: "hidden-root-before",
+    };
+    const hiddenAttachNodeBefore: SpatiallyIndexedSkeletonNode = {
+      nodeId: 202,
+      segmentId: hiddenSegmentId,
+      parentNodeId: hiddenRootNode.nodeId,
+      position: new Float32Array([10, 11, 12]),
+      isTrueEnd: false,
+      revisionToken: "hidden-attach-before",
+    };
+    const mergedNodes: SpatiallyIndexedSkeletonNode[] = [
+      cloneNode(visibleRootNode),
+      cloneNode(visibleAnchorNode),
+      {
+        ...cloneNode(hiddenAttachNodeBefore),
+        segmentId: visibleSegmentId,
+        parentNodeId: visibleAnchorNode.nodeId,
+      },
+      {
+        ...cloneNode(hiddenRootNode),
+        segmentId: visibleSegmentId,
+        parentNodeId: hiddenAttachNodeBefore.nodeId,
+      },
+    ];
+    const splitOnlyRestoredNodes: SpatiallyIndexedSkeletonNode[] = [
+      {
+        ...cloneNode(hiddenAttachNodeBefore),
+        parentNodeId: undefined,
+        revisionToken: "hidden-attach-split",
+      },
+      {
+        ...cloneNode(hiddenRootNode),
+        parentNodeId: hiddenAttachNodeBefore.nodeId,
+        revisionToken: "hidden-root-split",
+      },
+    ];
+
+    const serverSegments = new Map<number, SpatiallyIndexedSkeletonNode[]>();
+    const cacheBySegment = new Map<number, SpatiallyIndexedSkeletonNode[]>();
+    const cacheByNode = new Map<number, SpatiallyIndexedSkeletonNode>();
+
+    const syncCacheFromServer = (segmentId: number) => {
+      setSegmentNodes(
+        cacheBySegment,
+        cacheByNode,
+        segmentId,
+        serverSegments.get(segmentId) ?? [],
+      );
+      return cacheBySegment.get(segmentId) ?? [];
+    };
+
+    serverSegments.set(visibleSegmentId, [
+      cloneNode(visibleRootNode),
+      cloneNode(visibleAnchorNode),
+    ]);
+    serverSegments.set(hiddenSegmentId, [
+      cloneNode(hiddenRootNode),
+      cloneNode(hiddenAttachNodeBefore),
+    ]);
+    syncCacheFromServer(visibleSegmentId);
+
+    const skeletonSource = makeEditableSkeletonSource({
+      getSkeletonRootNode: vi.fn(async () => ({
+        nodeId: hiddenRootNode.nodeId,
+        x: hiddenRootNode.position[0],
+        y: hiddenRootNode.position[1],
+        z: hiddenRootNode.position[2],
+      })),
+      mergeSkeletons: vi.fn(async () => {
+        serverSegments.set(visibleSegmentId, mergedNodes.map(cloneNode));
+        serverSegments.delete(hiddenSegmentId);
+        return {
+          resultSkeletonId: visibleSegmentId,
+          deletedSkeletonId: hiddenSegmentId,
+          stableAnnotationSwap: false,
+        };
+      }),
+      splitSkeleton: vi.fn(async () => {
+        serverSegments.set(visibleSegmentId, [
+          cloneNode(visibleRootNode),
+          cloneNode(visibleAnchorNode),
+        ]);
+        serverSegments.set(hiddenSegmentId, splitOnlyRestoredNodes.map(cloneNode));
+        return {
+          existingSkeletonId: visibleSegmentId,
+          newSkeletonId: hiddenSegmentId,
+        };
+      }),
+      rerootSkeleton: vi.fn(async () => {
+        throw new Error("reroot failed");
+      }),
+    });
+
+    const getFullSegmentNodes = vi.fn(
+      async (_skeletonLayer: unknown, segmentId: number) =>
+        syncCacheFromServer(segmentId),
+    );
+    const layer = {
+      displayState: {
+        segmentationGroupState: {
+          value: {
+            visibleSegments: new Set<bigint>([BigInt(visibleSegmentId)]),
+            selectedSegments: new Set<bigint>(),
+            segmentEquivalences: {},
+            temporaryVisibleSegments: new Set<bigint>(),
+            temporarySegmentEquivalences: {},
+            useTemporaryVisibleSegments: { value: false },
+            useTemporarySegmentEquivalences: { value: false },
+          },
+        },
+        segmentStatedColors: {
+          value: {
+            delete: vi.fn(),
+          },
+        },
+      },
+      manager: {
+        root: {
+          selectionState: {
+            pin: {
+              value: true,
+            },
+          },
+        },
+      },
+      spatialSkeletonState: {
+        commandHistory: new SpatialSkeletonCommandHistory(),
+        getCachedNode: (nodeId: number) => cacheByNode.get(nodeId),
+        getCachedSegmentNodes: (segmentId: number) =>
+          cacheBySegment.get(segmentId),
+        getFullSegmentNodes,
+        invalidateCachedSegments: vi.fn((segmentIds: Iterable<number>) => {
+          for (const segmentId of segmentIds) {
+            setSegmentNodes(cacheBySegment, cacheByNode, segmentId, []);
+          }
+        }),
+      },
+      getSpatiallyIndexedSkeletonLayer: () => ({
+        source: skeletonSource,
+        getNode: vi.fn((nodeId: number) => cacheByNode.get(nodeId)),
+        invalidateSourceCaches: vi.fn(),
+        suppressBrowseSegment: vi.fn(),
+      }),
+      selectSegment: vi.fn(),
+      selectSpatialSkeletonNode: vi.fn(),
+      markSpatialSkeletonNodeDataChanged: vi.fn(),
+      clearSpatialSkeletonMergeAnchor: vi.fn(),
+    };
+
+    await executeSpatialSkeletonMerge(
+      layer as any,
+      {
+        nodeId: visibleAnchorNode.nodeId,
+        segmentId: visibleSegmentId,
+      },
+      {
+        nodeId: hiddenAttachNodeBefore.nodeId,
+        segmentId: hiddenSegmentId,
+        revisionToken: hiddenAttachNodeBefore.revisionToken,
+      },
+    );
+    statusSpy.mockClear();
+
+    await expect(undoSpatialSkeletonCommand(layer as any)).resolves.toBe(true);
+
+    expect(skeletonSource.splitSkeleton).toHaveBeenCalledWith(
+      hiddenAttachNodeBefore.nodeId,
+      expect.any(Object),
+    );
+    expect(skeletonSource.rerootSkeleton).toHaveBeenCalledWith(
+      hiddenRootNode.nodeId,
+      expect.any(Object),
+    );
+    expect(
+      cacheBySegment.get(hiddenSegmentId)?.map((node) => ({
+        nodeId: node.nodeId,
+        parentNodeId: node.parentNodeId,
+      })),
+    ).toEqual([
+      {
+        nodeId: hiddenAttachNodeBefore.nodeId,
+        parentNodeId: undefined,
+      },
+      {
+        nodeId: hiddenRootNode.nodeId,
+        parentNodeId: hiddenAttachNodeBefore.nodeId,
+      },
+    ]);
+    expect(statusSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Only the split completed."),
+    );
+  });
+
+  it("falls back to full resolution for an uncached second node without revision metadata", async () => {
+    suppressStatusMessages();
+
+    const firstSegmentId = 11;
+    const secondSegmentId = 17;
+    const firstRootNode: SpatiallyIndexedSkeletonNode = {
+      nodeId: 101,
+      segmentId: firstSegmentId,
+      position: new Float32Array([1, 2, 3]),
+      isTrueEnd: false,
+      revisionToken: "first-root-before",
+    };
+    const firstAnchorNode: SpatiallyIndexedSkeletonNode = {
+      nodeId: 102,
+      segmentId: firstSegmentId,
+      parentNodeId: firstRootNode.nodeId,
+      position: new Float32Array([4, 5, 6]),
+      isTrueEnd: false,
+      revisionToken: "first-anchor-before",
+    };
+    const secondRootNode: SpatiallyIndexedSkeletonNode = {
+      nodeId: 201,
+      segmentId: secondSegmentId,
+      position: new Float32Array([7, 8, 9]),
+      isTrueEnd: false,
+      revisionToken: "second-root-before",
+    };
+    const secondAttachNode: SpatiallyIndexedSkeletonNode = {
+      nodeId: 202,
+      segmentId: secondSegmentId,
+      parentNodeId: secondRootNode.nodeId,
+      position: new Float32Array([10, 11, 12]),
+      isTrueEnd: false,
+      revisionToken: "second-attach-before",
+    };
+
+    const serverSegments = new Map<number, SpatiallyIndexedSkeletonNode[]>();
+    const cacheBySegment = new Map<number, SpatiallyIndexedSkeletonNode[]>();
+    const cacheByNode = new Map<number, SpatiallyIndexedSkeletonNode>();
+
+    const syncCacheFromServer = (segmentId: number) => {
+      setSegmentNodes(
+        cacheBySegment,
+        cacheByNode,
+        segmentId,
+        serverSegments.get(segmentId) ?? [],
+      );
+      return cacheBySegment.get(segmentId) ?? [];
+    };
+
+    serverSegments.set(firstSegmentId, [
+      cloneNode(firstRootNode),
+      cloneNode(firstAnchorNode),
+    ]);
+    serverSegments.set(secondSegmentId, [
+      cloneNode(secondRootNode),
+      cloneNode(secondAttachNode),
+    ]);
+    syncCacheFromServer(firstSegmentId);
+
+    const skeletonSource = makeEditableSkeletonSource({
+      getSkeletonRootNode: vi.fn(async () => ({
+        nodeId: secondRootNode.nodeId,
+        x: secondRootNode.position[0],
+        y: secondRootNode.position[1],
+        z: secondRootNode.position[2],
+      })),
+      mergeSkeletons: vi.fn(async () => ({
+        resultSkeletonId: firstSegmentId,
+        deletedSkeletonId: secondSegmentId,
+        stableAnnotationSwap: false,
+      })),
+    });
+
+    const getFullSegmentNodes = vi.fn(
+      async (_skeletonLayer: unknown, segmentId: number) =>
+        syncCacheFromServer(segmentId),
+    );
+    const layer = {
+      displayState: {
+        segmentationGroupState: {
+          value: {
+            visibleSegments: new Set<bigint>([BigInt(firstSegmentId)]),
+            selectedSegments: new Set<bigint>(),
+            segmentEquivalences: {},
+            temporaryVisibleSegments: new Set<bigint>(),
+            temporarySegmentEquivalences: {},
+            useTemporaryVisibleSegments: { value: false },
+            useTemporarySegmentEquivalences: { value: false },
+          },
+        },
+        segmentStatedColors: {
+          value: {
+            delete: vi.fn(),
+          },
+        },
+      },
+      manager: {
+        root: {
+          selectionState: {
+            pin: {
+              value: true,
+            },
+          },
+        },
+      },
+      spatialSkeletonState: {
+        commandHistory: new SpatialSkeletonCommandHistory(),
+        getCachedNode: (nodeId: number) => cacheByNode.get(nodeId),
+        getCachedSegmentNodes: (segmentId: number) =>
+          cacheBySegment.get(segmentId),
+        getFullSegmentNodes,
+        invalidateCachedSegments: vi.fn((segmentIds: Iterable<number>) => {
+          for (const segmentId of segmentIds) {
+            setSegmentNodes(cacheBySegment, cacheByNode, segmentId, []);
+          }
+        }),
+      },
+      getSpatiallyIndexedSkeletonLayer: () => ({
+        source: skeletonSource,
+        getNode: vi.fn((nodeId: number) => cacheByNode.get(nodeId)),
+        invalidateSourceCaches: vi.fn(),
+        suppressBrowseSegment: vi.fn(),
+      }),
+      selectSegment: vi.fn(),
+      selectSpatialSkeletonNode: vi.fn(),
+      markSpatialSkeletonNodeDataChanged: vi.fn(),
+      clearSpatialSkeletonMergeAnchor: vi.fn(),
+    };
+
+    await executeSpatialSkeletonMerge(
+      layer as any,
+      {
+        nodeId: firstAnchorNode.nodeId,
+        segmentId: firstSegmentId,
+      },
+      {
+        nodeId: secondAttachNode.nodeId,
+        segmentId: secondSegmentId,
+      },
+    );
+
+    expect(skeletonSource.getSkeletonRootNode).not.toHaveBeenCalled();
+    expect(getFullSegmentNodes).toHaveBeenCalledWith(
+      expect.anything(),
+      secondSegmentId,
+    );
+    expect(skeletonSource.mergeSkeletons).toHaveBeenCalledWith(
+      firstAnchorNode.nodeId,
+      secondAttachNode.nodeId,
+      expect.any(Object),
+    );
   });
 });

--- a/src/layer/segmentation/spatial_skeleton_commands.ts
+++ b/src/layer/segmentation/spatial_skeleton_commands.ts
@@ -1578,7 +1578,10 @@ export function executeSpatialSkeletonAddNode(
       options.skeletonId,
     new Float32Array(options.positionInModelSpace),
   );
-  return layer.spatialSkeletonState.commandHistory.execute(command);
+  return executeSpatialSkeletonCommandWithPendingMessage(
+    layer.spatialSkeletonState.commandHistory.execute(command),
+    "Creating node...",
+  );
 }
 
 export function executeSpatialSkeletonMoveNode(
@@ -1621,7 +1624,10 @@ export function executeSpatialSkeletonDeleteNode(
     refreshedNode.nodeId,
   );
   const command = new DeleteNodeCommand(layer, refreshedNode, childNodes);
-  return layer.spatialSkeletonState.commandHistory.execute(command);
+  return executeSpatialSkeletonCommandWithPendingMessage(
+    layer.spatialSkeletonState.commandHistory.execute(command),
+    "Deleting node...",
+  );
 }
 
 export function executeSpatialSkeletonNodeDescriptionUpdate(
@@ -1731,13 +1737,24 @@ export function executeSpatialSkeletonSplit(
     commandMappings.getStableOrCurrentSegmentId(splitNode.segmentId),
     commandMappings.getStableOrCurrentNodeId(splitNode.parentNodeId),
   );
-  return layer.spatialSkeletonState.commandHistory.execute(command);
+  return executeSpatialSkeletonCommandWithPendingMessage(
+    layer.spatialSkeletonState.commandHistory.execute(command),
+    "Splitting skeleton...",
+  );
 }
 
 interface SpatialSkeletonMergeEndpoint {
   nodeId: number;
   segmentId: number;
   revisionToken?: string;
+}
+
+function executeSpatialSkeletonCommandWithPendingMessage<T>(
+  promise: Promise<T>,
+  message: string,
+) {
+  const status = StatusMessage.showMessage(message);
+  return promise.finally(() => status.dispose());
 }
 
 export function executeSpatialSkeletonMerge(
@@ -1754,7 +1771,10 @@ export function executeSpatialSkeletonMerge(
     commandMappings.getStableOrCurrentSegmentId(secondNode.segmentId),
     secondNode.revisionToken,
   );
-  return layer.spatialSkeletonState.commandHistory.execute(command);
+  return executeSpatialSkeletonCommandWithPendingMessage(
+    layer.spatialSkeletonState.commandHistory.execute(command),
+    "Merging skeletons...",
+  );
 }
 
 export async function undoSpatialSkeletonCommand(layer: SegmentationUserLayer) {

--- a/src/layer/segmentation/spatial_skeleton_commands.ts
+++ b/src/layer/segmentation/spatial_skeleton_commands.ts
@@ -44,6 +44,7 @@ import {
 import type { SpatiallyIndexedSkeletonLayer } from "#src/skeleton/frontend.js";
 import { getEditableSpatiallyIndexedSkeletonSource } from "#src/skeleton/spatial_skeleton_manager.js";
 import { StatusMessage } from "#src/status.js";
+import { formatErrorMessage } from "#src/util/error.js";
 
 function cloneNodeSnapshot(
   node: SpatiallyIndexedSkeletonNode,
@@ -140,11 +141,26 @@ function findRootNode(
   return segmentNodes.find((candidate) => candidate.parentNodeId === undefined);
 }
 
-async function getResolvedNodeForEdit(
+interface ResolvedSpatialSkeletonEditNode {
+  skeletonLayer: SpatiallyIndexedSkeletonLayer;
+  skeletonSource: EditableSpatiallyIndexedSkeletonSource;
+  segmentNodes: readonly SpatiallyIndexedSkeletonNode[];
+  node: SpatiallyIndexedSkeletonNode;
+}
+
+interface ResolvedSpatialSkeletonEditNodeContext {
+  currentNodeId: number;
+  segmentId: number;
+  cachedNode: SpatiallyIndexedSkeletonNode | undefined;
+  skeletonLayer: SpatiallyIndexedSkeletonLayer;
+  skeletonSource: EditableSpatiallyIndexedSkeletonSource;
+}
+
+function getResolvedNodeContextForEdit(
   layer: SegmentationUserLayer,
   stableNodeId: number,
   stableSegmentId: number | undefined,
-): Promise<ResolvedSpatialSkeletonEditNode> {
+): ResolvedSpatialSkeletonEditNodeContext {
   const commandMappings = layer.spatialSkeletonState.commandHistory.mappings;
   const currentNodeId = commandMappings.resolveNodeId(stableNodeId);
   if (currentNodeId === undefined) {
@@ -162,6 +178,26 @@ async function getResolvedNodeForEdit(
       `Unable to resolve the current segment for node ${stableNodeId}.`,
     );
   }
+  return {
+    currentNodeId,
+    segmentId: candidateSegmentId,
+    cachedNode,
+    skeletonLayer,
+    skeletonSource,
+  };
+}
+
+async function getResolvedNodeForEdit(
+  layer: SegmentationUserLayer,
+  stableNodeId: number,
+  stableSegmentId: number | undefined,
+): Promise<ResolvedSpatialSkeletonEditNode> {
+  const {
+    currentNodeId,
+    segmentId: candidateSegmentId,
+    skeletonLayer,
+    skeletonSource,
+  } = getResolvedNodeContextForEdit(layer, stableNodeId, stableSegmentId);
   let segmentNodes =
     layer.spatialSkeletonState.getCachedSegmentNodes(candidateSegmentId);
   if (segmentNodes === undefined) {
@@ -185,13 +221,6 @@ async function getResolvedNodeForEdit(
     segmentNodes,
     node,
   };
-}
-
-interface ResolvedSpatialSkeletonEditNode {
-  skeletonLayer: SpatiallyIndexedSkeletonLayer;
-  skeletonSource: EditableSpatiallyIndexedSkeletonSource;
-  segmentNodes: readonly SpatiallyIndexedSkeletonNode[];
-  node: SpatiallyIndexedSkeletonNode;
 }
 
 function buildInsertEditContext(
@@ -1288,6 +1317,7 @@ class MergeCommand implements SpatialSkeletonCommand {
     private stableFirstSegmentId: number | undefined,
     private stableSecondNodeId: number,
     private stableSecondSegmentId: number | undefined,
+    private secondNodeRevisionToken: string | undefined,
   ) {}
 
   private async merge(statusPrefix: string) {
@@ -1296,11 +1326,47 @@ class MergeCommand implements SpatialSkeletonCommand {
       this.stableFirstNodeId,
       this.stableFirstSegmentId,
     );
-    const secondNode = await getResolvedNodeForEdit(
+    const secondNodeContext = getResolvedNodeContextForEdit(
       this.layer,
       this.stableSecondNodeId,
       this.stableSecondSegmentId,
     );
+    let secondNode: ResolvedSpatialSkeletonEditNode;
+    let preservedSecondRootNodeId: number | undefined;
+    const secondSegmentCached =
+      this.layer.spatialSkeletonState.getCachedSegmentNodes(
+        secondNodeContext.segmentId,
+      ) !== undefined;
+    const secondRevisionToken =
+      this.secondNodeRevisionToken ??
+      secondNodeContext.cachedNode?.revisionToken;
+    if (secondSegmentCached || secondRevisionToken === undefined) {
+      secondNode = await getResolvedNodeForEdit(
+        this.layer,
+        this.stableSecondNodeId,
+        this.stableSecondSegmentId,
+      );
+    } else {
+      preservedSecondRootNodeId =
+        (
+          await secondNodeContext.skeletonSource.getSkeletonRootNode(
+            secondNodeContext.segmentId,
+          )
+        ).nodeId;
+      secondNode = {
+        skeletonLayer: secondNodeContext.skeletonLayer,
+        skeletonSource: secondNodeContext.skeletonSource,
+        segmentNodes: [],
+        node: {
+          nodeId: secondNodeContext.currentNodeId,
+          segmentId: secondNodeContext.segmentId,
+          position: new Float32Array(3),
+          parentNodeId: secondNodeContext.cachedNode?.parentNodeId,
+          isTrueEnd: secondNodeContext.cachedNode?.isTrueEnd ?? false,
+          revisionToken: secondRevisionToken,
+        },
+      };
+    }
     let result: SpatiallyIndexedSkeletonMergeResult;
     try {
       result = await firstNode.skeletonSource.mergeSkeletons(
@@ -1326,13 +1392,13 @@ class MergeCommand implements SpatialSkeletonCommand {
       winningNode.nodeId === firstNode.node.nodeId
         ? secondNode.node
         : firstNode.node;
-    const losingSegmentNodes =
-      losingNode.segmentId === firstNode.node.segmentId
-        ? firstNode.segmentNodes
-        : secondNode.segmentNodes;
-    const attachedRoot = findRootNode(losingSegmentNodes);
     const resultSkeletonId = result.resultSkeletonId ?? winningNode.segmentId;
     const deletedSkeletonId = result.deletedSkeletonId ?? losingNode.segmentId;
+    const attachedRootNodeId =
+      losingNode.segmentId === firstNode.node.segmentId
+        ? findRootNode(firstNode.segmentNodes)?.nodeId
+        : preservedSecondRootNodeId ??
+          findRootNode(secondNode.segmentNodes)?.nodeId;
     this.stableAttachedNodeId =
       this.stableAttachedNodeId ??
       this.layer.spatialSkeletonState.commandHistory.mappings.getStableOrCurrentNodeId(
@@ -1341,7 +1407,7 @@ class MergeCommand implements SpatialSkeletonCommand {
     this.stableAttachedRootNodeId =
       this.stableAttachedRootNodeId ??
       this.layer.spatialSkeletonState.commandHistory.mappings.getStableOrCurrentNodeId(
-        attachedRoot?.nodeId,
+        attachedRootNodeId,
       );
     this.stableResultSegmentId =
       this.stableResultSegmentId ??
@@ -1424,35 +1490,51 @@ class MergeCommand implements SpatialSkeletonCommand {
     );
     const survivingSegmentId =
       splitResult.existingSkeletonId ?? attachedNode.node.segmentId;
+    ensureVisibleSegment(this.layer, survivingSegmentId);
+    ensureVisibleSegment(this.layer, restoredSegmentId);
     await refreshTopologySegments(this.layer, [
       survivingSegmentId,
       restoredSegmentId,
     ]);
+    let rerootWarning: string | undefined;
     if (
       this.stableAttachedRootNodeId !== undefined &&
       this.stableAttachedRootNodeId !== this.stableAttachedNodeId
     ) {
-      const restoredRoot = await getResolvedNodeForEdit(
-        this.layer,
-        this.stableAttachedRootNodeId,
-        this.stableDeletedSegmentId,
-      );
-      if (restoredRoot.node.parentNodeId !== undefined) {
-        await restoredRoot.skeletonSource.rerootSkeleton?.(
-          restoredRoot.node.nodeId,
-          buildSpatiallyIndexedSkeletonRerootEditContext(
-            restoredRoot.node,
-            restoredRoot.segmentNodes,
-          ),
+      try {
+        const restoredRoot = await getResolvedNodeForEdit(
+          this.layer,
+          this.stableAttachedRootNodeId,
+          this.stableDeletedSegmentId,
         );
+        if (restoredRoot.node.parentNodeId !== undefined) {
+          if (restoredRoot.skeletonSource.rerootSkeleton === undefined) {
+            throw new Error(
+              "The active skeleton source does not support reroot.",
+            );
+          }
+          await restoredRoot.skeletonSource.rerootSkeleton(
+            restoredRoot.node.nodeId,
+            buildSpatiallyIndexedSkeletonRerootEditContext(
+              restoredRoot.node,
+              restoredRoot.segmentNodes,
+            ),
+          );
+          await refreshTopologySegments(this.layer, [
+            survivingSegmentId,
+            restoredSegmentId,
+          ]);
+        }
+      } catch (error) {
         await refreshTopologySegments(this.layer, [
           survivingSegmentId,
           restoredSegmentId,
         ]);
+        rerootWarning =
+          `Undo split the merged skeletons, but failed to reroot the restored skeleton. ` +
+          `Only the split completed. ${formatErrorMessage(error)}`;
       }
     }
-    ensureVisibleSegment(this.layer, survivingSegmentId);
-    ensureVisibleSegment(this.layer, restoredSegmentId);
     this.layer.selectSpatialSkeletonNode(
       attachedNode.node.nodeId,
       this.layer.manager.root.selectionState.pin.value,
@@ -1461,7 +1543,8 @@ class MergeCommand implements SpatialSkeletonCommand {
       },
     );
     StatusMessage.showTemporaryMessage(
-      `${statusPrefix} merge involving node ${attachedNode.node.nodeId}.`,
+      rerootWarning ??
+        `${statusPrefix} merge involving node ${attachedNode.node.nodeId}.`,
     );
   }
 
@@ -1651,10 +1734,16 @@ export function executeSpatialSkeletonSplit(
   return layer.spatialSkeletonState.commandHistory.execute(command);
 }
 
+interface SpatialSkeletonMergeEndpoint {
+  nodeId: number;
+  segmentId: number;
+  revisionToken?: string;
+}
+
 export function executeSpatialSkeletonMerge(
   layer: SegmentationUserLayer,
-  firstNode: Pick<SpatiallyIndexedSkeletonNode, "nodeId" | "segmentId">,
-  secondNode: Pick<SpatiallyIndexedSkeletonNode, "nodeId" | "segmentId">,
+  firstNode: SpatialSkeletonMergeEndpoint,
+  secondNode: SpatialSkeletonMergeEndpoint,
 ) {
   const commandMappings = layer.spatialSkeletonState.commandHistory.mappings;
   const command = new MergeCommand(
@@ -1663,6 +1752,7 @@ export function executeSpatialSkeletonMerge(
     commandMappings.getStableOrCurrentSegmentId(firstNode.segmentId),
     commandMappings.getStableOrCurrentNodeId(secondNode.nodeId)!,
     commandMappings.getStableOrCurrentSegmentId(secondNode.segmentId),
+    secondNode.revisionToken,
   );
   return layer.spatialSkeletonState.commandHistory.execute(command);
 }

--- a/src/object_picking.ts
+++ b/src/object_picking.ts
@@ -104,8 +104,7 @@ export class PickIDManager {
       values[valuesOffset + 1],
       values[valuesOffset + 2],
     ));
-    mouseState.pickedSpatialSkeletonNodeId = undefined;
-    mouseState.pickedSpatialSkeletonSegmentId = undefined;
+    mouseState.pickedSpatialSkeleton = undefined;
     mouseState.pickedAnnotationId = undefined;
     mouseState.pickedAnnotationLayer = undefined;
     mouseState.pickedAnnotationBuffer = undefined;

--- a/src/rendered_data_panel.ts
+++ b/src/rendered_data_panel.ts
@@ -511,7 +511,8 @@ export abstract class RenderedDataPanel extends RenderedPanel {
       if (!mouseState.updateUnconditionally()) {
         return undefined;
       }
-      const pickedNodeId = mouseState.pickedSpatialSkeletonNodeId;
+      const pickedSpatialSkeleton = mouseState.pickedSpatialSkeleton;
+      const pickedNodeId = pickedSpatialSkeleton?.nodeId;
       if (
         typeof pickedNodeId !== "number" ||
         !Number.isSafeInteger(pickedNodeId) ||
@@ -523,7 +524,7 @@ export abstract class RenderedDataPanel extends RenderedPanel {
       if (!isSpatialSkeletonSelectableLayer(pickedLayer)) {
         return undefined;
       }
-      const pickedSegmentId = mouseState.pickedSpatialSkeletonSegmentId;
+      const pickedSegmentId = pickedSpatialSkeleton?.segmentId;
       return {
         layer: pickedLayer,
         nodeId: pickedNodeId,

--- a/src/skeleton/api.ts
+++ b/src/skeleton/api.ts
@@ -19,6 +19,7 @@ export interface SpatiallyIndexedSkeletonNodeBase {
   segmentId: number;
   position: Float32Array;
   parentNodeId?: number;
+  revisionToken?: string;
 }
 
 export interface SpatiallyIndexedSkeletonNode
@@ -27,7 +28,6 @@ export interface SpatiallyIndexedSkeletonNode
   confidence?: number;
   description?: string;
   isTrueEnd: boolean;
-  revisionToken?: string;
 }
 
 export interface SpatiallyIndexedSkeletonOpenLeaf {
@@ -152,6 +152,9 @@ export interface SpatiallyIndexedSkeletonSource {
 
 export interface EditableSpatiallyIndexedSkeletonSource
   extends SpatiallyIndexedSkeletonSource {
+  getSkeletonRootNode(
+    skeletonId: number,
+  ): Promise<SpatiallyIndexedSkeletonNavigationTarget>;
   addNode(
     skeletonId: number,
     x: number,

--- a/src/skeleton/backend.ts
+++ b/src/skeleton/backend.ts
@@ -302,7 +302,8 @@ export class SpatiallyIndexedSkeletonChunk
   lod: number = 0;
   requestGeneration = -1;
   requestOwners = SpatiallyIndexedSkeletonChunkRequestOwner.NONE;
-  nodeMap: Map<number, number> = new Map(); // Maps node ID to vertex index
+  nodeIds: Int32Array | undefined;
+  nodeRevisionTokens: Array<string | undefined> | undefined;
 
   freeSystemMemory() {
     freeSkeletonChunkSystemMemory(this);

--- a/src/skeleton/frontend.spec.ts
+++ b/src/skeleton/frontend.spec.ts
@@ -69,6 +69,36 @@ describe("resolveSpatiallyIndexedSkeletonSegmentPick", () => {
   });
 });
 
+describe("SpatiallyIndexedSkeletonLayer browse node picks", () => {
+  it("resolves browse node picks with node id and revision token", () => {
+    const positions = new Float32Array([1, 2, 3, 4, 5, 6]);
+    const segmentIds = new Uint32Array([11, 17]);
+    const vertexBytes = new Uint8Array(
+      positions.byteLength + segmentIds.byteLength,
+    );
+    vertexBytes.set(new Uint8Array(positions.buffer), 0);
+    vertexBytes.set(new Uint8Array(segmentIds.buffer), positions.byteLength);
+    const chunk = {
+      vertexAttributes: vertexBytes,
+      vertexAttributeOffsets: new Uint32Array([0, positions.byteLength]),
+      numVertices: 2,
+      indices: new Uint32Array([0, 1]),
+      nodeIds: new Int32Array([101, 202]),
+      nodeRevisionTokens: ["2026-03-29T11:50:00Z", "2026-03-29T11:51:00Z"],
+    };
+    const layer = Object.create(SpatiallyIndexedSkeletonLayer.prototype);
+
+    expect(
+      (layer as any).resolveNodePickFromChunk(chunk, 1),
+    ).toEqual({
+      nodeId: 202,
+      segmentId: 17,
+      position: new Float32Array([4, 5, 6]),
+      revisionToken: "2026-03-29T11:51:00Z",
+    });
+  });
+});
+
 describe("spatiallyIndexedSkeletonTextureAttributeSpecs", () => {
   it("keeps the browse path upload layout to position plus segment", () => {
     expect(spatiallyIndexedSkeletonTextureAttributeSpecs).toEqual([

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -1535,7 +1535,8 @@ export class SpatiallyIndexedSkeletonChunk
   numVertices: number;
   vertexAttributeOffsets: Uint32Array;
   vertexAttributeTextures: (WebGLTexture | null)[] = [];
-  nodeMap: Map<number, number> = new Map(); // Maps node ID to vertex index
+  nodeIds: Int32Array = new Int32Array(0);
+  nodeRevisionTokens: Array<string | undefined> = [];
   lod: number | undefined;
 
   constructor(
@@ -1549,14 +1550,24 @@ export class SpatiallyIndexedSkeletonChunk
     this.numIndices = indices.length;
     this.vertexAttributeOffsets = chunkData.vertexAttributeOffsets;
     this.lod = (chunkData as any).lod;
-
-    // Deserialize nodeMap from array format [nodeId, vertexIndex, ...]
-    const nodeMapData = (chunkData as any).nodeMap;
-    if (Array.isArray(nodeMapData) && nodeMapData.length > 0) {
-      this.nodeMap = new Map(nodeMapData);
+    const nodeIdsData = (chunkData as any).nodeIds;
+    if (nodeIdsData instanceof Int32Array) {
+      this.nodeIds = nodeIdsData;
+    } else if (ArrayBuffer.isView(nodeIdsData)) {
+      this.nodeIds = new Int32Array(
+        nodeIdsData.buffer,
+        nodeIdsData.byteOffset,
+        nodeIdsData.byteLength / Int32Array.BYTES_PER_ELEMENT,
+      );
     } else {
-      this.nodeMap = new Map();
+      this.nodeIds = new Int32Array(0);
     }
+    const nodeRevisionTokens = (chunkData as any).nodeRevisionTokens;
+    this.nodeRevisionTokens = Array.isArray(nodeRevisionTokens)
+      ? nodeRevisionTokens.map((value) =>
+          typeof value === "string" ? value : undefined,
+        )
+      : [];
   }
 
   copyToGPU(gl: GL) {
@@ -2047,7 +2058,9 @@ function collectPlaneIntersectingSpatialChunkKeysBySource(
         }
         seenChunkKeys!.add(chunkKey);
         visibleChunkKeys.totalChunkKeys.add(chunkKey);
-        const chunk = tsource.source.chunks.get(chunkKey) as
+        const chunk = (tsource.source as SpatiallyIndexedSkeletonSource).chunks.get(
+          chunkKey,
+        ) as
           | SpatiallyIndexedSkeletonChunk
           | undefined;
         if (chunk?.state === ChunkState.GPU_MEMORY) {
@@ -2865,6 +2878,41 @@ export class SpatiallyIndexedSkeletonLayer
     );
   }
 
+  resolveNodePickFromChunk(
+    chunk: SpatiallyIndexedSkeletonChunk,
+    pickedOffset: number,
+  ) {
+    const data = this.getChunkPositionAndSegmentArrays(chunk);
+    if (
+      data === undefined ||
+      pickedOffset < 0 ||
+      pickedOffset >= chunk.numVertices ||
+      pickedOffset >= chunk.nodeIds.length
+    ) {
+      return undefined;
+    }
+    const nodeId = chunk.nodeIds[pickedOffset];
+    if (!Number.isSafeInteger(nodeId) || nodeId <= 0) {
+      return undefined;
+    }
+    const segmentId = resolveSpatiallyIndexedSkeletonSegmentPick(
+      chunk,
+      data.segmentIds,
+      pickedOffset,
+      "node",
+    );
+    if (segmentId === undefined) {
+      return undefined;
+    }
+    const baseOffset = pickedOffset * 3;
+    return {
+      nodeId,
+      segmentId,
+      position: data.positions.subarray(baseOffset, baseOffset + 3),
+      revisionToken: chunk.nodeRevisionTokens[pickedOffset],
+    };
+  }
+
   updateVisibleChunksForView(
     view: SpatiallyIndexedSkeletonView,
     transformedSources: readonly TransformedSource[][],
@@ -3490,7 +3538,7 @@ export class PerspectiveViewSpatiallyIndexedSkeletonLayer extends PerspectiveVie
   }
 
   transformPickedValue(pickState: PickState) {
-    const pickedSegmentId = pickState.pickedSpatialSkeletonSegmentId;
+    const pickedSegmentId = pickState.pickedSpatialSkeleton?.segmentId;
     if (
       typeof pickedSegmentId === "number" &&
       Number.isSafeInteger(pickedSegmentId)
@@ -3520,7 +3568,7 @@ export class PerspectiveViewSpatiallyIndexedSkeletonLayer extends PerspectiveVie
       if (!Number.isSafeInteger(segmentId) || segmentId <= 0) {
         return;
       }
-      mouseState.pickedSpatialSkeletonSegmentId = segmentId;
+      mouseState.pickedSpatialSkeleton = { segmentId };
       if (
         !getVisibleSegments(
           this.base.displayState.segmentationGroupState.value,
@@ -3530,11 +3578,15 @@ export class PerspectiveViewSpatiallyIndexedSkeletonLayer extends PerspectiveVie
       }
       const nodeId = pickData.nodeIds[pickedOffset];
       if (!Number.isSafeInteger(nodeId) || nodeId <= 0) return;
-      mouseState.pickedSpatialSkeletonNodeId = nodeId;
       const nodePosition = pickData.nodePositions.subarray(
         pickedOffset * 3,
         pickedOffset * 3 + 3,
       );
+      mouseState.pickedSpatialSkeleton = {
+        nodeId,
+        segmentId,
+        position: new Float32Array(nodePosition),
+      };
       const transform = this.base.displayState.transform.value;
       if (transform.error === undefined) {
         setMouseStatePositionFromSpatialSkeletonNode(mouseState, nodePosition, transform);
@@ -3547,18 +3599,33 @@ export class PerspectiveViewSpatiallyIndexedSkeletonLayer extends PerspectiveVie
       }
       const segmentId = pickData.segmentIds[pickedOffset];
       if (Number.isSafeInteger(segmentId) && segmentId > 0) {
-        mouseState.pickedSpatialSkeletonSegmentId = segmentId;
+        mouseState.pickedSpatialSkeleton = { segmentId };
       }
       return;
     }
     if (pickData.kind === "segment-node" || pickData.kind === "segment-edge") {
+      if (pickData.kind === "segment-node") {
+        const pickedNode = this.base.resolveNodePickFromChunk(
+          pickData.chunk,
+          pickedOffset,
+        );
+        if (pickedNode !== undefined) {
+          mouseState.pickedSpatialSkeleton = {
+            nodeId: pickedNode.nodeId,
+            segmentId: pickedNode.segmentId,
+            position: new Float32Array(pickedNode.position),
+            revisionToken: pickedNode.revisionToken,
+          };
+        }
+        return;
+      }
       const segmentId = this.base.resolveSegmentPickFromChunk(
         pickData.chunk,
         pickedOffset,
-        pickData.kind === "segment-node" ? "node" : "edge",
+        "edge",
       );
       if (segmentId !== undefined) {
-        mouseState.pickedSpatialSkeletonSegmentId = segmentId;
+        mouseState.pickedSpatialSkeleton = { segmentId };
       }
     }
   }
@@ -3795,7 +3862,7 @@ export class SliceViewPanelSpatiallyIndexedSkeletonLayer extends SliceViewPanelR
   }
 
   transformPickedValue(pickState: PickState) {
-    const pickedSegmentId = pickState.pickedSpatialSkeletonSegmentId;
+    const pickedSegmentId = pickState.pickedSpatialSkeleton?.segmentId;
     if (
       typeof pickedSegmentId === "number" &&
       Number.isSafeInteger(pickedSegmentId)
@@ -3825,7 +3892,7 @@ export class SliceViewPanelSpatiallyIndexedSkeletonLayer extends SliceViewPanelR
       if (!Number.isSafeInteger(segmentId) || segmentId <= 0) {
         return;
       }
-      mouseState.pickedSpatialSkeletonSegmentId = segmentId;
+      mouseState.pickedSpatialSkeleton = { segmentId };
       if (
         !getVisibleSegments(
           this.base.displayState.segmentationGroupState.value,
@@ -3835,11 +3902,15 @@ export class SliceViewPanelSpatiallyIndexedSkeletonLayer extends SliceViewPanelR
       }
       const nodeId = pickData.nodeIds[pickedOffset];
       if (!Number.isSafeInteger(nodeId) || nodeId <= 0) return;
-      mouseState.pickedSpatialSkeletonNodeId = nodeId;
       const nodePosition = pickData.nodePositions.subarray(
         pickedOffset * 3,
         pickedOffset * 3 + 3,
       );
+      mouseState.pickedSpatialSkeleton = {
+        nodeId,
+        segmentId,
+        position: new Float32Array(nodePosition),
+      };
       const transform = this.base.displayState.transform.value;
       if (transform.error === undefined) {
         setMouseStatePositionFromSpatialSkeletonNode(mouseState, nodePosition, transform);
@@ -3852,18 +3923,33 @@ export class SliceViewPanelSpatiallyIndexedSkeletonLayer extends SliceViewPanelR
       }
       const segmentId = pickData.segmentIds[pickedOffset];
       if (Number.isSafeInteger(segmentId) && segmentId > 0) {
-        mouseState.pickedSpatialSkeletonSegmentId = segmentId;
+        mouseState.pickedSpatialSkeleton = { segmentId };
       }
       return;
     }
     if (pickData.kind === "segment-node" || pickData.kind === "segment-edge") {
+      if (pickData.kind === "segment-node") {
+        const pickedNode = this.base.resolveNodePickFromChunk(
+          pickData.chunk,
+          pickedOffset,
+        );
+        if (pickedNode !== undefined) {
+          mouseState.pickedSpatialSkeleton = {
+            nodeId: pickedNode.nodeId,
+            segmentId: pickedNode.segmentId,
+            position: new Float32Array(pickedNode.position),
+            revisionToken: pickedNode.revisionToken,
+          };
+        }
+        return;
+      }
       const segmentId = this.base.resolveSegmentPickFromChunk(
         pickData.chunk,
         pickedOffset,
-        pickData.kind === "segment-node" ? "node" : "edge",
+        "edge",
       );
       if (segmentId !== undefined) {
-        mouseState.pickedSpatialSkeletonSegmentId = segmentId;
+        mouseState.pickedSpatialSkeleton = { segmentId };
       }
     }
   }

--- a/src/skeleton/skeleton_chunk_serialization.ts
+++ b/src/skeleton/skeleton_chunk_serialization.ts
@@ -21,7 +21,8 @@ export interface SkeletonChunkData {
   vertexAttributes: TypedNumberArray[] | null;
   indices: Uint32Array | null;
   lod?: number;
-  nodeMap?: Map<number, number>;
+  nodeIds?: Int32Array;
+  nodeRevisionTokens?: Array<string | undefined>;
 }
 
 /**
@@ -92,9 +93,12 @@ export function serializeSkeletonChunkData(
     }
   }
 
-  if (data.nodeMap) {
-    // Convert Map to array of [key, value] pairs for serialization
-    msg.nodeMap = Array.from(data.nodeMap.entries());
+  if (data.nodeIds) {
+    msg.nodeIds = data.nodeIds;
+    transfers.push(data.nodeIds.buffer);
+  }
+  if (data.nodeRevisionTokens) {
+    msg.nodeRevisionTokens = data.nodeRevisionTokens;
   }
 }
 
@@ -103,5 +107,6 @@ export function serializeSkeletonChunkData(
  */
 export function freeSkeletonChunkSystemMemory(data: SkeletonChunkData): void {
   data.vertexPositions = data.indices = data.vertexAttributes = null;
-  data.nodeMap = undefined;
+  data.nodeIds = undefined;
+  data.nodeRevisionTokens = undefined;
 }

--- a/src/skeleton/spatial_chunk_sizing.spec.ts
+++ b/src/skeleton/spatial_chunk_sizing.spec.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getDefaultSpatiallyIndexedSkeletonChunkSize,
+} from "#src/skeleton/spatial_chunk_sizing.js";
+
+describe("skeleton/spatial_chunk_sizing", () => {
+  it("derives an isotropic chunk size that stays within the default chunk budget", () => {
+    expect(
+      getDefaultSpatiallyIndexedSkeletonChunkSize({
+        min: { x: 5, y: 6, z: 7 },
+        max: { x: 25, y: 66, z: 127 },
+      }),
+    ).toEqual({ x: 15, y: 15, z: 15 });
+  });
+
+  it("handles elongated bounds while keeping the chunk size isotropic", () => {
+    expect(
+      getDefaultSpatiallyIndexedSkeletonChunkSize({
+        min: { x: 0, y: 0, z: 0 },
+        max: { x: 1000, y: 10, z: 10 },
+      }),
+    ).toEqual({ x: 16, y: 16, z: 16 });
+  });
+
+  it("returns the minimum chunk size for tiny bounds", () => {
+    expect(
+      getDefaultSpatiallyIndexedSkeletonChunkSize({
+        min: { x: 0, y: 0, z: 0 },
+        max: { x: 2, y: 2, z: 2 },
+      }),
+    ).toEqual({ x: 1, y: 1, z: 1 });
+  });
+
+  it("supports overriding the chunk budget", () => {
+    expect(
+      getDefaultSpatiallyIndexedSkeletonChunkSize(
+        {
+          min: { x: 0, y: 0, z: 0 },
+          max: { x: 100, y: 100, z: 100 },
+        },
+        { maxChunks: 8 },
+      ),
+    ).toEqual({ x: 50, y: 50, z: 50 });
+  });
+
+  it("rejects NaN bounds", () => {
+    expect(() =>
+      getDefaultSpatiallyIndexedSkeletonChunkSize({
+        min: { x: Number.NaN, y: 0, z: 0 },
+        max: { x: 10, y: 10, z: 10 },
+      }),
+    ).toThrow(/bounds must be finite/i);
+  });
+
+  it("rejects infinite bounds", () => {
+    expect(() =>
+      getDefaultSpatiallyIndexedSkeletonChunkSize({
+        min: { x: 0, y: 0, z: 0 },
+        max: { x: Number.POSITIVE_INFINITY, y: 10, z: 10 },
+      }),
+    ).toThrow(/bounds must be finite/i);
+  });
+
+  it("rejects NaN minChunkSize", () => {
+    expect(() =>
+      getDefaultSpatiallyIndexedSkeletonChunkSize(
+        {
+          min: { x: 0, y: 0, z: 0 },
+          max: { x: 10, y: 10, z: 10 },
+        },
+        { minChunkSize: Number.NaN },
+      ),
+    ).toThrow(/minChunkSize must be finite/i);
+  });
+
+  it("rejects infinite maxChunks", () => {
+    expect(() =>
+      getDefaultSpatiallyIndexedSkeletonChunkSize(
+        {
+          min: { x: 0, y: 0, z: 0 },
+          max: { x: 10, y: 10, z: 10 },
+        },
+        { maxChunks: Number.POSITIVE_INFINITY },
+      ),
+    ).toThrow(/maxChunks must be finite/i);
+  });
+});

--- a/src/skeleton/spatial_chunk_sizing.ts
+++ b/src/skeleton/spatial_chunk_sizing.ts
@@ -1,0 +1,122 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const DEFAULT_SPATIALLY_INDEXED_SKELETON_MAX_CHUNKS = 64;
+const DEFAULT_SPATIALLY_INDEXED_SKELETON_MIN_CHUNK_SIZE = 1;
+
+export interface SpatiallyIndexedSkeletonBounds {
+  min: { x: number; y: number; z: number };
+  max: { x: number; y: number; z: number };
+}
+
+export interface SpatiallyIndexedSkeletonChunkSize {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface DefaultSpatiallyIndexedSkeletonChunkSizeOptions {
+  maxChunks?: number;
+  minChunkSize?: number;
+}
+
+function validateFiniteOptions(
+  options: DefaultSpatiallyIndexedSkeletonChunkSizeOptions,
+) {
+  if (
+    options.minChunkSize !== undefined &&
+    !Number.isFinite(options.minChunkSize)
+  ) {
+    throw new Error(
+      "Spatially indexed skeleton minChunkSize must be finite.",
+    );
+  }
+  if (options.maxChunks !== undefined && !Number.isFinite(options.maxChunks)) {
+    throw new Error("Spatially indexed skeleton maxChunks must be finite.");
+  }
+}
+
+function validateFiniteBounds(bounds: SpatiallyIndexedSkeletonBounds) {
+  const values = [
+    ["min.x", bounds.min.x],
+    ["min.y", bounds.min.y],
+    ["min.z", bounds.min.z],
+    ["max.x", bounds.max.x],
+    ["max.y", bounds.max.y],
+    ["max.z", bounds.max.z],
+  ] as const;
+  for (const [name, value] of values) {
+    if (!Number.isFinite(value)) {
+      throw new Error(
+        `Spatially indexed skeleton bounds must be finite, but ${name} is ${value}.`,
+      );
+    }
+  }
+}
+
+function getChunkCoverageForChunkSize(
+  extents: readonly number[],
+  chunkSize: number,
+) {
+  return extents.reduce((product, extent) => {
+    const axisChunks = extent <= 0 ? 1 : Math.ceil(extent / chunkSize);
+    return product * axisChunks;
+  }, 1);
+}
+
+export function getDefaultSpatiallyIndexedSkeletonChunkSize(
+  bounds: SpatiallyIndexedSkeletonBounds,
+  options: DefaultSpatiallyIndexedSkeletonChunkSizeOptions = {},
+): SpatiallyIndexedSkeletonChunkSize {
+  validateFiniteOptions(options);
+  validateFiniteBounds(bounds);
+  const minChunkSize = Math.max(
+    DEFAULT_SPATIALLY_INDEXED_SKELETON_MIN_CHUNK_SIZE,
+    Math.ceil(
+      options.minChunkSize ??
+        DEFAULT_SPATIALLY_INDEXED_SKELETON_MIN_CHUNK_SIZE,
+    ),
+  );
+  const maxChunks = Math.max(
+    1,
+    Math.floor(options.maxChunks ?? DEFAULT_SPATIALLY_INDEXED_SKELETON_MAX_CHUNKS),
+  );
+  const extents = [
+    Math.max(0, bounds.max.x - bounds.min.x),
+    Math.max(0, bounds.max.y - bounds.min.y),
+    Math.max(0, bounds.max.z - bounds.min.z),
+  ] as const;
+  const maxExtent = Math.max(...extents);
+
+  if (!(maxExtent > 0)) {
+    return { x: minChunkSize, y: minChunkSize, z: minChunkSize };
+  }
+
+  // Choose the smallest isotropic chunk size that keeps the full bounding box
+  // coverage within the requested chunk budget.
+  let low = minChunkSize;
+  let high = Math.max(minChunkSize, Math.ceil(maxExtent));
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2);
+    if (getChunkCoverageForChunkSize(extents, mid) <= maxChunks) {
+      high = mid;
+    } else {
+      low = mid + 1;
+    }
+  }
+
+  return { x: low, y: low, z: low };
+}

--- a/src/skeleton/spatial_skeleton_manager.spec.ts
+++ b/src/skeleton/spatial_skeleton_manager.spec.ts
@@ -33,6 +33,7 @@ describe("skeleton/spatial_skeleton_manager", () => {
       getSkeleton: async () => [],
       fetchNodes: async () => [],
       getSpatialIndexMetadata: async () => null,
+      getSkeletonRootNode: async () => ({ nodeId: 1, x: 1, y: 2, z: 3 }),
       addNode: async () => ({ treenodeId: 1, skeletonId: 1 }),
       insertNode: async () => ({ treenodeId: 1, skeletonId: 1 }),
       moveNode: async () => {},

--- a/src/skeleton/spatial_skeleton_manager.ts
+++ b/src/skeleton/spatial_skeleton_manager.ts
@@ -65,6 +65,7 @@ export function isEditableSpatiallyIndexedSkeletonSource(
     hasFunction(value, "removeTrueEnd") &&
     hasFunction(value, "updateRadius") &&
     hasFunction(value, "updateConfidence") &&
+    hasFunction(value, "getSkeletonRootNode") &&
     hasFunction(value, "mergeSkeletons") &&
     hasFunction(value, "splitSkeleton")
   );

--- a/src/ui/spatial_skeleton_edit_tool.spec.ts
+++ b/src/ui/spatial_skeleton_edit_tool.spec.ts
@@ -70,6 +70,9 @@ function suppressStatusMessages() {
   vi.spyOn(StatusMessage, "showTemporaryMessage").mockImplementation(
     (_message: string, _closeAfter?: number) => fakeStatusMessage,
   );
+  vi.spyOn(StatusMessage, "showMessage").mockImplementation(
+    (_message: string) => fakeStatusMessage,
+  );
 }
 
 describe("spatial_skeleton_edit_tool", () => {

--- a/src/ui/spatial_skeleton_edit_tool.spec.ts
+++ b/src/ui/spatial_skeleton_edit_tool.spec.ts
@@ -46,6 +46,7 @@ function makeEditableSkeletonSource(overrides: Record<string, unknown> = {}) {
     getSkeleton: vi.fn(),
     fetchNodes: vi.fn(),
     getSpatialIndexMetadata: vi.fn(),
+    getSkeletonRootNode: vi.fn(),
     addNode: vi.fn(),
     insertNode: vi.fn(),
     moveNode: vi.fn(),
@@ -444,5 +445,60 @@ describe("spatial_skeleton_edit_tool", () => {
     expect(visibleSegmentsState.visibleSegments.has(11n)).toBe(false);
     expect(skeletonLayer.invalidateSourceCaches).toHaveBeenCalledTimes(1);
     expect(clearSpatialSkeletonMergeAnchor).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the merge anchor when the clear-selection action runs in merge mode", () => {
+    suppressStatusMessages();
+    const bindClearSelectionAction = (
+      SpatialSkeletonEditModeTool.prototype as any
+    ).bindClearSelectionAction as (this: any, activation: any) => void;
+    const clearSpatialSkeletonNodeSelection = vi.fn();
+    const clearSpatialSkeletonMergeAnchor = vi.fn();
+    const unpin = vi.fn();
+    let clearSelectionHandler: ((event: any) => void) | undefined;
+    const activation = {
+      bindAction: vi.fn((action: string, handler: (event: any) => void) => {
+        if (action === "spatial-skeleton-clear-node-selection") {
+          clearSelectionHandler = handler;
+        }
+      }),
+    };
+    const tool = {
+      layer: {
+        selectedSpatialSkeletonNodeId: { value: undefined },
+        spatialSkeletonState: {
+          mergeAnchorNodeId: { value: 101 },
+        },
+        clearSpatialSkeletonNodeSelection,
+        clearSpatialSkeletonMergeAnchor,
+        manager: {
+          root: {
+            selectionState: {
+              value: undefined,
+              unpin,
+            },
+          },
+        },
+      },
+    };
+
+    bindClearSelectionAction.call(tool, activation);
+
+    expect(clearSelectionHandler).toBeDefined();
+    clearSelectionHandler?.({
+      stopPropagation: vi.fn(),
+      detail: {
+        button: 2,
+        ctrlKey: true,
+        shiftKey: true,
+        preventDefault: vi.fn(),
+      },
+    });
+
+    expect(clearSpatialSkeletonNodeSelection).toHaveBeenCalledWith(
+      "force-unpin",
+    );
+    expect(clearSpatialSkeletonMergeAnchor).toHaveBeenCalledTimes(1);
+    expect(unpin).not.toHaveBeenCalled();
   });
 });

--- a/src/ui/spatial_skeleton_edit_tool.ts
+++ b/src/ui/spatial_skeleton_edit_tool.ts
@@ -174,12 +174,15 @@ abstract class SpatialSkeletonToolBase extends LayerTool<SegmentationUserLayer> 
     | {
         nodeId: number;
         segmentId?: number;
+        position?: Float32Array;
+        revisionToken?: string;
       }
     | undefined {
     if (!this.mouseState.updateUnconditionally() || !this.mouseState.active) {
       return undefined;
     }
-    const nodeIdRaw = this.mouseState.pickedSpatialSkeletonNodeId;
+    const pickedSpatialSkeleton = this.mouseState.pickedSpatialSkeleton;
+    const nodeIdRaw = pickedSpatialSkeleton?.nodeId;
     if (
       typeof nodeIdRaw !== "number" ||
       !Number.isSafeInteger(nodeIdRaw) ||
@@ -187,14 +190,19 @@ abstract class SpatialSkeletonToolBase extends LayerTool<SegmentationUserLayer> 
     ) {
       return undefined;
     }
-    const nodeId = nodeIdRaw;
-    const segmentIdRaw = this.mouseState.pickedSpatialSkeletonSegmentId;
+    const segmentIdRaw = pickedSpatialSkeleton?.segmentId;
+    const position = pickedSpatialSkeleton?.position;
+    const revisionToken = pickedSpatialSkeleton?.revisionToken;
     return {
-      nodeId,
+      nodeId: nodeIdRaw,
       segmentId:
         typeof segmentIdRaw === "number" && Number.isSafeInteger(segmentIdRaw)
           ? segmentIdRaw
           : undefined,
+      position:
+        position instanceof Float32Array ? new Float32Array(position) : undefined,
+      revisionToken:
+        typeof revisionToken === "string" ? revisionToken : undefined,
     };
   }
 
@@ -202,7 +210,7 @@ abstract class SpatialSkeletonToolBase extends LayerTool<SegmentationUserLayer> 
     if (!this.mouseState.updateUnconditionally() || !this.mouseState.active) {
       return undefined;
     }
-    const segmentIdRaw = this.mouseState.pickedSpatialSkeletonSegmentId;
+    const segmentIdRaw = this.mouseState.pickedSpatialSkeleton?.segmentId;
     if (
       typeof segmentIdRaw !== "number" ||
       !Number.isSafeInteger(segmentIdRaw) ||
@@ -354,10 +362,43 @@ abstract class SpatialSkeletonToolBase extends LayerTool<SegmentationUserLayer> 
       return undefined;
     }
     const resolvedNodeInfo = skeletonLayer.getNode(nodeHit.nodeId);
+    if (resolvedNodeInfo === undefined) {
+      return undefined;
+    }
     return {
       nodeId: nodeHit.nodeId,
       segmentId: nodeHit.segmentId ?? resolvedNodeInfo?.segmentId,
-      position: resolvedNodeInfo?.position,
+      position: nodeHit.position ?? resolvedNodeInfo.position,
+    };
+  }
+
+  protected resolvePickedNodeSelectionForMerge(
+    skeletonLayer: SpatiallyIndexedSkeletonLayer,
+  ):
+    | {
+        nodeId: number;
+        segmentId?: number;
+        position?: Float32Array;
+        revisionToken?: string;
+        visible: boolean;
+      }
+    | undefined {
+    const nodeHit = this.getPickedSpatialSkeletonNode();
+    if (nodeHit === undefined) {
+      return undefined;
+    }
+    const resolvedNodeInfo =
+      skeletonLayer.getNode(nodeHit.nodeId) ??
+      this.layer.spatialSkeletonState.getCachedNode(nodeHit.nodeId);
+    const segmentId = nodeHit.segmentId ?? resolvedNodeInfo?.segmentId;
+    return {
+      nodeId: nodeHit.nodeId,
+      segmentId,
+      position: nodeHit.position ?? resolvedNodeInfo?.position,
+      revisionToken: nodeHit.revisionToken ?? resolvedNodeInfo?.revisionToken,
+      visible:
+        segmentId !== undefined &&
+        this.isSpatialSkeletonSegmentVisible(segmentId),
     };
   }
 
@@ -1017,20 +1058,34 @@ class SpatialSkeletonMergeModeTool extends SpatialSkeletonToolBase {
       makeToolActivationStatusMessageWithHeader(activation);
     header.textContent = "Spatial skeleton merge mode";
     let pending = false;
+    type MergeAnchorSelection = {
+      nodeId: number;
+      segmentId?: number;
+      position?: ArrayLike<number>;
+      revisionToken?: string;
+    };
+    let anchorSelection: MergeAnchorSelection | undefined;
     let statusOverride: string | undefined;
-    const getAnchorNode = () => {
+    const getAnchorNode = (): MergeAnchorSelection | undefined => {
       const nodeId = this.layer.spatialSkeletonState.mergeAnchorNodeId.value;
       if (nodeId === undefined || !Number.isSafeInteger(nodeId)) {
+        anchorSelection = undefined;
         return undefined;
+      }
+      if (anchorSelection?.nodeId === nodeId) {
+        return anchorSelection;
       }
       const cachedNode =
         this.getActiveSpatiallyIndexedSkeletonLayer()?.getNode(nodeId) ??
         this.layer.spatialSkeletonState.getCachedNode(nodeId);
-      return {
+      const anchorNode = {
         nodeId,
         segmentId: cachedNode?.segmentId,
         position: cachedNode?.position,
+        revisionToken: cachedNode?.revisionToken,
       };
+      anchorSelection = anchorNode;
+      return anchorNode;
     };
     const renderStatus = () => {
       const anchorNode = getAnchorNode();
@@ -1093,7 +1148,9 @@ class SpatialSkeletonMergeModeTool extends SpatialSkeletonToolBase {
           );
           return;
         }
-        const pickedNode = this.resolvePickedNodeSelection(skeletonLayer);
+        const pickedNode = this.resolvePickedNodeSelectionForMerge(
+          skeletonLayer,
+        );
         const anchorNode = getAnchorNode();
         if (pickedNode === undefined) {
           const pickedSegmentId = this.getPickedSpatialSkeletonSegment();
@@ -1112,11 +1169,23 @@ class SpatialSkeletonMergeModeTool extends SpatialSkeletonToolBase {
         if (pickedNode === undefined || pickedNode.segmentId === undefined) {
           return;
         }
-        this.pinSegmentByNumber(pickedNode.segmentId);
         if (
           anchorNode === undefined ||
           anchorNode.nodeId === pickedNode.nodeId
         ) {
+          if (!pickedNode.visible) {
+            StatusMessage.showTemporaryMessage(
+              "Pick the first merge anchor from a visible segment.",
+            );
+            return;
+          }
+          this.pinSegmentByNumber(pickedNode.segmentId);
+          anchorSelection = {
+            nodeId: pickedNode.nodeId,
+            segmentId: pickedNode.segmentId,
+            position: pickedNode.position,
+            revisionToken: pickedNode.revisionToken,
+          };
           this.layer.setSpatialSkeletonMergeAnchor(pickedNode.nodeId);
           this.layer.selectSpatialSkeletonNode(pickedNode.nodeId, true, {
             segmentId: pickedNode.segmentId,
@@ -1126,6 +1195,19 @@ class SpatialSkeletonMergeModeTool extends SpatialSkeletonToolBase {
           return;
         }
         if (anchorNode.segmentId === pickedNode.segmentId) {
+          if (!pickedNode.visible) {
+            StatusMessage.showTemporaryMessage(
+              "Pick the first merge anchor from a visible segment.",
+            );
+            return;
+          }
+          this.pinSegmentByNumber(pickedNode.segmentId);
+          anchorSelection = {
+            nodeId: pickedNode.nodeId,
+            segmentId: pickedNode.segmentId,
+            position: pickedNode.position,
+            revisionToken: pickedNode.revisionToken,
+          };
           this.layer.setSpatialSkeletonMergeAnchor(pickedNode.nodeId);
           this.layer.selectSpatialSkeletonNode(pickedNode.nodeId, true, {
             segmentId: pickedNode.segmentId,
@@ -1139,16 +1221,18 @@ class SpatialSkeletonMergeModeTool extends SpatialSkeletonToolBase {
           nodeId: pickedNode.nodeId,
           segmentId: pickedNode.segmentId,
           position: pickedNode.position,
+          revisionToken: pickedNode.revisionToken,
         };
         if (
           firstNode.segmentId === undefined ||
           secondNode.segmentId === undefined
         ) {
           StatusMessage.showTemporaryMessage(
-            "Load both skeletons in the Skeleton tab before merging them.",
+            "Unable to resolve both merge segments.",
           );
           return;
         }
+        this.pinSegmentByNumber(pickedNode.segmentId);
         pending = true;
         setStatus("Merging selected nodes.");
         void (async () => {
@@ -1158,10 +1242,12 @@ class SpatialSkeletonMergeModeTool extends SpatialSkeletonToolBase {
               {
                 nodeId: firstNode.nodeId,
                 segmentId: firstNode.segmentId!,
+                revisionToken: firstNode.revisionToken,
               },
               {
                 nodeId: secondNode.nodeId,
                 segmentId: secondNode.segmentId!,
+                revisionToken: secondNode.revisionToken,
               },
             );
           } catch (error) {

--- a/src/ui/spatial_skeleton_edit_tool.ts
+++ b/src/ui/spatial_skeleton_edit_tool.ts
@@ -114,6 +114,16 @@ const SPATIAL_SKELETON_PICK_AUX_INPUT_EVENT_MAP = EventActionMap.fromObject({
 
 const DRAG_START_DISTANCE_PX = 4;
 
+function waitForNextAnimationFrame() {
+  return new Promise<void>((resolve) => {
+    if (typeof requestAnimationFrame !== "function") {
+      window.setTimeout(resolve, 0);
+      return;
+    }
+    requestAnimationFrame(() => resolve());
+  });
+}
+
 function renderSpatialSkeletonToolStatus(
   body: HTMLElement,
   options: {
@@ -1233,10 +1243,15 @@ class SpatialSkeletonMergeModeTool extends SpatialSkeletonToolBase {
           return;
         }
         this.pinSegmentByNumber(pickedNode.segmentId);
+        this.layer.selectSpatialSkeletonNode(pickedNode.nodeId, true, {
+          segmentId: pickedNode.segmentId,
+          position: pickedNode.position,
+        });
         pending = true;
         setStatus("Merging selected nodes.");
         void (async () => {
           try {
+            await waitForNextAnimationFrame();
             await executeSpatialSkeletonMerge(
               this.layer,
               {


### PR DESCRIPTION
Closes https://metacell.atlassian.net/browse/NA-718

- the pick pipeline now carries full node metadata {nodeId, segmentId, position, revisionToken} out of rendered chunks
- the merge tool now allows the use of a node from a non-visible segment as second anchor
- we now remember the losing skeleton’s root via a lightweight root endpoint call (if needed) so undo can still split and reroot correctly
- adds pending status messages for async add/delete/split/merge operations


https://github.com/user-attachments/assets/23747aec-06b2-4b48-b877-05e0ee29ea27

