### PR TITLE
feat: Update default grid size and rename catmaid metadata key

### DIFF
--- a/src/datasource/catmaid/api.spec.ts
+++ b/src/datasource/catmaid/api.spec.ts
@@ -69,12 +69,42 @@ describe("CatmaidClient skeleton editing methods", () => {
         max: { x: 25, y: 66, z: 127 },
       },
       resolution: { x: 2, y: 3, z: 4 },
-      gridCellSizes: [{ x: 25000, y: 25000, z: 40 }],
+      gridCellSizes: [{ x: 15, y: 15, z: 15 }],
     });
 
     expect((client as any).listStacks).toHaveBeenCalledTimes(2);
     expect((client as any).getStackInfo).toHaveBeenCalledTimes(1);
     warnSpy.mockRestore();
+  });
+
+  it("reads spatial skeleton chunk sizes from stack metadata", async () => {
+    const client = new CatmaidClient("https://example.invalid", 1);
+    (client as any).listStacks = vi.fn().mockResolvedValue([{ id: 7 }]);
+    (client as any).getStackInfo = vi.fn().mockResolvedValue({
+      dimension: { x: 10, y: 20, z: 30 },
+      resolution: { x: 2, y: 3, z: 4 },
+      translation: { x: 5, y: 6, z: 7 },
+      metadata: {
+        spatial_skeleton_chunk_sizes: [
+          [120, 120, 120],
+          [60, 60, 60],
+          [30, 30, 30],
+        ],
+      },
+    });
+
+    await expect(client.getSpatialIndexMetadata()).resolves.toEqual({
+      bounds: {
+        min: { x: 5, y: 6, z: 7 },
+        max: { x: 25, y: 66, z: 127 },
+      },
+      resolution: { x: 2, y: 3, z: 4 },
+      gridCellSizes: [
+        { x: 120, y: 120, z: 120 },
+        { x: 60, y: 60, z: 60 },
+        { x: 30, y: 30, z: 30 },
+      ],
+    });
   });
 
   it("parses live compact-detail history rows and label maps", async () => {

--- a/src/datasource/catmaid/api.ts
+++ b/src/datasource/catmaid/api.ts
@@ -37,14 +37,10 @@ import type {
 import {
   SPATIALLY_INDEXED_SKELETON_CONFIDENCE_VALUES,
 } from "#src/skeleton/api.js";
+import {
+  getDefaultSpatiallyIndexedSkeletonChunkSize,
+} from "#src/skeleton/spatial_chunk_sizing.js";
 import { HttpError } from "#src/util/http_request.js";
-
-interface CatmaidCacheConfiguration {
-  cache_type: string;
-  cell_width: number;
-  cell_height: number;
-  cell_depth: number;
-}
 
 interface CatmaidStackInfo {
   dimension: { x: number; y: number; z: number };
@@ -52,7 +48,7 @@ interface CatmaidStackInfo {
   translation: { x: number; y: number; z: number };
   metadata?: {
     cache_provider?: string;
-    cache_configurations?: CatmaidCacheConfiguration[];
+    spatial_skeleton_chunk_sizes?: Array<readonly [number, number, number]>;
   };
 }
 
@@ -61,9 +57,6 @@ export interface CatmaidToken {
 }
 
 export const credentialsKey = "CATMAID";
-const DEFAULT_CACHE_GRID_CELL_WIDTH = 25000;
-const DEFAULT_CACHE_GRID_CELL_HEIGHT = 25000;
-const DEFAULT_CACHE_GRID_CELL_DEPTH = 40;
 const CATMAID_NO_MATCHING_NODE_PROVIDER_ERROR =
   "Could not find matching node provider for request";
 const CATMAID_STATE_MATCHING_ERROR_TYPE = "StateMatchingError";
@@ -993,30 +986,32 @@ export class CatmaidClient implements EditableSpatiallyIndexedSkeletonSource {
   }
 
   private getGridCellSizesFromMetadataInfo(
-    info: CatmaidStackInfo | null,
+    info: CatmaidStackInfo,
+    bounds = getCatmaidProjectSpaceBounds(info),
   ): Array<{ x: number; y: number; z: number }> {
     const gridSizes: Array<{ x: number; y: number; z: number }> = [];
 
-    // Try to get all grid cell sizes from metadata
-    if (info?.metadata?.cache_configurations) {
-      for (const config of info.metadata.cache_configurations) {
-        if (config.cache_type === "grid") {
+    // Try to get all allowed spatial skeleton chunk sizes from metadata.
+    if (info.metadata?.spatial_skeleton_chunk_sizes) {
+      for (const chunkSize of info.metadata.spatial_skeleton_chunk_sizes) {
+        if (
+          chunkSize.length === 3 &&
+          Number.isFinite(chunkSize[0]) &&
+          Number.isFinite(chunkSize[1]) &&
+          Number.isFinite(chunkSize[2])
+        ) {
           gridSizes.push({
-            x: config.cell_width,
-            y: config.cell_height,
-            z: config.cell_depth,
+            x: chunkSize[0],
+            y: chunkSize[1],
+            z: chunkSize[2],
           });
         }
       }
     }
 
-    // If no grid configs found, use default
+    // If no chunk sizes are specified, use the bounds-derived default.
     if (gridSizes.length === 0) {
-      gridSizes.push({
-        x: DEFAULT_CACHE_GRID_CELL_WIDTH,
-        y: DEFAULT_CACHE_GRID_CELL_HEIGHT,
-        z: DEFAULT_CACHE_GRID_CELL_DEPTH,
-      });
+      gridSizes.push(getDefaultSpatiallyIndexedSkeletonChunkSize(bounds));
     }
 
     return gridSizes;
@@ -1027,10 +1022,11 @@ export class CatmaidClient implements EditableSpatiallyIndexedSkeletonSource {
     if (info === null) {
       return null;
     }
+    const bounds = getCatmaidProjectSpaceBounds(info);
     return {
-      bounds: getCatmaidProjectSpaceBounds(info),
+      bounds,
       resolution: info.resolution,
-      gridCellSizes: this.getGridCellSizesFromMetadataInfo(info),
+      gridCellSizes: this.getGridCellSizesFromMetadataInfo(info, bounds),
     };
   }
 

--- a/src/skeleton/spatial_chunk_sizing.spec.ts
+++ b/src/skeleton/spatial_chunk_sizing.spec.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getDefaultSpatiallyIndexedSkeletonChunkSize,
+} from "#src/skeleton/spatial_chunk_sizing.js";
+
+describe("skeleton/spatial_chunk_sizing", () => {
+  it("derives an isotropic chunk size that stays within the default chunk budget", () => {
+    expect(
+      getDefaultSpatiallyIndexedSkeletonChunkSize({
+        min: { x: 5, y: 6, z: 7 },
+        max: { x: 25, y: 66, z: 127 },
+      }),
+    ).toEqual({ x: 15, y: 15, z: 15 });
+  });
+
+  it("handles elongated bounds while keeping the chunk size isotropic", () => {
+    expect(
+      getDefaultSpatiallyIndexedSkeletonChunkSize({
+        min: { x: 0, y: 0, z: 0 },
+        max: { x: 1000, y: 10, z: 10 },
+      }),
+    ).toEqual({ x: 16, y: 16, z: 16 });
+  });
+
+  it("returns the minimum chunk size for tiny bounds", () => {
+    expect(
+      getDefaultSpatiallyIndexedSkeletonChunkSize({
+        min: { x: 0, y: 0, z: 0 },
+        max: { x: 2, y: 2, z: 2 },
+      }),
+    ).toEqual({ x: 1, y: 1, z: 1 });
+  });
+
+  it("supports overriding the chunk budget", () => {
+    expect(
+      getDefaultSpatiallyIndexedSkeletonChunkSize(
+        {
+          min: { x: 0, y: 0, z: 0 },
+          max: { x: 100, y: 100, z: 100 },
+        },
+        { maxChunks: 8 },
+      ),
+    ).toEqual({ x: 50, y: 50, z: 50 });
+  });
+
+  it("rejects NaN bounds", () => {
+    expect(() =>
+      getDefaultSpatiallyIndexedSkeletonChunkSize({
+        min: { x: Number.NaN, y: 0, z: 0 },
+        max: { x: 10, y: 10, z: 10 },
+      }),
+    ).toThrow(/bounds must be finite/i);
+  });
+
+  it("rejects infinite bounds", () => {
+    expect(() =>
+      getDefaultSpatiallyIndexedSkeletonChunkSize({
+        min: { x: 0, y: 0, z: 0 },
+        max: { x: Number.POSITIVE_INFINITY, y: 10, z: 10 },
+      }),
+    ).toThrow(/bounds must be finite/i);
+  });
+
+  it("rejects NaN minChunkSize", () => {
+    expect(() =>
+      getDefaultSpatiallyIndexedSkeletonChunkSize(
+        {
+          min: { x: 0, y: 0, z: 0 },
+          max: { x: 10, y: 10, z: 10 },
+        },
+        { minChunkSize: Number.NaN },
+      ),
+    ).toThrow(/minChunkSize must be finite/i);
+  });
+
+  it("rejects infinite maxChunks", () => {
+    expect(() =>
+      getDefaultSpatiallyIndexedSkeletonChunkSize(
+        {
+          min: { x: 0, y: 0, z: 0 },
+          max: { x: 10, y: 10, z: 10 },
+        },
+        { maxChunks: Number.POSITIVE_INFINITY },
+      ),
+    ).toThrow(/maxChunks must be finite/i);
+  });
+});

--- a/src/skeleton/spatial_chunk_sizing.ts
+++ b/src/skeleton/spatial_chunk_sizing.ts
@@ -1,0 +1,122 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const DEFAULT_SPATIALLY_INDEXED_SKELETON_MAX_CHUNKS = 64;
+const DEFAULT_SPATIALLY_INDEXED_SKELETON_MIN_CHUNK_SIZE = 1;
+
+export interface SpatiallyIndexedSkeletonBounds {
+  min: { x: number; y: number; z: number };
+  max: { x: number; y: number; z: number };
+}
+
+export interface SpatiallyIndexedSkeletonChunkSize {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface DefaultSpatiallyIndexedSkeletonChunkSizeOptions {
+  maxChunks?: number;
+  minChunkSize?: number;
+}
+
+function validateFiniteOptions(
+  options: DefaultSpatiallyIndexedSkeletonChunkSizeOptions,
+) {
+  if (
+    options.minChunkSize !== undefined &&
+    !Number.isFinite(options.minChunkSize)
+  ) {
+    throw new Error(
+      "Spatially indexed skeleton minChunkSize must be finite.",
+    );
+  }
+  if (options.maxChunks !== undefined && !Number.isFinite(options.maxChunks)) {
+    throw new Error("Spatially indexed skeleton maxChunks must be finite.");
+  }
+}
+
+function validateFiniteBounds(bounds: SpatiallyIndexedSkeletonBounds) {
+  const values = [
+    ["min.x", bounds.min.x],
+    ["min.y", bounds.min.y],
+    ["min.z", bounds.min.z],
+    ["max.x", bounds.max.x],
+    ["max.y", bounds.max.y],
+    ["max.z", bounds.max.z],
+  ] as const;
+  for (const [name, value] of values) {
+    if (!Number.isFinite(value)) {
+      throw new Error(
+        `Spatially indexed skeleton bounds must be finite, but ${name} is ${value}.`,
+      );
+    }
+  }
+}
+
+function getChunkCoverageForChunkSize(
+  extents: readonly number[],
+  chunkSize: number,
+) {
+  return extents.reduce((product, extent) => {
+    const axisChunks = extent <= 0 ? 1 : Math.ceil(extent / chunkSize);
+    return product * axisChunks;
+  }, 1);
+}
+
+export function getDefaultSpatiallyIndexedSkeletonChunkSize(
+  bounds: SpatiallyIndexedSkeletonBounds,
+  options: DefaultSpatiallyIndexedSkeletonChunkSizeOptions = {},
+): SpatiallyIndexedSkeletonChunkSize {
+  validateFiniteOptions(options);
+  validateFiniteBounds(bounds);
+  const minChunkSize = Math.max(
+    DEFAULT_SPATIALLY_INDEXED_SKELETON_MIN_CHUNK_SIZE,
+    Math.ceil(
+      options.minChunkSize ??
+        DEFAULT_SPATIALLY_INDEXED_SKELETON_MIN_CHUNK_SIZE,
+    ),
+  );
+  const maxChunks = Math.max(
+    1,
+    Math.floor(options.maxChunks ?? DEFAULT_SPATIALLY_INDEXED_SKELETON_MAX_CHUNKS),
+  );
+  const extents = [
+    Math.max(0, bounds.max.x - bounds.min.x),
+    Math.max(0, bounds.max.y - bounds.min.y),
+    Math.max(0, bounds.max.z - bounds.min.z),
+  ] as const;
+  const maxExtent = Math.max(...extents);
+
+  if (!(maxExtent > 0)) {
+    return { x: minChunkSize, y: minChunkSize, z: minChunkSize };
+  }
+
+  // Choose the smallest isotropic chunk size that keeps the full bounding box
+  // coverage within the requested chunk budget.
+  let low = minChunkSize;
+  let high = Math.max(minChunkSize, Math.ceil(maxExtent));
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2);
+    if (getChunkCoverageForChunkSize(extents, mid) <= maxChunks) {
+      high = mid;
+    } else {
+      low = mid + 1;
+    }
+  }
+
+  return { x: low, y: low, z: low };
+}


### PR DESCRIPTION
Closes https://metacell.atlassian.net/browse/NA-688

- Adds a new helper that computes a default isotropic spatial-skeleton chunk size from dataset bounds, targeting at most 64 chunks over the full bounding box
- Changes the CATMAID datasource metadata contract: Instead of reading metadata.cache_configurations as a 1:1 mapping to chunk sizes, Neuroglancer now reads metadata.spatial_skeleton_chunk_sizes. If that property is absent, it falls back to the new bounds-derived chunk-size helper.

<img width="2556" height="1354" alt="image" src="https://github.com/user-attachments/assets/9d8ec3ff-35b3-4b20-9210-7b0796aeeaef" />
