### PR TITLE
feat: add python state, remove uneeded functions, convert node type to enum

### DIFF
--- a/python/examples/example_spatial_skeletons.py
+++ b/python/examples/example_spatial_skeletons.py
@@ -1,0 +1,61 @@
+import argparse
+
+import neuroglancer
+import neuroglancer.cli
+import numpy as np
+
+voxel_size = np.array([10, 10, 10])
+
+shape = (100, 100, 100)
+
+segmentation = np.arange(np.prod(shape), dtype=np.uint32).reshape(shape)
+
+viewer = neuroglancer.Viewer()
+dimensions = neuroglancer.CoordinateSpace(
+    names=["x", "y", "z"],
+    units="nm",
+    scales=[10, 10, 10],
+)
+with viewer.txn() as s:
+    s.layers.append(
+        name="a",
+        layer=neuroglancer.SegmentationLayer(
+            source=[
+                neuroglancer.LocalVolume(
+                    data=segmentation,
+                    dimensions=dimensions,
+                ),  # example of segmentation that could accompany the skeleton
+                "catmaid://http://localhost:8000/4",  # replace with your catmaid URL/project ID
+            ],
+            tab="skeleton",
+        ),
+    )
+    # Can adjust the skeleton rendering options
+    s.layers[0].skeleton_rendering.mode2d = "lines"
+    s.layers[0].skeleton_rendering.line_width2d = 3
+    s.layers[0].skeleton_rendering.mode3d = "lines_and_points"
+    s.layers[0].skeleton_rendering.line_width3d = 10
+
+    # Can adjust visibility of layer side panel
+    s.selected_layer.layer = "a"
+    s.selected_layer.visible = True
+
+    # Can set the new spatial related options
+    layer = s.layers[0]
+    layer.spatial_skeleton_node_query = "1"
+    layer.spatial_skeleton_node_filter = neuroglancer.SpatialSkeletonNodeFilterType.LEAF
+    layer.hidden_object_alpha = 0.8
+    layer.skeleton_cross_section_render_scale = 4.0
+    layer.skeleton_perspective_render_scale = 4.0
+    layer.visible_segments = [649]
+
+    # Can pick a specific segment and node to select
+    selection_for_layers = s.selection.layers
+    selection_for_layers["a"] = {"value": "649", "nodeId": "131"}
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    neuroglancer.cli.add_server_arguments(ap)
+    args = ap.parse_args()
+    neuroglancer.cli.handle_server_arguments(args)
+    print(viewer)

