### PR TITLE
fix: bump overlay retained segs

### DIFF
--- a/src/skeleton/segment_overlay.ts
+++ b/src/skeleton/segment_overlay.ts
@@ -144,7 +144,7 @@ export function buildSpatiallyIndexedSkeletonOverlayGeometry(
   };
 }
 
-export const DEFAULT_MAX_RETAINED_OVERLAY_SEGMENTS = 4;
+export const DEFAULT_MAX_RETAINED_OVERLAY_SEGMENTS = 16;
 
 function normalizeSegmentId(segmentId: number) {
   const normalizedSegmentId = Math.round(Number(segmentId));


### PR DESCRIPTION
Bumps the default number of segments kept in the overlay, and removes empty segments from the overlay before they roll away naturally due to the max limit