### PR TITLE
Debug: chunk debugging in spatial index

### DIFF
--- a/src/datasource/catmaid/api.ts
+++ b/src/datasource/catmaid/api.ts
@@ -38,8 +38,6 @@ import { SPATIALLY_INDEXED_SKELETON_CONFIDENCE_VALUES } from "#src/skeleton/api.
 import { getDefaultSpatiallyIndexedSkeletonChunkSize } from "#src/skeleton/spatial_chunk_sizing.js";
 import { HttpError } from "#src/util/http_request.js";
 
-const DEBUG_DISABLE_ACROSS_CHUNK_NODES = false;
-
 interface CatmaidStackInfo {
   dimension: { x: number; y: number; z: number };
   resolution: { x: number; y: number; z: number };
@@ -1207,19 +1205,6 @@ export class CatmaidClient implements EditableSpatiallyIndexedSkeletonSource {
           }
         }
       }
-    }
-
-    if (DEBUG_DISABLE_ACROSS_CHUNK_NODES) {
-      // Ensure nodes don't fall outside the bounding box
-      return nodes.filter(
-        (x) =>
-          x.position[0] >= boundingBox.min.x &&
-          x.position[0] <= boundingBox.max.x &&
-          x.position[1] >= boundingBox.min.y &&
-          x.position[1] <= boundingBox.max.y &&
-          x.position[2] >= boundingBox.min.z &&
-          x.position[2] <= boundingBox.max.z,
-      );
     }
 
     return nodes;

--- a/src/datasource/catmaid/api.ts
+++ b/src/datasource/catmaid/api.ts
@@ -38,7 +38,7 @@ import { SPATIALLY_INDEXED_SKELETON_CONFIDENCE_VALUES } from "#src/skeleton/api.
 import { getDefaultSpatiallyIndexedSkeletonChunkSize } from "#src/skeleton/spatial_chunk_sizing.js";
 import { HttpError } from "#src/util/http_request.js";
 
-const DEBUG_DISABLE_ACROSS_CHUNK_NODES = true;
+const DEBUG_DISABLE_ACROSS_CHUNK_NODES = false;
 
 interface CatmaidStackInfo {
   dimension: { x: number; y: number; z: number };

--- a/src/datasource/catmaid/api.ts
+++ b/src/datasource/catmaid/api.ts
@@ -38,6 +38,8 @@ import { SPATIALLY_INDEXED_SKELETON_CONFIDENCE_VALUES } from "#src/skeleton/api.
 import { getDefaultSpatiallyIndexedSkeletonChunkSize } from "#src/skeleton/spatial_chunk_sizing.js";
 import { HttpError } from "#src/util/http_request.js";
 
+const DEBUG_DISABLE_ACROSS_CHUNK_NODES = true;
+
 interface CatmaidStackInfo {
   dimension: { x: number; y: number; z: number };
   resolution: { x: number; y: number; z: number };
@@ -1205,6 +1207,19 @@ export class CatmaidClient implements EditableSpatiallyIndexedSkeletonSource {
           }
         }
       }
+    }
+
+    if (DEBUG_DISABLE_ACROSS_CHUNK_NODES) {
+      // Ensure nodes don't fall outside the bounding box
+      return nodes.filter(
+        (x) =>
+          x.position[0] >= boundingBox.min.x &&
+          x.position[0] <= boundingBox.max.x &&
+          x.position[1] >= boundingBox.min.y &&
+          x.position[1] <= boundingBox.max.y &&
+          x.position[2] >= boundingBox.min.z &&
+          x.position[2] <= boundingBox.max.z,
+      );
     }
 
     return nodes;

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -21,6 +21,7 @@ import {
   ChunkRenderLayerFrontend,
   ChunkSource,
 } from "#src/chunk_manager/frontend.js";