--- a/python/neuroglancer/__init__.py
+++ b/python/neuroglancer/__init__.py
@@ -91,6 +91,7 @@ from .viewer_state import (
     InvlerpParameters,  # noqa: F401
     TransferFunctionParameters,  # noqa: F401
     ImageLayer,  # noqa: F401
+    SpatialSkeletonNodeFilterType,  # noqa: F401
     SkeletonRenderingOptions,  # noqa: F401
     StarredSegments,  # noqa: F401
     VisibleSegments,  # noqa: F401

--- a/python/neuroglancer/catmaid_credentials.py
+++ b/python/neuroglancer/catmaid_credentials.py
@@ -1,0 +1,40 @@
+# @license
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import urllib.request
+
+from . import credentials_provider
+from .futures import run_on_new_thread
+
+
+class CatmaidAnonymousCredentialsProvider(credentials_provider.CredentialsProvider):
+    def __init__(self, parameters):
+        super().__init__()
+        self.server_url = (parameters or {}).get("serverUrl", "")
+
+    def get_new(self):
+        server_url = self.server_url
+
+        def func():
+            token_url = f"{server_url}/accounts/anonymous-api-token"
+            with urllib.request.urlopen(token_url) as response:
+                data = json.loads(response.read().decode())
+            if not isinstance(data, dict) or not isinstance(data.get("token"), str):
+                raise RuntimeError(
+                    f"Unexpected response from {token_url}: {data!r}"
+                )
+            return {"token": data["token"]}
+
+        return run_on_new_thread(func)

--- a/python/neuroglancer/credentials_provider.py
+++ b/python/neuroglancer/credentials_provider.py
@@ -27,7 +27,10 @@ class CredentialsManager:
         self._providers[key] = credentials_provider_getter
 
     def get(self, key, parameters):
-        return self._providers[key](parameters)
+        getter = self._providers.get(key)
+        if getter is None:
+            return None
+        return getter(parameters)
 
 
 class CredentialsProvider:

--- a/python/neuroglancer/default_credentials_manager.py
+++ b/python/neuroglancer/default_credentials_manager.py
@@ -14,6 +14,7 @@
 
 from . import (
     boss_credentials,
+    catmaid_credentials,
     credentials_provider,
     dvid_credentials,
     google_credentials,
@@ -44,6 +45,11 @@ default_credentials_manager.register(
     lambda parameters: dvid_credentials.get_tokenbased_application_default_credentials_provider(
         parameters
     ),
+)
+
+default_credentials_manager.register(
+    "CATMAID",
+    lambda parameters: catmaid_credentials.CatmaidAnonymousCredentialsProvider(parameters),
 )
 
 

--- a/python/neuroglancer/viewer_state.py
+++ b/python/neuroglancer/viewer_state.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import collections
 import collections.abc
 import copy
+import enum
 import math
 import numbers
 import os
@@ -644,6 +645,15 @@ def _linked_segmentation_color_group_value(x):
 
 
 @export
+class SpatialSkeletonNodeFilterType(enum.IntEnum):
+    NONE = 0
+    LEAF = 1
+    VIRTUAL_END = 2
+    TRUE_END = 3
+    HAS_DESCRIPTION = 4
+
+
+@export
 class SkeletonRenderingOptions(JsonObjectWrapper):
     __slots__ = ()
 
@@ -976,6 +986,21 @@ class SegmentationLayer(Layer, _AnnotationLayerOptions):
         "meshSilhouetteRendering", optional(float, 0)
     )
     segment_query = segmentQuery = wrapped_property("segmentQuery", optional(str))
+    spatial_skeleton_node_query = spatialSkeletonNodeQuery = wrapped_property(
+        "spatialSkeletonNodeQuery", optional(str, "")
+    )
+    spatial_skeleton_node_filter = spatialSkeletonNodeFilter = wrapped_property(
+        "spatialSkeletonNodeFilter", optional(int, 0)
+    )
+    hidden_object_alpha = hiddenObjectAlpha = wrapped_property(
+        "hiddenObjectAlpha", optional(float, 0.5)
+    )
+    skeleton_cross_section_render_scale = skeletonCrossSectionRenderScale = wrapped_property(
+        "skeletonCrossSectionRenderScale", optional(float, 1)
+    )
+    skeleton_perspective_render_scale = skeletonPerspectiveRenderScale = wrapped_property(
+        "skeletonPerspectiveRenderScale", optional(float, 1)
+    )
     segment_colors = segmentColors = wrapped_property(
         "segmentColors", typed_map(key_type=np.uint64, value_type=str)
     )

--- a/python/neuroglancer/viewer_state.py
+++ b/python/neuroglancer/viewer_state.py
@@ -995,11 +995,11 @@ class SegmentationLayer(Layer, _AnnotationLayerOptions):
     hidden_object_alpha = hiddenObjectAlpha = wrapped_property(
         "hiddenObjectAlpha", optional(float, 0.5)
     )
-    skeleton_cross_section_render_scale = skeletonCrossSectionRenderScale = wrapped_property(
-        "skeletonCrossSectionRenderScale", optional(float, 1)
+    skeleton_cross_section_render_scale = skeletonCrossSectionRenderScale = (
+        wrapped_property("skeletonCrossSectionRenderScale", optional(float, 1))
     )
-    skeleton_perspective_render_scale = skeletonPerspectiveRenderScale = wrapped_property(
-        "skeletonPerspectiveRenderScale", optional(float, 1)
+    skeleton_perspective_render_scale = skeletonPerspectiveRenderScale = (
+        wrapped_property("skeletonPerspectiveRenderScale", optional(float, 1))
     )
     segment_colors = segmentColors = wrapped_property(
         "segmentColors", typed_map(key_type=np.uint64, value_type=str)
@@ -1872,12 +1872,7 @@ class LayerSelectionState(JsonObjectWrapper):
     annotation_subsource = annotationSubsource = wrapped_property(
         "annotationSubsource", optional(str)
     )
-    spatial_skeleton_node_id = spatialSkeletonNodeId = wrapped_property(
-        "spatialSkeletonNodeId", optional(int)
-    )
-    spatial_skeleton_segment_id = spatialSkeletonSegmentId = wrapped_property(
-        "spatialSkeletonSegmentId", optional(int)
-    )
+    node_id = nodeId = wrapped_property("nodeId", optional(str))
 
 
 if typing.TYPE_CHECKING or _BUILDING_DOCS:

--- a/python/neuroglancer/viewer_state.py
+++ b/python/neuroglancer/viewer_state.py
@@ -645,12 +645,12 @@ def _linked_segmentation_color_group_value(x):
 
 
 @export
-class SpatialSkeletonNodeFilterType(enum.IntEnum):
-    NONE = 0
-    LEAF = 1
-    VIRTUAL_END = 2
-    TRUE_END = 3
-    HAS_DESCRIPTION = 4
+class SpatialSkeletonNodeFilterType(enum.StrEnum):
+    NONE = "none"
+    LEAF = "leaf"
+    VIRTUAL_END = "virtual_end"
+    TRUE_END = "true_end"
+    HAS_DESCRIPTION = "has_description"
 
 
 @export
@@ -990,7 +990,7 @@ class SegmentationLayer(Layer, _AnnotationLayerOptions):
         "spatialSkeletonNodeQuery", optional(str, "")
     )
     spatial_skeleton_node_filter = spatialSkeletonNodeFilter = wrapped_property(
-        "spatialSkeletonNodeFilter", optional(int, 0)
+        "spatialSkeletonNodeFilter", optional(SpatialSkeletonNodeFilterType)
     )
     hidden_object_alpha = hiddenObjectAlpha = wrapped_property(
         "hiddenObjectAlpha", optional(float, 0.5)

--- a/python/tests/viewer_state_test.py
+++ b/python/tests/viewer_state_test.py
@@ -116,25 +116,3 @@ def test_tool():
 
 def test_annotation():
     viewer_state.PointAnnotation(point=[1])
-
-
-def test_spatial_skeleton_node_selection_fields_roundtrip():
-    selection = viewer_state.LayerSelectionState(
-        {
-            "spatialSkeletonNodeId": 17,
-            "spatialSkeletonSegmentId": 9,
-        }
-    )
-    assert selection.spatial_skeleton_node_id == 17
-    assert selection.spatial_skeleton_segment_id == 9
-    assert selection.to_json() == {
-        "spatialSkeletonNodeId": 17,
-        "spatialSkeletonSegmentId": 9,
-    }
-
-
-def test_spatial_skeleton_node_selection_without_segment_roundtrip():
-    selection = viewer_state.LayerSelectionState(spatial_skeleton_node_id=5)
-    assert selection.to_json() == {
-        "spatialSkeletonNodeId": 5,
-    }

--- a/src/layer/index.ts
+++ b/src/layer/index.ts
@@ -91,7 +91,6 @@ import {
   emptyToUndefined,
   parseArray,
   parseFixedLengthArray,
-  parseUint64,
   verifyBoolean,
   verifyFiniteFloat,
   verifyInt,
@@ -157,20 +156,6 @@ export class LayerActionContext {
   }
 }
 
-function parsePositiveUint64String(value: unknown) {
-  if (typeof value !== "string") {
-    throw new Error(
-      `Expected string-encoded positive uint64 value, but received: ${JSON.stringify(value)}.`,
-    );
-  }
-  const parsedValue = parseUint64(value);
-  if (parsedValue <= 0n) {
-    throw new Error(
-      `Expected positive uint64 value, but received: ${JSON.stringify(value)}.`,
-    );
-  }
-  return parsedValue.toString();
-}
 
 export interface UserLayerTab {
   id: string;
@@ -297,11 +282,7 @@ export class UserLayer extends RefCounted {
         verifyString,
       );
     }
-    state.nodeId = verifyOptionalObjectProperty(
-      json,
-      "nodeId",
-      parsePositiveUint64String,
-    );
+    state.nodeId = verifyOptionalObjectProperty(json, "nodeId", verifyString);
 
     state.value = json.value;
   }

--- a/src/layer/segmentation/index.ts
+++ b/src/layer/segmentation/index.ts
@@ -136,8 +136,8 @@ import {
   classifySpatialSkeletonDisplayNodeType as getSpatialSkeletonDisplayNodeType,
   getSpatialSkeletonNodeFilterLabel,
   getSpatialSkeletonNodeIconFilterType,
+  SpatialSkeletonDisplayNodeType,
   SpatialSkeletonNodeFilterType,
-  type SpatialSkeletonDisplayNodeType,
 } from "#src/skeleton/node_types.js";
 import {
   getEditableSpatiallyIndexedSkeletonSource,
@@ -211,10 +211,10 @@ const SPATIAL_SKELETON_NODE_TYPE_ICONS: Record<
   SpatialSkeletonDisplayNodeType,
   string
 > = {
-  root: svg_origin,
-  branchStart: svg_share_android,
-  regular: svg_minus,
-  virtualEnd: svg_circle,
+  [SpatialSkeletonDisplayNodeType.ROOT]: svg_origin,
+  [SpatialSkeletonDisplayNodeType.BRANCH_START]: svg_share_android,
+  [SpatialSkeletonDisplayNodeType.REGULAR]: svg_minus,
+  [SpatialSkeletonDisplayNodeType.VIRTUAL_END]: svg_circle,
 };
 
 function getSpatialSkeletonNodeTypeLabel(
@@ -223,11 +223,11 @@ function getSpatialSkeletonNodeTypeLabel(
 ) {
   if (nodeHasTrueEnd) return "True end";
   switch (nodeType) {
-    case "root":
+    case SpatialSkeletonDisplayNodeType.ROOT:
       return "Root";
-    case "branchStart":
+    case SpatialSkeletonDisplayNodeType.BRANCH_START:
       return "Branch point";
-    case "virtualEnd":
+    case SpatialSkeletonDisplayNodeType.VIRTUAL_END:
       return "Leaf";
     default:
       return "Node";

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -227,6 +227,7 @@ interface SkeletonShaderParameters {
   dynamicSegmentAppearance: boolean;
   hasSegmentStatedColors: boolean;
   hasSegmentDefaultColor: boolean;
+  hoverHighlight: boolean;
   spatialChunkCulling: boolean;
 }
 
@@ -326,9 +327,6 @@ class RenderHelper extends RefCounted {
     this.defineAttributeAccess(builder);
     if (skeletonParams.dynamicSegmentAppearance) {
       this.defineDynamicSegmentAppearance(builder, skeletonParams);
-    }
-    if (skeletonParams.dynamicSegmentAppearance) {
-      builder.addVarying("highp uint", "vSegmentValue", "flat");
     }
     if (skeletonParams.spatialChunkCulling) {
       builder.addUniform("highp vec3", "uChunkOrigin");
@@ -441,9 +439,14 @@ void spatialChunkCull() {
     }
     builder.addUniform("highp float", "uVisibleAlpha");
     builder.addUniform("highp float", "uHiddenAlpha");
+    builder.addUniform("highp float", "uSaturation");
     if (params.hasSegmentDefaultColor) {
       builder.addUniform("highp vec3", "uSegmentDefaultColor");
     }
+    if (params.hoverHighlight) {
+      builder.addUniform("highp uvec2", "uHoveredSegmentId");
+    }
+    builder.addVarying("highp uint", "vSegmentValue", "flat");
 
     const statedColorFragment = params.hasSegmentStatedColors
       ? `
@@ -457,13 +460,28 @@ void spatialChunkCull() {
       ? "  return uSegmentDefaultColor;"
       : `  ${colorExpression}`;
 
+    const hoverAdjustFragment = params.hoverHighlight
+      ? `
+  if (segmentId.value.x == uHoveredSegmentId.x &&
+      segmentId.value.y == uHoveredSegmentId.y) {
+    if (saturation > 0.5) { saturation -= 0.5; }
+    else { saturation += 0.5; }
+  }`
+      : "";
+
     builder.addFragmentCode(`
 uint64_t getSegmentAppearanceId(highp uint segmentValue) {
   return uint64_t(uvec2(segmentValue, 0u));
 }
-vec3 getSegmentLookupColor(uint64_t segmentId) {
+vec3 getSegmentBaseColor(uint64_t segmentId) {
 ${statedColorFragment}
 ${defaultColorFragment}
+}
+vec3 getSegmentLookupColor(uint64_t segmentId) {
+  vec3 baseColor = getSegmentBaseColor(segmentId);
+  float saturation = uSaturation;
+${hoverAdjustFragment}
+  return mix(vec3(1.0, 1.0, 1.0), baseColor, saturation);
 }
 float getSegmentLookupAlpha(uint64_t segmentId) {
   if (${this.excludedSegmentsShaderManager.hasFunctionName}(segmentId)) {
@@ -535,6 +553,19 @@ vec4 getSegmentAppearance(highp uint segmentValue) {
         gl,
         shader,
         this.gpuSegmentStatedColorHashTable,
+      );
+    }
+
+    const { saturation, segmentSelectionState } = this.base.displayState;
+    gl.uniform1f(shader.uniform("uSaturation"), saturation.value);
+    if (skeletonParams.hoverHighlight) {
+      const seg = segmentSelectionState.hasSelectedSegment
+        ? segmentSelectionState.selectedSegment
+        : 0n;
+      gl.uniform2ui(
+        shader.uniform("uHoveredSegmentId"),
+        Number(seg & 0xffff_ffffn),
+        Number((seg >> 32n) & 0xffff_ffffn),
       );
     }
   }
@@ -647,6 +678,9 @@ highp uint vertexIndex = aVertexIndex.x * (1u - lineEndpointIndex) + aVertexInde
               ? "uColor.a"
               : `${segmentColorExpression}.a`;
           if (skeletonParams.dynamicSegmentAppearance) {
+            // Dynamic path (spatial skeletons): per-segment color, visibility,
+            // saturation and hover highlight all resolved in the shader via
+            // getSegmentAppearance(). uColor is unused in this path.
             builder.addFragmentCode(`
 vec4 segmentColor() {
   return getSegmentAppearance(vSegmentValue);
@@ -665,10 +699,9 @@ void emitDefault() {
 }
 `);
           } else if (this.segmentColorAttributeIndex === undefined) {
-            // Preserve legacy skeleton behavior where `uColor` is already
-            // premultiplied by `objectAlpha` in `getObjectColor`.
-            // in this path, whole skeletons are drawn at one time
-            // as opposed to multiple skeletons
+            // Legacy path (non-spatial skeletons): one skeleton drawn per call;
+            // uColor is set per-skeleton by the CPU via getObjectColor(), which
+            // already incorporates saturation and hover highlighting.
             builder.addFragmentCode(`
 vec4 segmentColor() {
   return ${segmentColorExpression};
@@ -681,6 +714,8 @@ void emitDefault() {
 }
 `);
           } else {
+            // Per-vertex color attribute path: color comes from a per-vertex
+            // attribute; alpha is taken from uColor.
             builder.addFragmentCode(`
 vec4 segmentColor() {
   return ${segmentColorExpression};
@@ -772,6 +807,9 @@ emitCircle(
             skeletonParams.dynamicSegmentAppearance &&
             this.segmentAttributeIndex !== undefined
           ) {
+            // Dynamic path (spatial skeletons): per-segment color, visibility,
+            // saturation and hover highlight all resolved in the shader via
+            // getSegmentAppearance(). uColor is unused in this path.
             const segmentExpression = `vSegmentValue`;
             const selectedNodeExpression =
               this.selectedNodeAttributeIndex === undefined
@@ -802,7 +840,9 @@ void emitDefault() {
 }
 `);
           } else if (this.segmentColorAttributeIndex === undefined) {
-            // Preserve legacy skeleton behavior for non-spatial skeletons.
+            // Legacy path (non-spatial skeletons): one skeleton drawn per call;
+            // uColor is set per-skeleton by the CPU via getObjectColor(), which
+            // already incorporates saturation and hover highlighting.
             builder.addFragmentCode(`
 vec4 segmentColor() {
   return ${segmentColorExpression};
@@ -819,6 +859,8 @@ void emitDefault() {
 }
 `);
           } else {
+            // Per-vertex color attribute path: color comes from a per-vertex
+            // attribute; alpha is taken from the attribute's alpha component.
             const selectedNodeExpression =
               this.selectedNodeAttributeIndex === undefined
                 ? undefined
@@ -1199,6 +1241,7 @@ export class SkeletonLayer extends RefCounted implements SkeletonShaderContext {
       dynamicSegmentAppearance: false,
       hasSegmentStatedColors: false,
       hasSegmentDefaultColor: false,
+      hoverHighlight: false,
       spatialChunkCulling: false,
     });
   fallbackShaderParameters = new WatchableValue(
@@ -2440,29 +2483,41 @@ export class SpatiallyIndexedSkeletonLayer
         dynamicSegmentAppearance: true,
         hasSegmentStatedColors: false,
         hasSegmentDefaultColor: false,
+        hoverHighlight: false,
         spatialChunkCulling: false,
       });
+    const updateSkeletonShaderParameters = () => {
+      const colorGroupState =
+        this.displayState.segmentationColorGroupState.value;
+      this.skeletonShaderParameters.value = {
+        dynamicSegmentAppearance: true,
+        hasSegmentStatedColors: colorGroupState.segmentStatedColors.size !== 0,
+        hasSegmentDefaultColor:
+          colorGroupState.segmentDefaultColor.value !== undefined ||
+          DEBUG_SPATIAL_SKELETON_CHUNKS,
+        hoverHighlight: this.displayState.hoverHighlight.value,
+        spatialChunkCulling: false,
+      };
+    };
     this.registerDisposer(
       registerNested((context, colorGroupState) => {
-        const update = () => {
-          this.skeletonShaderParameters.value = {
-            dynamicSegmentAppearance: true,
-            hasSegmentStatedColors:
-              colorGroupState.segmentStatedColors.size !== 0,
-            hasSegmentDefaultColor:
-              colorGroupState.segmentDefaultColor.value !== undefined ||
-              DEBUG_SPATIAL_SKELETON_CHUNKS,
-            spatialChunkCulling: false,
-          };
-        };
         context.registerDisposer(
-          colorGroupState.segmentStatedColors.changed.add(update),
+          colorGroupState.segmentStatedColors.changed.add(
+            updateSkeletonShaderParameters,
+          ),
         );
         context.registerDisposer(
-          colorGroupState.segmentDefaultColor.changed.add(update),
+          colorGroupState.segmentDefaultColor.changed.add(
+            updateSkeletonShaderParameters,
+          ),
         );
-        update();
+        updateSkeletonShaderParameters();
       }, this.displayState.segmentationColorGroupState),
+    );
+    this.registerDisposer(
+      this.displayState.hoverHighlight.changed.add(
+        updateSkeletonShaderParameters,
+      ),
     );
     this.browsePassSkeletonShaderParameters = this.registerDisposer(
       makeCachedLazyDerivedWatchableValue(

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -2974,6 +2974,14 @@ export class SpatiallyIndexedSkeletonLayer
     const chunkOrigin = vec3.create();
     const chunkBound = vec3.create();
     for (const { chunk, chunkLayout } of visibleChunks) {
+      if (skeletonParams.spatialChunkCulling) {
+        vec3.mul(chunkOrigin, chunk.chunkGridPosition, chunkLayout.size);
+        vec3.add(chunkBound, chunkOrigin, chunkLayout.size);
+        edgeShader.bind();
+        renderHelper.setChunkBounds(gl, edgeShader, chunkOrigin, chunkBound);
+        nodeShader.bind();
+        renderHelper.setChunkBounds(gl, nodeShader, chunkOrigin, chunkBound);
+      }
       if (renderContext.emitPickID) {
         let edgePickId = 0;
         let edgePickStride = 0;
@@ -3006,17 +3014,9 @@ export class SpatiallyIndexedSkeletonLayer
         edgeShader.bind();
         renderHelper.setPickID(gl, edgeShader, edgePickId);
         renderHelper.setPickInstanceStride(gl, edgeShader, edgePickStride);
-        if (skeletonParams.spatialChunkCulling) {
-          vec3.mul(chunkOrigin, chunk.chunkGridPosition, chunkLayout.size);
-          vec3.add(chunkBound, chunkOrigin, chunkLayout.size);
-          renderHelper.setChunkBounds(gl, edgeShader, chunkOrigin, chunkBound);
-        }
         nodeShader.bind();
         renderHelper.setPickID(gl, nodeShader, nodePickId);
         renderHelper.setPickInstanceStride(gl, nodeShader, nodePickStride);
-        if (skeletonParams.spatialChunkCulling) {
-          renderHelper.setChunkBounds(gl, nodeShader, chunkOrigin, chunkBound);
-        }
       }
       // Render each chunk with different node/edge colors for debugging
       if (DEBUG_SPATIAL_SKELETON_CHUNKS) {

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -2817,7 +2817,11 @@ export class SpatiallyIndexedSkeletonLayer
     ) {
       return true;
     }
-    if (lod === undefined || transformedSources.length === 0) {
+    if (lod === undefined) {
+      // No LOD configured — draw() renders nothing in this case, so nothing to wait for.
+      return true;
+    }
+    if (transformedSources.length === 0) {
       return false;
     }
     const lodSuffix = `:${lod}`;

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -781,7 +781,6 @@ emitCircle(
               selectedNodeExpression === undefined
                 ? "renderColor"
                 : `((${selectedNodeExpression} > 0.5) ? vec4(${SELECTED_NODE_OUTLINE_COLOR_RGB}, renderColor.a) : renderColor)`;
-            // TODO (SKM) interaction between default and emitRGBA looks odd
             builder.addFragmentCode(`
 vec4 segmentColor() {
   return getSegmentAppearance(${segmentExpression});
@@ -799,13 +798,7 @@ void emitRGB(vec3 color) {
   emitRGBA(vec4(color, 1.0));
 }
 void emitDefault() {
-  vec4 baseColor = segmentColor();
-  highp float alpha = baseColor.a;
-  if (alpha <= 0.0) discard;
-  vec4 renderColor = vec4(baseColor.rgb, alpha);
-  vec4 borderColor = ${borderColorExpression};
-  vec4 circleColor = getCircleColor(renderColor, borderColor);
-  emit(vec4(circleColor.rgb * circleColor.a, circleColor.a), vPickID);
+  emitRGBA(vec4(segmentColor().rgb, 1.0));
 }
 `);
           } else if (this.segmentColorAttributeIndex === undefined) {

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -124,7 +124,7 @@ import { DataType } from "#src/util/data_type.js";
 import { RefCounted } from "#src/util/disposable.js";
 import type { ValueOrError } from "#src/util/error.js";
 import { makeValueOrError, valueOrThrow } from "#src/util/error.js";
-import { kOneVec4, mat4, type vec4 } from "#src/util/geom.js";
+import { kOneVec4, mat4, vec3, type vec4 } from "#src/util/geom.js";
 import { verifyFinitePositiveFloat } from "#src/util/json.js";
 import * as matrix from "#src/util/matrix.js";
 import { getObjectId } from "#src/util/object_id.js";
@@ -218,10 +218,16 @@ const vertexPositionTextureFormat = computeTextureFormat(
   3,
 );
 
+interface VisibleChunk {
+  chunk: SpatiallyIndexedSkeletonChunk;
+  chunkLayout: ChunkLayout;
+}
+
 interface SkeletonShaderParameters {
   dynamicSegmentAppearance: boolean;
   hasSegmentStatedColors: boolean;
   hasSegmentDefaultColor: boolean;
+  spatialChunkCulling: boolean;
 }
 
 interface SkeletonShaderContext {
@@ -324,6 +330,17 @@ class RenderHelper extends RefCounted {
     if (skeletonParams.dynamicSegmentAppearance) {
       builder.addVarying("highp uint", "vSegmentValue", "flat");
     }
+    if (skeletonParams.spatialChunkCulling) {
+      builder.addUniform("highp vec3", "uChunkOrigin");
+      builder.addUniform("highp vec3", "uChunkBound");
+      builder.addVarying("highp vec3", "vCullPos");
+      builder.addFragmentCode(`
+void spatialChunkCull() {
+  if (any(lessThan(vCullPos, uChunkOrigin)) ||
+      any(greaterThanEqual(vCullPos, uChunkBound))) discard;
+}
+`);
+    }
   }
 
   // TODO (SKM): segmentAttribute is UINT32 but segments can be UINT64.
@@ -369,8 +386,16 @@ class RenderHelper extends RefCounted {
     }
     builder.setVertexMain(vertexMain);
     addControlsToBuilder(shaderBuilderState, builder);
-    builder.setFragmentMainFunction(
-      shaderCodeWithLineDirective(shaderBuilderState.parseResult.code),
+    builder.addFragmentCode(`void userMain();\n`);
+    builder.addFragmentCode(
+      "#define main userMain\n" +
+        shaderCodeWithLineDirective(shaderBuilderState.parseResult.code) +
+        "\n#undef main\n",
+    );
+    builder.setFragmentMain(
+      skeletonParams.spatialChunkCulling
+        ? "spatialChunkCull();\nuserMain();"
+        : "userMain();",
     );
   }
 
@@ -606,6 +631,9 @@ emitLine(uProjection, vertexA, vertexB, uLineWidth);
 highp uint lineEndpointIndex = getLineEndpointIndex();
 highp uint vertexIndex = aVertexIndex.x * (1u - lineEndpointIndex) + aVertexIndex.y * lineEndpointIndex;
 `;
+          if (skeletonParams.spatialChunkCulling) {
+            vertexMain += `vCullPos = mix(vertexA, vertexB, float(lineEndpointIndex));\n`;
+          }
           if (
             skeletonParams.dynamicSegmentAppearance &&
             this.segmentAttributeIndex !== undefined
@@ -720,8 +748,17 @@ highp uint pickOffset = vertexIndex * uPickInstanceStride;
 vPickID = uPickID + pickOffset;
 highp vec3 vertexPosition = readAttribute0(vertexIndex);
 `;
+          if (skeletonParams.spatialChunkCulling) {
+            vertexMain += `vCullPos = vertexPosition;\n`;
+          }
           if (this.selectedNodeAttributeIndex !== undefined) {
             vertexMain += `vSelectedNode = readAttribute${this.selectedNodeAttributeIndex}(vertexIndex);\n`;
+          }
+          if (
+            skeletonParams.dynamicSegmentAppearance &&
+            this.segmentAttributeIndex !== undefined
+          ) {
+            vertexMain += `vSegmentValue = toRaw(readAttribute${this.segmentAttributeIndex}(vertexIndex));\n`;
           }
           vertexMain += `
 emitCircle(
@@ -730,13 +767,6 @@ emitCircle(
   ${selectedOutlineWidthExpression}
 );
 `;
-          if (
-            skeletonParams.dynamicSegmentAppearance &&
-            this.segmentAttributeIndex !== undefined
-          ) {
-            vertexMain += `vSegmentValue = toRaw(readAttribute${this.segmentAttributeIndex}(vertexIndex));\n`;
-          }
-
           const segmentColorExpression = this.getSegmentColorExpression();
           if (
             skeletonParams.dynamicSegmentAppearance &&
@@ -751,6 +781,7 @@ emitCircle(
               selectedNodeExpression === undefined
                 ? "renderColor"
                 : `((${selectedNodeExpression} > 0.5) ? vec4(${SELECTED_NODE_OUTLINE_COLOR_RGB}, renderColor.a) : renderColor)`;
+            // TODO (SKM) interaction between default and emitRGBA looks odd
             builder.addFragmentCode(`
 vec4 segmentColor() {
   return getSegmentAppearance(${segmentExpression});
@@ -889,6 +920,16 @@ void emitDefault() {
 
   setPickInstanceStride(gl: GL, shader: ShaderProgram, stride: number) {
     gl.uniform1ui(shader.uniform("uPickInstanceStride"), stride);
+  }
+
+  setChunkBounds(
+    gl: GL,
+    shader: ShaderProgram,
+    origin: Float32Array,
+    upperBound: Float32Array,
+  ) {
+    gl.uniform3fv(shader.uniform("uChunkOrigin"), origin);
+    gl.uniform3fv(shader.uniform("uChunkBound"), upperBound);
   }
 
   drawSkeletons(
@@ -1165,6 +1206,7 @@ export class SkeletonLayer extends RefCounted implements SkeletonShaderContext {
       dynamicSegmentAppearance: false,
       hasSegmentStatedColors: false,
       hasSegmentDefaultColor: false,
+      spatialChunkCulling: false,
     });
   fallbackShaderParameters = new WatchableValue(
     getFallbackBuilderState(parseShaderUiControls(DEFAULT_FRAGMENT_MAIN)),
@@ -2017,6 +2059,7 @@ export class SpatiallyIndexedSkeletonLayer
   selectedNodeAttributeIndex: number | undefined;
   readonly browsePassLayerView: SkeletonShaderContext;
   readonly skeletonShaderParameters: WatchableValue<SkeletonShaderParameters>;
+  readonly browsePassSkeletonShaderParameters: WatchableValueInterface<SkeletonShaderParameters>;
   fallbackShaderParameters = new WatchableValue(
     getFallbackBuilderState(parseShaderUiControls(DEFAULT_FRAGMENT_MAIN)),
   );
@@ -2404,6 +2447,7 @@ export class SpatiallyIndexedSkeletonLayer
         dynamicSegmentAppearance: true,
         hasSegmentStatedColors: false,
         hasSegmentDefaultColor: false,
+        spatialChunkCulling: false,
       });
     this.registerDisposer(
       registerNested((context, colorGroupState) => {
@@ -2414,6 +2458,7 @@ export class SpatiallyIndexedSkeletonLayer
               colorGroupState.segmentStatedColors.size !== 0,
             hasSegmentDefaultColor:
               colorGroupState.segmentDefaultColor.value !== undefined,
+            spatialChunkCulling: false,
           };
         };
         context.registerDisposer(
@@ -2425,6 +2470,13 @@ export class SpatiallyIndexedSkeletonLayer
         update();
       }, this.displayState.segmentationColorGroupState),
     );
+    this.browsePassSkeletonShaderParameters = this.registerDisposer(
+      makeCachedLazyDerivedWatchableValue(
+        (params) => ({ ...params, spatialChunkCulling: true }),
+        this.skeletonShaderParameters,
+      ),
+    );
+
     // Browse pass uses uniform-based dynamic segment color (not per-vertex attribute),
     // so segmentColorAttributeIndex is intentionally undefined here.
     this.browsePassLayerView = {
@@ -2433,7 +2485,7 @@ export class SpatiallyIndexedSkeletonLayer
       gl: this.gl,
       fallbackShaderParameters: this.fallbackShaderParameters,
       displayState: this.displayState,
-      skeletonShaderParameters: this.skeletonShaderParameters,
+      skeletonShaderParameters: this.browsePassSkeletonShaderParameters,
     };
     const selectedNodeIndex = this.vertexAttributes.findIndex(
       (x) => x.name === selectedNodeAttribute.name,
@@ -2664,7 +2716,7 @@ export class SpatiallyIndexedSkeletonLayer
     transformedSources: readonly TransformedSource[][],
     projectionParameters: any,
     lod: number | undefined,
-  ): SpatiallyIndexedSkeletonChunk[] {
+  ): VisibleChunk[] {
     if (lod === undefined) {
       return [];
     }
@@ -2674,7 +2726,7 @@ export class SpatiallyIndexedSkeletonLayer
       ),
     );
     const lodSuffix = `:${lod}`;
-    const result: SpatiallyIndexedSkeletonChunk[] = [];
+    const result: VisibleChunk[] = [];
     const seenChunkKeysBySource = new Map<string, Set<string>>();
     for (const scales of transformedSources) {
       for (const tsource of scales) {
@@ -2697,7 +2749,7 @@ export class SpatiallyIndexedSkeletonLayer
               tsource.source as SpatiallyIndexedSkeletonSource;
             const chunk = chunkSource.chunks.get(chunkKey);
             if (chunk?.state !== ChunkState.GPU_MEMORY) return;
-            result.push(chunk);
+            result.push({ chunk, chunkLayout: tsource.chunkLayout });
           },
         );
       }
@@ -2910,7 +2962,7 @@ export class SpatiallyIndexedSkeletonLayer
     modelMatrix: mat4,
     lineWidth: number,
     pointDiameter: number,
-    visibleChunks: SpatiallyIndexedSkeletonChunk[],
+    visibleChunks: VisibleChunk[],
   ) {
     if (visibleChunks.length === 0) return;
     const hasExcludedSegments =
@@ -2926,7 +2978,9 @@ export class SpatiallyIndexedSkeletonLayer
     if (passState === undefined) return;
     const { gl, edgeShader, nodeShader, skeletonParams } = passState;
 
-    for (const chunk of visibleChunks) {
+    const chunkOrigin = vec3.create();
+    const chunkBound = vec3.create();
+    for (const { chunk, chunkLayout } of visibleChunks) {
       if (renderContext.emitPickID) {
         let edgePickId = 0;
         let edgePickStride = 0;
@@ -2959,9 +3013,17 @@ export class SpatiallyIndexedSkeletonLayer
         edgeShader.bind();
         renderHelper.setPickID(gl, edgeShader, edgePickId);
         renderHelper.setPickInstanceStride(gl, edgeShader, edgePickStride);
+        if (skeletonParams.spatialChunkCulling) {
+          vec3.mul(chunkOrigin, chunk.chunkGridPosition, chunkLayout.size);
+          vec3.add(chunkBound, chunkOrigin, chunkLayout.size);
+          renderHelper.setChunkBounds(gl, edgeShader, chunkOrigin, chunkBound);
+        }
         nodeShader.bind();
         renderHelper.setPickID(gl, nodeShader, nodePickId);
         renderHelper.setPickInstanceStride(gl, nodeShader, nodePickStride);
+        if (skeletonParams.spatialChunkCulling) {
+          renderHelper.setChunkBounds(gl, nodeShader, chunkOrigin, chunkBound);
+        }
       }
       // Render each chunk with different node/edge colors for debugging
       if (DEBUG_SPATIAL_SKELETON_CHUNKS) {
@@ -3101,7 +3163,7 @@ export class SpatiallyIndexedSkeletonLayer
     browseRenderHelper: RenderHelper,
     renderOptions: ViewSpecificSkeletonRenderingOptions,
     modelMatrix: mat4,
-    visibleChunks: SpatiallyIndexedSkeletonChunk[],
+    visibleChunks: VisibleChunk[],
   ) {
     const { displayState } = this;
     if (
@@ -3438,7 +3500,7 @@ export class PerspectiveViewSpatiallyIndexedSkeletonLayer extends PerspectiveVie
 
   private drawChunkBoundsWireframe(
     renderContext: PerspectiveViewRenderContext,
-    visibleChunks: SpatiallyIndexedSkeletonChunk[],
+    visibleChunks: VisibleChunk[],
     modelMatrix?: mat4,
   ) {
     if (
@@ -3447,15 +3509,6 @@ export class PerspectiveViewSpatiallyIndexedSkeletonLayer extends PerspectiveVie
       modelMatrix === undefined
     )
       return;
-
-    const chunkLayoutBySource = new Map<object, ChunkLayout>();
-    for (const scales of this.transformedSources) {
-      for (const tsource of scales) {
-        if (!chunkLayoutBySource.has(tsource.source)) {
-          chunkLayoutBySource.set(tsource.source, tsource.chunkLayout);
-        }
-      }
-    }
 
     const { gl } = this.base;
     const wireframeHelper = ChunkWireframeHelper.get(gl);
@@ -3466,10 +3519,7 @@ export class PerspectiveViewSpatiallyIndexedSkeletonLayer extends PerspectiveVie
     mat4.multiply(tempMat4, viewProjectionMat, modelMatrix);
     gl.uniformMatrix4fv(shader.uniform("uChunkToClip"), false, tempMat4);
 
-    for (const chunk of visibleChunks) {
-      const chunkLayout = chunkLayoutBySource.get(chunk.source);
-      if (chunkLayout === undefined) continue;
-
+    for (const { chunk, chunkLayout } of visibleChunks) {
       wireframeHelper.setChunkUniforms(
         gl,
         shader,

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -2450,7 +2450,8 @@ export class SpatiallyIndexedSkeletonLayer
             hasSegmentStatedColors:
               colorGroupState.segmentStatedColors.size !== 0,
             hasSegmentDefaultColor:
-              colorGroupState.segmentDefaultColor.value !== undefined,
+              colorGroupState.segmentDefaultColor.value !== undefined ||
+              DEBUG_SPATIAL_SKELETON_CHUNKS,
             spatialChunkCulling: false,
           };
         };

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -2759,6 +2759,53 @@ export class SpatiallyIndexedSkeletonLayer
     };
   }
 
+  // Iterates every chunk slot in view for the given view/gridLevel/lod.
+  // Callback receives (chunkKey, chunkSource, chunkLayout); return false to stop early.
+  private forEachVisibleChunkSlot(
+    view: SpatiallyIndexedSkeletonView,
+    gridLevel: number | undefined,
+    transformedSources: readonly TransformedSource[][],
+    projectionParameters: ProjectionParameters,
+    lod: number,
+    callback: (
+      chunkKey: string,
+      chunkSource: SpatiallyIndexedSkeletonSource,
+      chunkLayout: ChunkLayout,
+    ) => boolean | void,
+  ) {
+    const selectedSourceIds = new Set(
+      this.selectSourcesForViewAndGrid(view, gridLevel).map((s) =>
+        getObjectId(s.chunkSource),
+      ),
+    );
+    const lodSuffix = `:${lod}`;
+    let shouldContinue = true;
+    for (const scales of transformedSources) {
+      for (const tsource of scales) {
+        if (!shouldContinue) return;
+        if (!selectedSourceIds.has(getObjectId(tsource.source))) continue;
+        forEachVisibleVolumetricChunk(
+          projectionParameters,
+          this.localPosition.value,
+          tsource,
+          (positionInChunks) => {
+            if (!shouldContinue) return;
+            const chunkKey = `${positionInChunks.join()}${lodSuffix}`;
+            if (
+              callback(
+                chunkKey,
+                tsource.source as SpatiallyIndexedSkeletonSource,
+                tsource.chunkLayout,
+              ) === false
+            ) {
+              shouldContinue = false;
+            }
+          },
+        );
+      }
+    }
+  }
+
   getVisibleChunksInCurrentViewAndLod(
     view: SpatiallyIndexedSkeletonView,
     gridLevel: number | undefined,
@@ -2769,40 +2816,20 @@ export class SpatiallyIndexedSkeletonLayer
     if (lod === undefined) {
       return [];
     }
-    const selectedSourceIds = new Set(
-      this.selectSourcesForViewAndGrid(view, gridLevel).map((s) =>
-        getObjectId(s.chunkSource),
-      ),
-    );
-    const lodSuffix = `:${lod}`;
     const result: VisibleChunk[] = [];
-    const seenChunkKeysBySource = new Map<string, Set<string>>();
-    for (const scales of transformedSources) {
-      for (const tsource of scales) {
-        const sourceId = getObjectId(tsource.source);
-        if (!selectedSourceIds.has(sourceId)) continue;
-        let seenChunkKeys = seenChunkKeysBySource.get(sourceId);
-        if (seenChunkKeys === undefined) {
-          seenChunkKeys = new Set<string>();
-          seenChunkKeysBySource.set(sourceId, seenChunkKeys);
+    this.forEachVisibleChunkSlot(
+      view,
+      gridLevel,
+      transformedSources,
+      projectionParameters,
+      lod,
+      (chunkKey, chunkSource, chunkLayout) => {
+        const chunk = chunkSource.chunks.get(chunkKey);
+        if (chunk?.state === ChunkState.GPU_MEMORY) {
+          result.push({ chunk, chunkLayout });
         }
-        forEachVisibleVolumetricChunk(
-          projectionParameters,
-          this.localPosition.value,
-          tsource,
-          (positionInChunks) => {
-            const chunkKey = `${positionInChunks.join()}${lodSuffix}`;
-            if (seenChunkKeys!.has(chunkKey)) return;
-            seenChunkKeys!.add(chunkKey);
-            const chunkSource =
-              tsource.source as SpatiallyIndexedSkeletonSource;
-            const chunk = chunkSource.chunks.get(chunkKey);
-            if (chunk?.state !== ChunkState.GPU_MEMORY) return;
-            result.push({ chunk, chunkLayout: tsource.chunkLayout });
-          },
-        );
-      }
-    }
+      },
+    );
     return result;
   }
 
@@ -2826,52 +2853,23 @@ export class SpatiallyIndexedSkeletonLayer
     if (transformedSources.length === 0) {
       return false;
     }
-    const selectedSourceIds = new Set(
-      this.selectSourcesForViewAndGrid(view, gridLevel).map((s) =>
-        getObjectId(s.chunkSource),
-      ),
-    );
-    const lodSuffix = `:${lod}`;
-    const seenChunkKeysBySource = new Map<string, Set<string>>();
     let ready = true;
-    for (const scales of transformedSources) {
-      for (const tsource of scales) {
-        const sourceId = getObjectId(tsource.source);
-        if (!selectedSourceIds.has(sourceId)) continue;
-        let seenChunkKeys = seenChunkKeysBySource.get(sourceId);
-        if (seenChunkKeys === undefined) {
-          seenChunkKeys = new Set<string>();
-          seenChunkKeysBySource.set(sourceId, seenChunkKeys);
-        }
-        forEachVisibleVolumetricChunk(
-          projectionParameters,
-          this.localPosition.value,
-          tsource,
-          (positionInChunks) => {
-            if (!ready) {
-              return;
-            }
-            const chunkKey = `${positionInChunks.join()}${lodSuffix}`;
-            if (seenChunkKeys!.has(chunkKey)) {
-              return;
-            }
-            seenChunkKeys!.add(chunkKey);
-            const chunkSource =
-              tsource.source as SpatiallyIndexedSkeletonSource;
-            const chunk = chunkSource.chunks.get(chunkKey) as
-              | SpatiallyIndexedSkeletonChunk
-              | undefined;
-            if (chunk?.state !== ChunkState.GPU_MEMORY) {
-              ready = false;
-            }
-          },
-        );
-        if (!ready) {
+    this.forEachVisibleChunkSlot(
+      view,
+      gridLevel,
+      transformedSources,
+      projectionParameters,
+      lod,
+      (chunkKey, chunkSource, _) => {
+        const chunk = chunkSource.chunks.get(chunkKey);
+        if (chunk?.state !== ChunkState.GPU_MEMORY) {
+          ready = false;
           return false;
         }
-      }
-    }
-    return true;
+        return true;
+      },
+    );
+    return ready;
   }
 
   getNode(

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -2807,6 +2807,8 @@ export class SpatiallyIndexedSkeletonLayer
   }
 
   private areVisibleChunksReady(
+    view: SpatiallyIndexedSkeletonView,
+    gridLevel: number | undefined,
     transformedSources: readonly TransformedSource[][],
     projectionParameters: ProjectionParameters,
     lod: number | undefined,
@@ -2824,12 +2826,18 @@ export class SpatiallyIndexedSkeletonLayer
     if (transformedSources.length === 0) {
       return false;
     }
+    const selectedSourceIds = new Set(
+      this.selectSourcesForViewAndGrid(view, gridLevel).map((s) =>
+        getObjectId(s.chunkSource),
+      ),
+    );
     const lodSuffix = `:${lod}`;
     const seenChunkKeysBySource = new Map<string, Set<string>>();
     let ready = true;
     for (const scales of transformedSources) {
       for (const tsource of scales) {
         const sourceId = getObjectId(tsource.source);
+        if (!selectedSourceIds.has(sourceId)) continue;
         let seenChunkKeys = seenChunkKeysBySource.get(sourceId);
         if (seenChunkKeys === undefined) {
           seenChunkKeys = new Set<string>();
@@ -3252,14 +3260,15 @@ export class SpatiallyIndexedSkeletonLayer
   }
 
   isReady(
+    view: SpatiallyIndexedSkeletonView,
+    gridLevel: number | undefined,
     transformedSources: readonly TransformedSource[][],
     projectionParameters: ProjectionParameters,
     lod?: number,
   ) {
-    // TODO (SKM) I don't think this is getting
-    // called as expected, for example, I think
-    // the screenshot should call this but it doesn't seem to
     return this.areVisibleChunksReady(
+      view,
+      gridLevel,
       transformedSources,
       projectionParameters,
       lod,
@@ -3591,11 +3600,12 @@ export class PerspectiveViewSpatiallyIndexedSkeletonLayer extends PerspectiveVie
     >,
   ) {
     const { displayState } = this.base;
-    const lodValue = displayState.skeletonLod?.value;
     return this.base.isReady(
+      "3d",
+      displayState.spatialSkeletonGridLevel3d?.value,
       this.transformedSources,
       renderContext.projectionParameters,
-      lodValue,
+      displayState.skeletonLod?.value,
     );
   }
 }
@@ -3734,11 +3744,12 @@ export class SliceViewPanelSpatiallyIndexedSkeletonLayer extends SliceViewPanelR
     >,
   ) {
     const { displayState } = this.base;
-    const lodValue = displayState.spatialSkeletonLod2d?.value;
     return this.base.isReady(
+      "2d",
+      displayState.spatialSkeletonGridLevel2d?.value,
       this.transformedSources,
       renderContext.projectionParameters,
-      lodValue,
+      displayState.spatialSkeletonLod2d?.value,
     );
   }
 }

--- a/src/skeleton/node_types.spec.ts
+++ b/src/skeleton/node_types.spec.ts
@@ -22,6 +22,7 @@ import {
   getSpatialSkeletonNodeFilterLabel,
   getSpatialSkeletonNodeIconFilterType,
   matchesSpatialSkeletonNodeFilter,
+  SpatialSkeletonDisplayNodeType,
   SpatialSkeletonNodeFilterType,
 } from "#src/skeleton/node_types.js";
 
@@ -68,25 +69,25 @@ describe("skeleton node types", () => {
       isLeaf: true,
       nodeHasDescription: false,
       nodeIsTrueEnd: false,
-      nodeType: "root" as const,
+      nodeType: SpatialSkeletonDisplayNodeType.ROOT,
     };
     const virtualEnd = {
       isLeaf: true,
       nodeHasDescription: false,
       nodeIsTrueEnd: false,
-      nodeType: "virtualEnd" as const,
+      nodeType: SpatialSkeletonDisplayNodeType.VIRTUAL_END,
     };
     const trueEnd = {
       isLeaf: true,
       nodeHasDescription: false,
       nodeIsTrueEnd: true,
-      nodeType: "virtualEnd" as const,
+      nodeType: SpatialSkeletonDisplayNodeType.VIRTUAL_END,
     };
     const describedNode = {
       isLeaf: false,
       nodeHasDescription: true,
       nodeIsTrueEnd: false,
-      nodeType: "regular" as const,
+      nodeType: SpatialSkeletonDisplayNodeType.REGULAR,
     };
 
     expect(
@@ -137,19 +138,19 @@ describe("skeleton node types", () => {
     expect(
       getSpatialSkeletonNodeIconFilterType({
         nodeIsTrueEnd: false,
-        nodeType: "virtualEnd",
+        nodeType: SpatialSkeletonDisplayNodeType.VIRTUAL_END,
       }),
     ).toBe(SpatialSkeletonNodeFilterType.VIRTUAL_END);
     expect(
       getSpatialSkeletonNodeIconFilterType({
         nodeIsTrueEnd: true,
-        nodeType: "regular",
+        nodeType: SpatialSkeletonDisplayNodeType.REGULAR,
       }),
     ).toBe(SpatialSkeletonNodeFilterType.TRUE_END);
     expect(
       getSpatialSkeletonNodeIconFilterType({
         nodeIsTrueEnd: false,
-        nodeType: "root",
+        nodeType: SpatialSkeletonDisplayNodeType.ROOT,
       }),
     ).toBeUndefined();
     expect(

--- a/src/skeleton/node_types.ts
+++ b/src/skeleton/node_types.ts
@@ -16,11 +16,12 @@
 
 import type { SpatiallyIndexedSkeletonNode } from "#src/skeleton/api.js";
 
-export type SpatialSkeletonDisplayNodeType =
-  | "root"
-  | "branchStart"
-  | "regular"
-  | "virtualEnd";
+export enum SpatialSkeletonDisplayNodeType {
+  ROOT = "root",
+  BRANCH_START = "branchStart",
+  REGULAR = "regular",
+  VIRTUAL_END = "virtualEnd",
+}
 
 export enum SpatialSkeletonNodeFilterType {
   NONE,
@@ -36,18 +37,18 @@ export function classifySpatialSkeletonDisplayNodeType(
   parentInTree = true,
 ): SpatialSkeletonDisplayNodeType {
   if (node.parentNodeId === undefined || !parentInTree) {
-    return "root";
+    return SpatialSkeletonDisplayNodeType.ROOT;
   }
   if (childCount === undefined) {
-    return "regular";
+    return SpatialSkeletonDisplayNodeType.REGULAR;
   }
   if (childCount > 1) {
-    return "branchStart";
+    return SpatialSkeletonDisplayNodeType.BRANCH_START;
   }
   if (childCount === 0) {
-    return "virtualEnd";
+    return SpatialSkeletonDisplayNodeType.VIRTUAL_END;
   }
-  return "regular";
+  return SpatialSkeletonDisplayNodeType.REGULAR;
 }
 
 export function getSpatialSkeletonNodeFilterLabel(
@@ -97,7 +98,7 @@ export function getSpatialSkeletonNodeIconFilterType(options: {
   if (options.nodeIsTrueEnd) {
     return SpatialSkeletonNodeFilterType.TRUE_END;
   }
-  if (options.nodeType === "virtualEnd") {
+  if (options.nodeType === SpatialSkeletonDisplayNodeType.VIRTUAL_END) {
     return SpatialSkeletonNodeFilterType.VIRTUAL_END;
   }
   return undefined;

--- a/src/ui/layer_bar.ts
+++ b/src/ui/layer_bar.ts
@@ -42,39 +42,6 @@ import { makeDeleteButton } from "#src/widget/delete_button.js";
 import { makeIcon } from "#src/widget/icon.js";
 import { PositionWidget } from "#src/widget/position_widget.js";
 
-function formatLayerHoverValue(value: unknown) {
-  if (value === undefined || value === null) {
-    return "";
-  }
-  if (typeof value !== "object") {
-    return `${value}`;
-  }
-  const entry = value as {
-    key?: unknown;
-    value?: unknown;
-    label?: unknown;
-  };
-  if (typeof entry.key !== "bigint") {
-    return `${value}`;
-  }
-  const keyString = entry.key.toString();
-  const mappedString =
-    typeof entry.value === "bigint" ? entry.value.toString() : undefined;
-  const baseText =
-    mappedString === undefined ? keyString : `${keyString}→${mappedString}`;
-  if (typeof entry.label !== "string") {
-    return baseText;
-  }
-  const label = entry.label.trim();
-  if (
-    label.length === 0 ||
-    label === keyString ||
-    (mappedString !== undefined && label === mappedString)
-  ) {
-    return baseText;
-  }
-  return `${baseText} ${label}`;
-}
 
 class LayerWidget extends RefCounted {
   element = document.createElement("div");
@@ -469,7 +436,7 @@ export class LayerBar extends RefCounted {
         if (state !== undefined) {
           const { value } = state;
           if (value !== undefined) {
-            text = formatLayerHoverValue(value);
+            text = "" + value;
           }
         }
       }

--- a/src/ui/spatial_skeleton_edit_tab.ts
+++ b/src/ui/spatial_skeleton_edit_tab.ts
@@ -63,8 +63,8 @@ import {
 import {
   getSpatialSkeletonNodeFilterLabel,
   getSpatialSkeletonNodeIconFilterType,
+  SpatialSkeletonDisplayNodeType,
   SpatialSkeletonNodeFilterType,
-  type SpatialSkeletonDisplayNodeType,
 } from "#src/skeleton/node_types.js";
 import { StatusMessage } from "#src/status.js";
 import { observeWatchable, registerNested } from "#src/trackable_value.js";
@@ -142,17 +142,17 @@ interface SpatiallyIndexedSkeletonNavigationApi {
 }
 
 const NODE_TYPE_ICONS: Record<SpatialSkeletonDisplayNodeType, string> = {
-  root: svg_origin,
-  branchStart: svg_share_android,
-  regular: svg_minus,
-  virtualEnd: svg_circle,
+  [SpatialSkeletonDisplayNodeType.ROOT]: svg_origin,
+  [SpatialSkeletonDisplayNodeType.BRANCH_START]: svg_share_android,
+  [SpatialSkeletonDisplayNodeType.REGULAR]: svg_minus,
+  [SpatialSkeletonDisplayNodeType.VIRTUAL_END]: svg_circle,
 };
 
 const NODE_TYPE_LABELS: Record<SpatialSkeletonDisplayNodeType, string> = {
-  root: "root",
-  branchStart: "branch start",
-  regular: "regular",
-  virtualEnd: "virtual end",
+  [SpatialSkeletonDisplayNodeType.ROOT]: "root",
+  [SpatialSkeletonDisplayNodeType.BRANCH_START]: "branch start",
+  [SpatialSkeletonDisplayNodeType.REGULAR]: "regular",
+  [SpatialSkeletonDisplayNodeType.VIRTUAL_END]: "virtual end",
 };
 
 export class SpatialSkeletonEditTab extends Tab {

--- a/src/ui/spatial_skeleton_edit_tab_render.ts
+++ b/src/ui/spatial_skeleton_edit_tab_render.ts
@@ -22,9 +22,11 @@ import {
 import {
   classifySpatialSkeletonDisplayNodeType as classifyNodeType,
   matchesSpatialSkeletonNodeFilter,
+  SpatialSkeletonDisplayNodeType,
   SpatialSkeletonNodeFilterType,
-  type SpatialSkeletonDisplayNodeType as SkeletonNodeType,
 } from "#src/skeleton/node_types.js";
+
+type SkeletonNodeType = SpatialSkeletonDisplayNodeType;
 
 function nodeMatchesFilter(
   node: SpatiallyIndexedSkeletonNode,
@@ -141,7 +143,7 @@ export function buildSpatialSkeletonSegmentRenderState(
     const parentInTree =
       node.parentNodeId !== undefined && nodeById.has(node.parentNodeId);
     const type = classifyNodeType(node, children.length, parentInTree);
-    if (type === "regular" && !(node.isTrueEnd ?? false)) {
+    if (type === SpatialSkeletonDisplayNodeType.REGULAR && !(node.isTrueEnd ?? false)) {
       continue;
     }
     rows.push({ node, type, isLeaf: children.length === 0 });


### PR DESCRIPTION
- **refactor: use annotationId pattern for nodeId**
- **revert: remove uneeded format hover this was used when we initially had ID=label**
- **python: add state for new viewer state related to skesl**
- **refactor: convert node type as str to enum**