+import { hashCombine } from "#src/gpu_hash/hash_function.js";
 import { GPUHashTable, HashSetShaderManager } from "#src/gpu_hash/shader.js";
 import type {
   LayerView,
@@ -125,6 +126,7 @@ import {
 } from "#src/trackable_value.js";
 import { Uint64Set } from "#src/uint64_set.js";
 import { gatherUpdate } from "#src/util/array.js";
+import { hsvToRgb } from "#src/util/colorspace.js";
 import { DATA_TYPE_SIGNED, DataType } from "#src/util/data_type.js";
 import { RefCounted } from "#src/util/disposable.js";
 import type { ValueOrError } from "#src/util/error.js";
@@ -189,7 +191,7 @@ import type { RPC } from "#src/worker_rpc.js";
 
 const DEBUG_SPATIAL_SKELETON_OVERLAY = false;
 const DEBUG_EXCLUDED_SEGMENTS = false;
-const DEBUG_SPATIAL_SKELETON_CHUNKS = false;
+const DEBUG_SPATIAL_SKELETON_CHUNKS = true;
 // Used for debugging chunks via a different color for each chunk
 const tempChunkKeyToColorMap = new Map<string, Float32Array>();
 
@@ -2838,11 +2840,15 @@ export class SpatiallyIndexedSkeletonLayer
         const chunkKey = `${chunk.chunkGridPosition[0]},${chunk.chunkGridPosition[1]},${chunk.chunkGridPosition[2]}`;
         let randomColor = tempChunkKeyToColorMap.get(chunkKey);
         if (randomColor === undefined) {
-          randomColor = new Float32Array([
-            Math.random(),
-            Math.random(),
-            Math.random(),
-          ]);
+          // Use same strategy as segment color hashing to be consistent
+          // in colors across neuroglancer sessions
+          randomColor = new Float32Array([0, 0, 0]);
+          let h = hashCombine(0, chunk.chunkGridPosition[0]);
+          h = hashCombine(h, chunk.chunkGridPosition[1]);
+          h = hashCombine(h, chunk.chunkGridPosition[2]);
+          const c0 = (h & 0xff) / 255;
+          const c1 = ((h >> 8) & 0xff) / 255;
+          hsvToRgb(randomColor, c0, 0.5 + 0.5 * c1, 1.0);
           tempChunkKeyToColorMap.set(chunkKey, randomColor);
         }
         nodeShader.bind();

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -185,12 +185,11 @@ import type { RPC } from "#src/worker_rpc.js";
 
 const DEBUG_SPATIAL_SKELETON_OVERLAY = false;
 const DEBUG_EXCLUDED_SEGMENTS = false;
-const DEBUG_CHUNK_WIREFRAME = true;
+const DEBUG_CHUNK_WIREFRAME_3D = true;
 const DEBUG_CHUNK_COLORS = true;
 const tempChunkColorMap = new Map<vec3, Float32Array>();
 
-const tempMat2 = mat4.create();
-const tempWireframeMat = mat4.create();
+const tempMat4 = mat4.create();
 const DEFAULT_FRAGMENT_MAIN = `void main() {
   emitDefault();
 }
@@ -893,7 +892,7 @@ void emitDefault() {
     modelMatrix: mat4,
   ) {
     const { viewProjectionMat } = renderContext.projectionParameters;
-    const mat = mat4.multiply(tempMat2, viewProjectionMat, modelMatrix);
+    const mat = mat4.multiply(tempMat4, viewProjectionMat, modelMatrix);
     gl.uniformMatrix4fv(shader.uniform("uProjection"), false, mat);
     this.vertexIdHelper.enable();
   }
@@ -2979,10 +2978,7 @@ export class SpatiallyIndexedSkeletonLayer
     overlayRenderHelper: RenderHelper,
     browseRenderHelper: RenderHelper,
     renderOptions: ViewSpecificSkeletonRenderingOptions,
-    attachment: VisibleLayerInfo<
-      LayerView,
-      ThreeDimensionalRenderLayerAttachmentState
-    >,
+    modelMatrix: mat4,
     visibleChunks: SpatiallyIndexedSkeletonChunk[],
   ) {
     const { displayState } = this;
@@ -2992,12 +2988,6 @@ export class SpatiallyIndexedSkeletonLayer
     ) {
       return;
     }
-    const modelMatrix = update3dRenderLayerAttachment(
-      displayState.transform.value,
-      renderContext.projectionParameters.displayDimensionRenderInfo,
-      attachment,
-    );
-    if (modelMatrix === undefined) return;
 
     const lineWidth = renderOptions.lineWidth.value;
     const pointDiameter = getSkeletonNodeDiameter(
@@ -3287,38 +3277,37 @@ export class PerspectiveViewSpatiallyIndexedSkeletonLayer extends PerspectiveVie
         levels,
       );
     }
+    const modelMatrix = update3dRenderLayerAttachment(
+      displayState.transform.value,
+      renderContext.projectionParameters.displayDimensionRenderInfo,
+      attachment,
+    );
+    if (modelMatrix === undefined) return;
     this.base.draw(
       renderContext,
       this,
       this.renderHelper,
       this.browseRenderHelper,
       this.renderOptions,
-      attachment,
+      modelMatrix,
       visibleChunks,
     );
-    if (
-      DEBUG_CHUNK_WIREFRAME &&
-      renderContext.emitColor &&
-      visibleChunks.length > 0
-    ) {
-      this.drawChunkBoundsWireframe(renderContext, attachment, visibleChunks);
+    if (DEBUG_CHUNK_WIREFRAME_3D) {
+      this.drawChunkBoundsWireframe(renderContext, visibleChunks, modelMatrix);
     }
   }
 
   private drawChunkBoundsWireframe(
     renderContext: PerspectiveViewRenderContext,
-    attachment: VisibleLayerInfo<
-      PerspectivePanel,
-      ThreeDimensionalRenderLayerAttachmentState
-    >,
     visibleChunks: SpatiallyIndexedSkeletonChunk[],
+    modelMatrix?: mat4,
   ) {
-    const modelMatrix = update3dRenderLayerAttachment(
-      this.base.displayState.transform.value,
-      renderContext.projectionParameters.displayDimensionRenderInfo,
-      attachment,
-    );
-    if (modelMatrix === undefined) return;
+    if (
+      visibleChunks.length === 0 ||
+      !renderContext.emitColor ||
+      modelMatrix === undefined
+    )
+      return;
 
     // Build source → chunkLayout lookup from the current transformed sources.
     const chunkLayoutBySource = new Map<object, ChunkLayout>();
@@ -3330,32 +3319,28 @@ export class PerspectiveViewSpatiallyIndexedSkeletonLayer extends PerspectiveVie
       }
     }
 
-    const wireframeHelper = ChunkWireframeHelper.get(this.base.gl);
+    const { gl } = this.base;
+    const wireframeHelper = ChunkWireframeHelper.get(gl);
     const shader = wireframeHelper.getShader(renderContext.emitter);
     shader.bind();
     const { viewProjectionMat } = renderContext.projectionParameters;
-    const gl = this.base.gl;
 
     for (const chunk of visibleChunks) {
       const chunkLayout = chunkLayoutBySource.get(chunk.source);
       if (chunkLayout === undefined) continue;
 
       // Compose: clip ← view-projection ← model ← chunk-layout-transform
-      mat4.multiply(tempWireframeMat, viewProjectionMat, modelMatrix);
-      mat4.multiply(tempWireframeMat, tempWireframeMat, chunkLayout.transform);
-      gl.uniformMatrix4fv(
-        shader.uniform("uChunkToClip"),
-        false,
-        tempWireframeMat,
-      );
+      mat4.multiply(tempMat4, viewProjectionMat, modelMatrix);
+      mat4.multiply(tempMat4, tempMat4, chunkLayout.transform);
+      gl.uniformMatrix4fv(shader.uniform("uChunkToClip"), false, tempMat4);
 
       const { size } = chunkLayout;
-      const gp = chunk.chunkGridPosition;
+      const gridPosition = chunk.chunkGridPosition;
       gl.uniform3f(
         shader.uniform("uChunkMin"),
-        gp[0] * size[0],
-        gp[1] * size[1],
-        gp[2] * size[2],
+        gridPosition[0] * size[0],
+        gridPosition[1] * size[1],
+        gridPosition[2] * size[2],
       );
       gl.uniform3f(shader.uniform("uChunkSize"), size[0], size[1], size[2]);
       gl.drawArrays(WebGL2RenderingContext.LINES, 0, 24);
@@ -3648,13 +3633,19 @@ export class SliceViewPanelSpatiallyIndexedSkeletonLayer extends SliceViewPanelR
         levels,
       );
     }
+    const modelMatrix = update3dRenderLayerAttachment(
+      displayState.transform.value,
+      renderContext.projectionParameters.displayDimensionRenderInfo,
+      attachment,
+    );
+    if (modelMatrix === undefined) return;
     this.base.draw(
       renderContext,
       this,
       this.renderHelper,
       this.browseRenderHelper,
       this.renderOptions,
-      attachment,
+      modelMatrix,
       visibleChunks,
     );
   }

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -2202,17 +2202,15 @@ export class SpatiallyIndexedSkeletonLayer
       return undefined;
     }
     this.inspectionState.evictInactiveSegmentNodes(overlaySegmentIds);
-    const segmentNodeSets: SpatiallyIndexedSkeletonNode[][] = [];
+
+    // Pass 1: cheap scan to determine which segments are loaded and check cache.
     const loadedSegmentIds: number[] = [];
     for (const segmentId of overlaySegmentIds) {
-      const segmentNodes =
-        this.inspectionState.getCachedSegmentNodes(segmentId);
-      if (segmentNodes === undefined) {
+      if (this.inspectionState.getCachedSegmentNodes(segmentId) !== undefined) {
+        loadedSegmentIds.push(segmentId);
+      } else {
         this.requestOverlaySegmentLoad(segmentId);
-        continue;
       }
-      loadedSegmentIds.push(segmentId);
-      segmentNodeSets.push(segmentNodes.map((node) => node));
     }
     if (loadedSegmentIds.length === 0) {
       this.disposeOverlayChunk();
@@ -2224,6 +2222,15 @@ export class SpatiallyIndexedSkeletonLayer
       this.overlayChunkKey === overlayChunkKey
     ) {
       return this.overlayChunk;
+    }
+
+    // Pass 2: cache miss — collect node sets and rebuild geometry.
+    const segmentNodeSets: (readonly SpatiallyIndexedSkeletonNode[])[] = [];
+    for (const segmentId of loadedSegmentIds) {
+      const segmentNodes = this.inspectionState.getCachedSegmentNodes(segmentId);
+      if (segmentNodes !== undefined) {
+        segmentNodeSets.push(segmentNodes);
+      }
     }
     this.disposeOverlayChunk();
     const geometry = buildSpatiallyIndexedSkeletonOverlayGeometry(

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -137,6 +137,10 @@ import { NullarySignal } from "#src/util/signal.js";
 import type { Trackable } from "#src/util/trackable.js";
 import { CompoundTrackable } from "#src/util/trackable.js";
 import { TrackableEnum } from "#src/util/trackable_enum.js";
+import {
+  drawBoxEdges,
+  glsl_getBoxEdgeVertexPosition,
+} from "#src/webgl/bounding_box.js";
 import { GLBuffer } from "#src/webgl/buffer.js";
 import {
   defineCircleShader,
@@ -988,7 +992,7 @@ void emitDefault() {
   }
 }
 
-// Draws the spatial bounds of each chunk as a cyan wireframe box, for debugging.
+// Draws the spatial bounds of each chunk as a cyan box overlay, for debugging.
 // One shader is compiled per emitter so the emitter can inject the correct
 // output-buffer declarations and `emit(color, pickID)` function.
 class ChunkWireframeHelper extends RefCounted {
@@ -1012,33 +1016,34 @@ class ChunkWireframeHelper extends RefCounted {
       const builder = new ShaderBuilder(this.gl);
       builder.require(emitter);
       builder.addUniform("highp mat4", "uChunkToClip");
-      builder.addUniform("highp vec3", "uChunkMin");
-      builder.addUniform("highp vec3", "uChunkSize");
-      // 12 edges of a unit cube encoded as pairs of corner indices (0–7).
-      // Corner i has bit-decoded coords: x=(i>>0)&1, y=(i>>1)&1, z=(i>>2)&1.
-      builder.addVertexCode(`
-const int kEdgeTable[24] = int[24](
-  0,1, 2,3, 4,5, 6,7,
-  0,2, 1,3, 4,6, 5,7,
-  0,4, 1,5, 2,6, 3,7
-);
-`);
+      builder.addUniform("highp vec3", "uTranslation");
+      builder.addUniform("highp vec3", "uChunkDataSize");
+      builder.addVertexCode(glsl_getBoxEdgeVertexPosition);
       builder.setVertexMain(`
-int edgeIdx = gl_VertexID / 2;
-int endpointIdx = gl_VertexID % 2;
-int corner = kEdgeTable[edgeIdx * 2 + endpointIdx];
-vec3 unitPos = vec3(
-  float((corner >> 0) & 1),
-  float((corner >> 1) & 1),
-  float((corner >> 2) & 1)
-);
-gl_Position = uChunkToClip * vec4(uChunkMin + unitPos * uChunkSize, 1.0);
+vec3 boxVertex = getBoxEdgeVertexPosition(gl_VertexID);
+gl_Position = uChunkToClip * vec4(uTranslation + boxVertex * uChunkDataSize, 1.0);
 `);
       builder.setFragmentMain(`emit(vec4(0.0, 1.0, 1.0, 1.0), 0u);`);
       shader = builder.build();
       this.shaderCache.set(emitter, shader);
     }
     return shader;
+  }
+
+  setChunkUniforms(
+    gl: GL,
+    shader: ShaderProgram,
+    chunkLayout: ChunkLayout,
+    chunkGridPosition: Float32Array,
+  ) {
+    const { size } = chunkLayout;
+    gl.uniform3f(
+      shader.uniform("uTranslation"),
+      chunkGridPosition[0] * size[0],
+      chunkGridPosition[1] * size[1],
+      chunkGridPosition[2] * size[2],
+    );
+    gl.uniform3fv(shader.uniform("uChunkDataSize"), size);
   }
 
   static get(gl: GL) {
@@ -3309,7 +3314,6 @@ export class PerspectiveViewSpatiallyIndexedSkeletonLayer extends PerspectiveVie
     )
       return;
 
-    // Build source → chunkLayout lookup from the current transformed sources.
     const chunkLayoutBySource = new Map<object, ChunkLayout>();
     for (const scales of this.transformedSources) {
       for (const tsource of scales) {
@@ -3325,25 +3329,20 @@ export class PerspectiveViewSpatiallyIndexedSkeletonLayer extends PerspectiveVie
     shader.bind();
     const { viewProjectionMat } = renderContext.projectionParameters;
 
+    mat4.multiply(tempMat4, viewProjectionMat, modelMatrix);
+    gl.uniformMatrix4fv(shader.uniform("uChunkToClip"), false, tempMat4);
+
     for (const chunk of visibleChunks) {
       const chunkLayout = chunkLayoutBySource.get(chunk.source);
       if (chunkLayout === undefined) continue;
 
-      // Compose: clip ← view-projection ← model ← chunk-layout-transform
-      mat4.multiply(tempMat4, viewProjectionMat, modelMatrix);
-      mat4.multiply(tempMat4, tempMat4, chunkLayout.transform);
-      gl.uniformMatrix4fv(shader.uniform("uChunkToClip"), false, tempMat4);
-
-      const { size } = chunkLayout;
-      const gridPosition = chunk.chunkGridPosition;
-      gl.uniform3f(
-        shader.uniform("uChunkMin"),
-        gridPosition[0] * size[0],
-        gridPosition[1] * size[1],
-        gridPosition[2] * size[2],
+      wireframeHelper.setChunkUniforms(
+        gl,
+        shader,
+        chunkLayout,
+        chunk.chunkGridPosition,
       );
-      gl.uniform3f(shader.uniform("uChunkSize"), size[0], size[1], size[2]);
-      gl.drawArrays(WebGL2RenderingContext.LINES, 0, 24);
+      drawBoxEdges(gl, 1, 1);
     }
   }
 

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -189,8 +189,6 @@ import type { RPC } from "#src/worker_rpc.js";
 
 const DEBUG_SPATIAL_SKELETON_OVERLAY = false;
 const DEBUG_EXCLUDED_SEGMENTS = false;
-const DEBUG_CHUNK_WIREFRAME_3D = true;
-const DEBUG_CHUNK_COLORS = true;
 const tempChunkColorMap = new Map<vec3, Float32Array>();
 
 const tempMat4 = mat4.create();
@@ -2834,7 +2832,7 @@ export class SpatiallyIndexedSkeletonLayer
         renderHelper.setNodePickInstanceStride(gl, nodeShader, nodePickStride);
       }
       // Render each chunk with different node/edge colors for debugging
-      if (DEBUG_CHUNK_COLORS) {
+      if (renderContext.wireFrame) {
         let randomColor = tempChunkColorMap.get(chunk.chunkGridPosition);
         if (randomColor === undefined) {
           randomColor = new Float32Array([
@@ -3297,7 +3295,7 @@ export class PerspectiveViewSpatiallyIndexedSkeletonLayer extends PerspectiveVie
       modelMatrix,
       visibleChunks,
     );
-    if (DEBUG_CHUNK_WIREFRAME_3D) {
+    if (renderContext.wireFrame) {
       this.drawChunkBoundsWireframe(renderContext, visibleChunks, modelMatrix);
     }
   }

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -189,7 +189,9 @@ import type { RPC } from "#src/worker_rpc.js";
 
 const DEBUG_SPATIAL_SKELETON_OVERLAY = false;
 const DEBUG_EXCLUDED_SEGMENTS = false;
-const tempChunkColorMap = new Map<vec3, Float32Array>();
+const DEBUG_SPATIAL_SKELETON_CHUNKS = false;
+// Used for debugging chunks via a different color for each chunk
+const tempChunkKeyToColorMap = new Map<string, Float32Array>();
 
 const tempMat4 = mat4.create();
 const DEFAULT_FRAGMENT_MAIN = `void main() {
@@ -2832,15 +2834,16 @@ export class SpatiallyIndexedSkeletonLayer
         renderHelper.setNodePickInstanceStride(gl, nodeShader, nodePickStride);
       }
       // Render each chunk with different node/edge colors for debugging
-      if (renderContext.wireFrame) {
-        let randomColor = tempChunkColorMap.get(chunk.chunkGridPosition);
+      if (DEBUG_SPATIAL_SKELETON_CHUNKS) {
+        const chunkKey = `${chunk.chunkGridPosition[0]},${chunk.chunkGridPosition[1]},${chunk.chunkGridPosition[2]}`;
+        let randomColor = tempChunkKeyToColorMap.get(chunkKey);
         if (randomColor === undefined) {
           randomColor = new Float32Array([
             Math.random(),
             Math.random(),
             Math.random(),
           ]);
-          tempChunkColorMap.set(chunk.chunkGridPosition, randomColor);
+          tempChunkKeyToColorMap.set(chunkKey, randomColor);
         }
         nodeShader.bind();
         gl.uniform1ui(nodeShader.uniform("uUseSegmentDefaultColor"), 1);

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -129,7 +129,7 @@ import { DATA_TYPE_SIGNED, DataType } from "#src/util/data_type.js";
 import { RefCounted } from "#src/util/disposable.js";
 import type { ValueOrError } from "#src/util/error.js";
 import { makeValueOrError, valueOrThrow } from "#src/util/error.js";
-import { kOneVec4, mat4, type vec4 } from "#src/util/geom.js";
+import { kOneVec4, mat4, type vec4, type vec3 } from "#src/util/geom.js";
 import { verifyFinitePositiveFloat } from "#src/util/json.js";
 import * as matrix from "#src/util/matrix.js";
 import { getObjectId } from "#src/util/object_id.js";
@@ -157,10 +157,11 @@ import {
   initializeLineShader,
 } from "#src/webgl/lines.js";
 import type {
-  ShaderBuilder,
+  ShaderModule,
   ShaderProgram,
   ShaderSamplerType,
 } from "#src/webgl/shader.js";
+import { ShaderBuilder } from "#src/webgl/shader.js";
 import {
   dataTypeShaderDefinition,
   getShaderType,
@@ -184,8 +185,12 @@ import type { RPC } from "#src/worker_rpc.js";
 
 const DEBUG_SPATIAL_SKELETON_OVERLAY = false;
 const DEBUG_EXCLUDED_SEGMENTS = false;
+const DEBUG_CHUNK_WIREFRAME = true;
+const DEBUG_CHUNK_COLORS = true;
+const tempChunkColorMap = new Map<vec3, Float32Array>();
 
 const tempMat2 = mat4.create();
+const tempWireframeMat = mat4.create();
 const DEFAULT_FRAGMENT_MAIN = `void main() {
   emitDefault();
 }
@@ -430,9 +435,7 @@ vec4 getSegmentAppearance(highp uint segmentValue) {
       gl.uniform1ui(shader.uniform("uUseSegmentDefaultColor"), 1);
       gl.uniform3fv(
         shader.uniform("uSegmentDefaultColor"),
-        segmentDefaultColor[0],
-        segmentDefaultColor[1],
-        segmentDefaultColor[2],
+        segmentDefaultColor,
       );
     }
     if (DEBUG_SPATIAL_SKELETON_OVERLAY && excludedSegments === undefined) {
@@ -983,6 +986,67 @@ void emitDefault() {
       }
     }
     this.vertexIdHelper.disable();
+  }
+}
+
+// Draws the spatial bounds of each chunk as a cyan wireframe box, for debugging.
+// One shader is compiled per emitter so the emitter can inject the correct
+// output-buffer declarations and `emit(color, pickID)` function.
+class ChunkWireframeHelper extends RefCounted {
+  private shaderCache = new Map<ShaderModule, ShaderProgram>();
+
+  constructor(private gl: GL) {
+    super();
+  }
+
+  disposed() {
+    for (const shader of this.shaderCache.values()) {
+      shader.dispose();
+    }
+    this.shaderCache.clear();
+    super.disposed();
+  }
+
+  getShader(emitter: ShaderModule): ShaderProgram {
+    let shader = this.shaderCache.get(emitter);
+    if (shader === undefined) {
+      const builder = new ShaderBuilder(this.gl);
+      builder.require(emitter);
+      builder.addUniform("highp mat4", "uChunkToClip");
+      builder.addUniform("highp vec3", "uChunkMin");
+      builder.addUniform("highp vec3", "uChunkSize");
+      // 12 edges of a unit cube encoded as pairs of corner indices (0–7).
+      // Corner i has bit-decoded coords: x=(i>>0)&1, y=(i>>1)&1, z=(i>>2)&1.
+      builder.addVertexCode(`
+const int kEdgeTable[24] = int[24](
+  0,1, 2,3, 4,5, 6,7,
+  0,2, 1,3, 4,6, 5,7,
+  0,4, 1,5, 2,6, 3,7
+);
+`);
+      builder.setVertexMain(`
+int edgeIdx = gl_VertexID / 2;
+int endpointIdx = gl_VertexID % 2;
+int corner = kEdgeTable[edgeIdx * 2 + endpointIdx];
+vec3 unitPos = vec3(
+  float((corner >> 0) & 1),
+  float((corner >> 1) & 1),
+  float((corner >> 2) & 1)
+);
+gl_Position = uChunkToClip * vec4(uChunkMin + unitPos * uChunkSize, 1.0);
+`);
+      builder.setFragmentMain(`emit(vec4(0.0, 1.0, 1.0, 1.0), 0u);`);
+      shader = builder.build();
+      this.shaderCache.set(emitter, shader);
+    }
+    return shader;
+  }
+
+  static get(gl: GL) {
+    return gl.memoize.get(
+      "skeleton/ChunkWireframeHelper",
+      () => new ChunkWireframeHelper(gl),
+    );
   }
 }
 
@@ -2765,6 +2829,24 @@ export class SpatiallyIndexedSkeletonLayer
         renderHelper.setPickID(gl, nodeShader, nodePickId);
         renderHelper.setNodePickInstanceStride(gl, nodeShader, nodePickStride);
       }
+      // Render each chunk with different node/edge colors for debugging
+      if (DEBUG_CHUNK_COLORS) {
+        let randomColor = tempChunkColorMap.get(chunk.chunkGridPosition);
+        if (randomColor === undefined) {
+          randomColor = new Float32Array([
+            Math.random(),
+            Math.random(),
+            Math.random(),
+          ]);
+          tempChunkColorMap.set(chunk.chunkGridPosition, randomColor);
+        }
+        nodeShader.bind();
+        gl.uniform1ui(nodeShader.uniform("uUseSegmentDefaultColor"), 1);
+        gl.uniform3fv(nodeShader.uniform("uSegmentDefaultColor"), randomColor);
+        edgeShader.bind();
+        gl.uniform1ui(edgeShader.uniform("uUseSegmentDefaultColor"), 1);
+        gl.uniform3fv(edgeShader.uniform("uSegmentDefaultColor"), randomColor);
+      }
       renderHelper.drawSkeletons(
         gl,
         edgeShader,
@@ -3214,6 +3296,70 @@ export class PerspectiveViewSpatiallyIndexedSkeletonLayer extends PerspectiveVie
       attachment,
       visibleChunks,
     );
+    if (
+      DEBUG_CHUNK_WIREFRAME &&
+      renderContext.emitColor &&
+      visibleChunks.length > 0
+    ) {
+      this.drawChunkBoundsWireframe(renderContext, attachment, visibleChunks);
+    }
+  }
+
+  private drawChunkBoundsWireframe(
+    renderContext: PerspectiveViewRenderContext,
+    attachment: VisibleLayerInfo<
+      PerspectivePanel,
+      ThreeDimensionalRenderLayerAttachmentState
+    >,
+    visibleChunks: SpatiallyIndexedSkeletonChunk[],
+  ) {
+    const modelMatrix = update3dRenderLayerAttachment(
+      this.base.displayState.transform.value,
+      renderContext.projectionParameters.displayDimensionRenderInfo,
+      attachment,
+    );
+    if (modelMatrix === undefined) return;
+
+    // Build source → chunkLayout lookup from the current transformed sources.
+    const chunkLayoutBySource = new Map<object, ChunkLayout>();
+    for (const scales of this.transformedSources) {
+      for (const tsource of scales) {
+        if (!chunkLayoutBySource.has(tsource.source)) {
+          chunkLayoutBySource.set(tsource.source, tsource.chunkLayout);
+        }
+      }
+    }
+
+    const wireframeHelper = ChunkWireframeHelper.get(this.base.gl);
+    const shader = wireframeHelper.getShader(renderContext.emitter);
+    shader.bind();
+    const { viewProjectionMat } = renderContext.projectionParameters;
+    const gl = this.base.gl;
+
+    for (const chunk of visibleChunks) {
+      const chunkLayout = chunkLayoutBySource.get(chunk.source);
+      if (chunkLayout === undefined) continue;
+
+      // Compose: clip ← view-projection ← model ← chunk-layout-transform
+      mat4.multiply(tempWireframeMat, viewProjectionMat, modelMatrix);
+      mat4.multiply(tempWireframeMat, tempWireframeMat, chunkLayout.transform);
+      gl.uniformMatrix4fv(
+        shader.uniform("uChunkToClip"),
+        false,
+        tempWireframeMat,
+      );
+
+      const { size } = chunkLayout;
+      const gp = chunk.chunkGridPosition;
+      gl.uniform3f(
+        shader.uniform("uChunkMin"),
+        gp[0] * size[0],
+        gp[1] * size[1],
+        gp[2] * size[2],
+      );
+      gl.uniform3f(shader.uniform("uChunkSize"), size[0], size[1], size[2]);
+      gl.drawArrays(WebGL2RenderingContext.LINES, 0, 24);
+    }
   }
 
   isReady(

--- a/src/webgl/bounding_box.ts
+++ b/src/webgl/bounding_box.ts
@@ -69,6 +69,35 @@ vec3 getBoxFaceVertexPosition(int vertexIndex) {
 }
 `;
 
+export const glsl_getBoxEdgeVertexPosition = `
+vec3 getBoxEdgeVertexPosition(int vertexIndex) {
+  // 12 edges × 2 endpoints = 24
+  const int edgeTable[24] = int[24](
+    0,1, 2,3, 4,5, 6,7,
+    0,2, 1,3, 4,6, 5,7,
+    0,4, 1,5, 2,6, 3,7
+  );
+  // Order is x, y, z, so at
+  // corner i: x=i&1, y=(i>>1)&1, z=(i>>2)&1
+  // for example, corner 5 is 0101 in binary, so x=1, y=0, z=1
+  int corner = edgeTable[vertexIndex];
+  return vec3(float(corner & 1), float((corner >> 1) & 1), float((corner >> 2) & 1));
+}
+`;
+
+export function drawBoxEdges(
+  gl: WebGL2RenderingContext,
+  boxesPerInstance: number,
+  numInstances: number,
+) {
+  gl.drawArraysInstanced(
+    WebGL2RenderingContext.LINES,
+    0,
+    EDGES_PER_BOX * 2 * boxesPerInstance,
+    numInstances,
+  );
+}
+
 export function drawBoxes(
   gl: WebGL2RenderingContext,
   boxesPerInstance: number,


### PR DESCRIPTION
This includes extra debugging with a wireframe and per chunk colors.

<img width="1846" height="925" alt="image" src="https://github.com/user-attachments/assets/b8262f04-5a67-4fbc-9482-e09341dc27ca" />

<img width="1862" height="1017" alt="image" src="https://github.com/user-attachments/assets/4032ebf8-96aa-45f6-a18b-8c42283914a1" />

I didn't add a 2D version, just a 3D. If we need a 2D we could come back to it.