### PR TITLE
refactor: Deduplicate catmaid spatially indexed skeletons code

### DIFF
--- a/src/datasource/catmaid/api.spec.ts
+++ b/src/datasource/catmaid/api.spec.ts
@@ -517,7 +517,7 @@ describe("CatmaidClient skeleton editing methods", () => {
     (client as any).fetch = fetchMock;
 
     await expect(
-      client.fetchNodesInBoundingBox({
+      client.fetchNodes({
         lowerBounds: [0, 0, 0],
         upperBounds: [10, 10, 10],
       }),
@@ -557,7 +557,7 @@ describe("CatmaidClient skeleton editing methods", () => {
     (client as any).fetch = fetchMock;
 
     await expect(
-      client.fetchNodesInBoundingBox({
+      client.fetchNodes({
         lowerBounds: [0, 0],
         upperBounds: [10, 10],
       }),

--- a/src/datasource/catmaid/api.ts
+++ b/src/datasource/catmaid/api.ts
@@ -59,6 +59,7 @@ type CatmaidFetchPriority = "high" | "low" | "auto";
 type CatmaidRequestInit = RequestInit & { priority?: CatmaidFetchPriority };
 
 export type CatmaidNodeSourceState = { readonly revisionToken: string };
+export type CatmaidRank3Vector = readonly [number, number, number];
 
 export interface CatmaidEditNodeContext {
   nodeId: number;
@@ -568,10 +569,10 @@ function getDefaultCatmaidSpatialIndexLevel(
   };
 }
 
-function requireCatmaidRank3Vector(
+export function requireCatmaidRank3Vector(
   vector: SpatialSkeletonVector,
   label: string,
-): readonly [number, number, number] {
+): CatmaidRank3Vector {
   if (vector.length < 3) {
     throw new Error(`CATMAID ${label} requires at least 3 coordinates.`);
   }
@@ -586,10 +587,10 @@ function requireCatmaidRank3Vector(
   return values;
 }
 
-function requireCatmaidPositiveRank3Vector(
+export function requireCatmaidPositiveRank3Vector(
   value: unknown,
   label: string,
-): readonly [number, number, number] {
+): CatmaidRank3Vector {
   if (!Array.isArray(value) || value.length !== 3) {
     throw new Error(`CATMAID ${label} must be a rank-3 array.`);
   }
@@ -604,6 +605,13 @@ function requireCatmaidPositiveRank3Vector(
     );
   }
   return values;
+}
+
+export function toCatmaidPositionInModelSpace(
+  position: SpatialSkeletonVector,
+  label: string,
+) {
+  return new Float32Array(requireCatmaidRank3Vector(position, label));
 }
 
 function requireCatmaidNonNegativeInt(value: unknown, label: string): number {
@@ -1426,7 +1434,7 @@ export class CatmaidClient implements CatmaidSpatialSkeletonEditApi {
     }));
   }
 
-  async fetchNodesInBoundingBox(
+  async fetchNodes(
     bounds: SpatialSkeletonBounds,
     lod: number = 0,
     options: {

--- a/src/datasource/catmaid/backend.ts
+++ b/src/datasource/catmaid/backend.ts
@@ -16,14 +16,15 @@
 
 import { WithParameters } from "#src/chunk_manager/backend.js";
 import { WithSharedCredentialsProviderCounterpart } from "#src/credentials_provider/shared_counterpart.js";
-import type { CatmaidToken } from "#src/datasource/catmaid/api.js";
-import {
+import type {
   CatmaidClient,
-  getCatmaidSpatialSkeletonGridCellBounds,
+  CatmaidToken,
 } from "#src/datasource/catmaid/api.js";
+import { getCatmaidSpatialSkeletonGridCellBounds } from "#src/datasource/catmaid/api.js";
 import {
   CatmaidSkeletonSourceParameters,
   CatmaidCompleteSkeletonSourceParameters,
+  makeCatmaidClient,
 } from "#src/datasource/catmaid/base.js";
 import { packCatmaidSkeletonNodes } from "#src/datasource/catmaid/skeleton_packing.js";
 import type {
@@ -46,17 +47,10 @@ export class CatmaidSpatiallyIndexedSkeletonSourceBackend extends WithParameters
   private clientInstance: CatmaidClient | undefined;
 
   get client(): CatmaidClient {
-    let client = this.clientInstance;
-    if (client === undefined) {
-      const { catmaidParameters } = this.parameters;
-      client = new CatmaidClient(
-        catmaidParameters.url,
-        catmaidParameters.projectId,
-        this.credentialsProvider,
-      );
-      this.clientInstance = client;
-    }
-    return client;
+    return (this.clientInstance ??= makeCatmaidClient(
+      this.parameters.catmaidParameters,
+      this.credentialsProvider,
+    ));
   }
 
   constructor(...args: any[]) {
@@ -72,7 +66,7 @@ export class CatmaidSpatiallyIndexedSkeletonSourceBackend extends WithParameters
     );
     const lodValue = this.parameters.catmaidLod ?? 0;
     const cacheProvider = this.parameters.catmaidParameters.cacheProvider;
-    const nodes = await this.client.fetchNodesInBoundingBox(bounds, lodValue, {
+    const nodes = await this.client.fetchNodes(bounds, lodValue, {
       cacheProvider,
       signal,
     });
@@ -96,17 +90,10 @@ export class CatmaidSkeletonSourceBackend extends WithParameters(
   private clientInstance: CatmaidClient | undefined;
 
   get client(): CatmaidClient {
-    let client = this.clientInstance;
-    if (client === undefined) {
-      const { catmaidParameters } = this.parameters;
-      client = new CatmaidClient(
-        catmaidParameters.url,
-        catmaidParameters.projectId,
-        this.credentialsProvider,
-      );
-      this.clientInstance = client;
-    }
-    return client;
+    return (this.clientInstance ??= makeCatmaidClient(
+      this.parameters.catmaidParameters,
+      this.credentialsProvider,
+    ));
   }
 
   constructor(...args: any[]) {

--- a/src/datasource/catmaid/base.ts
+++ b/src/datasource/catmaid/base.ts
@@ -14,7 +14,15 @@
  * limitations under the License.
  */
 
-import { SkeletonSourceParameters } from "#src/datasource/precomputed/base.js";
+import type { CredentialsProvider } from "#src/credentials_provider/index.js";
+import type { CatmaidToken } from "#src/datasource/catmaid/api.js";
+import { CatmaidClient } from "#src/datasource/catmaid/api.js";
+import {
+  SkeletonSourceParameters,
+  type SkeletonMetadata,
+} from "#src/datasource/precomputed/base.js";
+import { DataType } from "#src/util/data_type.js";
+import { mat4 } from "#src/util/geom.js";
 
 export class CatmaidDataSourceParameters {
   url!: string;
@@ -33,4 +41,25 @@ export class CatmaidSkeletonSourceParameters extends SkeletonSourceParameters {
 export class CatmaidCompleteSkeletonSourceParameters extends SkeletonSourceParameters {
   catmaidParameters!: CatmaidDataSourceParameters;
   static RPC_ID = "catmaid/CompleteSkeletonSource";
+}
+
+export function makeCatmaidClient(
+  parameters: CatmaidDataSourceParameters,
+  credentialsProvider?: CredentialsProvider<CatmaidToken>,
+) {
+  return new CatmaidClient(
+    parameters.url,
+    parameters.projectId,
+    credentialsProvider,
+  );
+}
+
+export function makeCatmaidSkeletonMetadata(): SkeletonMetadata {
+  return {
+    transform: mat4.create(),
+    vertexAttributes: new Map([
+      ["segment", { dataType: DataType.UINT32, numComponents: 1 }],
+    ]),
+    sharding: undefined,
+  };
 }

--- a/src/datasource/catmaid/frontend.ts
+++ b/src/datasource/catmaid/frontend.ts
@@ -23,10 +23,12 @@ import {
 } from "#src/coordinate_transform.js";
 import { WithCredentialsProvider } from "#src/credentials_provider/chunk_source_frontend.js";
 import type { CredentialsProvider } from "#src/credentials_provider/index.js";
-import type { CatmaidToken } from "#src/datasource/catmaid/api.js";
+import type {
+  CatmaidClient,
+  CatmaidToken,
+} from "#src/datasource/catmaid/api.js";
 import {
   CATMAID_SPATIAL_SKELETON_CONFIDENCE_VALUES,
-  CatmaidClient,
   credentialsKey,
   getCatmaidSpatialSkeletonGridCellBounds,
 } from "#src/datasource/catmaid/api.js";
@@ -34,6 +36,8 @@ import {
   CatmaidSkeletonSourceParameters,
   CatmaidCompleteSkeletonSourceParameters,
   CatmaidDataSourceParameters,
+  makeCatmaidClient,
+  makeCatmaidSkeletonMetadata,
 } from "#src/datasource/catmaid/base.js";
 import { CatmaidSpatialSkeletonEditCommands } from "#src/datasource/catmaid/spatial_skeleton_commands.js";
 import type {
@@ -58,11 +62,15 @@ import {
   MultiscaleSpatiallyIndexedSkeletonSource,
   SPATIAL_SKELETON_SOURCE_OPTIONS,
 } from "#src/skeleton/frontend.js";
+import {
+  buildSpatialSkeletonGridLevels,
+  type SpatialSkeletonGridLevel,
+  type SpatialSkeletonGridSize,
+} from "#src/skeleton/spatial_chunk_sizing.js";
 import type { SliceViewSourceOptions } from "#src/sliceview/base.js";
 import { makeSliceViewChunkSpecification } from "#src/sliceview/base.js";
 import { ChunkLayout } from "#src/sliceview/chunk_layout.js";
 import type { SliceViewSingleResolutionSource } from "#src/sliceview/frontend.js";
-import { DataType } from "#src/util/data_type.js";
 import type { Borrowed } from "#src/util/disposable.js";
 import { mat4, vec3 } from "#src/util/geom.js";
 import "#src/datasource/catmaid/register_credentials_provider.js";
@@ -140,18 +148,10 @@ export class CatmaidSpatiallyIndexedSkeletonSource extends WithParameters(
   }
 
   private get client() {
-    let client = this.client_;
-    if (client !== undefined) {
-      return client;
-    }
-    const catmaidParameters = this.parameters.catmaidParameters;
-    client = new CatmaidClient(
-      catmaidParameters.url,
-      catmaidParameters.projectId,
+    return (this.client_ ??= makeCatmaidClient(
+      this.parameters.catmaidParameters,
       this.credentialsProvider,
-    );
-    this.client_ = client;
-    return client;
+    ));
   }
 
   getSkeleton(
@@ -179,14 +179,10 @@ export class CatmaidSpatiallyIndexedSkeletonSource extends WithParameters(
       cellIndex.cell,
       this.spec.chunkDataSize,
     );
-    return this.client.fetchNodesInBoundingBox(
-      bounds,
-      this.parameters.catmaidLod ?? 0,
-      {
-        cacheProvider: this.parameters.catmaidParameters.cacheProvider,
-        signal: options.signal,
-      },
-    );
+    return this.client.fetchNodes(bounds, this.parameters.catmaidLod ?? 0, {
+      cacheProvider: this.parameters.catmaidParameters.cacheProvider,
+      signal: options.signal,
+    });
   }
 
   getSkeletonRootNode(skeletonId: number) {
@@ -208,7 +204,7 @@ export class CatmaidMultiscaleSpatiallyIndexedSkeletonSource extends MultiscaleS
     return 3;
   }
 
-  private sortedGridCellSizes: Array<{ x: number; y: number; z: number }>;
+  private gridLevels: SpatialSkeletonGridLevel[];
 
   constructor(
     chunkManager: Borrowed<ChunkManager>,
@@ -218,18 +214,16 @@ export class CatmaidMultiscaleSpatiallyIndexedSkeletonSource extends MultiscaleS
     private coordinateScaleFactorsInMeters: Float32Array,
     private lowerBoundsInNanometers: Float32Array,
     private upperBoundsInNanometers: Float32Array,
-    gridCellSizes: Array<{ x: number; y: number; z: number }>,
+    gridCellSizes: SpatialSkeletonGridSize[],
     private cacheProvider?: string,
     private sourceReadonly = true,
   ) {
     super(chunkManager);
-    this.sortedGridCellSizes = [...gridCellSizes].sort(
-      (a, b) => Math.min(b.x, b.y, b.z) - Math.min(a.x, a.y, a.z),
-    );
+    this.gridLevels = buildSpatialSkeletonGridLevels(gridCellSizes);
   }
 
-  getSpatialSkeletonGridSizes(): Array<{ x: number; y: number; z: number }> {
-    return this.sortedGridCellSizes;
+  getSpatialSkeletonGridSizes(): SpatialSkeletonGridSize[] {
+    return this.gridLevels.map(({ size }) => size);
   }
 
   getPerspectiveSources(): SliceViewSingleResolutionSource<SpatiallyIndexedSkeletonSource>[] {
@@ -247,11 +241,10 @@ export class CatmaidMultiscaleSpatiallyIndexedSkeletonSource extends MultiscaleS
     const sources: SliceViewSingleResolutionSource<SpatiallyIndexedSkeletonSource>[] =
       [];
 
-    // Sorted by minimum dimension (Descending: Large/Coarse -> Small/Fine)
-    const sortedGridSizes = this.sortedGridCellSizes;
-
-    const lastGridIndex = sortedGridSizes.length - 1;
-    for (const [gridIndex, gridCellSize] of sortedGridSizes.entries()) {
+    for (const [
+      gridIndex,
+      { size: gridCellSize, lod },
+    ] of this.gridLevels.entries()) {
       const chunkDataSize = Uint32Array.from([
         gridCellSize.x,
         gridCellSize.y,
@@ -291,15 +284,8 @@ export class CatmaidMultiscaleSpatiallyIndexedSkeletonSource extends MultiscaleS
       parameters.catmaidParameters.cacheProvider = this.cacheProvider;
       parameters.catmaidParameters.readonly = this.sourceReadonly;
       parameters.gridIndex = gridIndex;
-      parameters.catmaidLod =
-        lastGridIndex <= 0 ? 0 : gridIndex / lastGridIndex;
-      parameters.metadata = {
-        transform: mat4.create(),
-        vertexAttributes: new Map([
-          ["segment", { dataType: DataType.UINT32, numComponents: 1 }],
-        ]),
-        sharding: undefined,
-      };
+      parameters.catmaidLod = lod;
+      parameters.metadata = makeCatmaidSkeletonMetadata();
 
       const chunkSource = this.chunkManager.getChunkSource(
         CatmaidSpatiallyIndexedSkeletonSource,
@@ -362,7 +348,10 @@ export class CatmaidDataSourceProvider implements DataSourceProvider {
         { serverUrl: baseUrl },
       ) as CredentialsProvider<CatmaidToken>;
 
-    const client = new CatmaidClient(baseUrl, projectId, credentialsProvider);
+    const client = makeCatmaidClient(
+      { url: baseUrl, projectId, readonly: true },
+      credentialsProvider,
+    );
 
     // Fetch metadata-derived values through the generic source interface.
     const [spatialIndexMetadata, cacheProvider, skeletonIds] =
@@ -453,13 +442,7 @@ export class CatmaidDataSourceProvider implements DataSourceProvider {
     completeSkeletonParameters.catmaidParameters.url = baseUrl;
     completeSkeletonParameters.catmaidParameters.projectId = projectId;
     completeSkeletonParameters.url = providerUrl;
-    completeSkeletonParameters.metadata = {
-      transform: mat4.create(),
-      vertexAttributes: new Map([
-        ["segment", { dataType: DataType.UINT32, numComponents: 1 }],
-      ]),
-      sharding: undefined,
-    };
+    completeSkeletonParameters.metadata = makeCatmaidSkeletonMetadata();
 
     const completeSkeletonSource = options.registry.chunkManager.getChunkSource(
       CatmaidSkeletonSource,

--- a/src/datasource/catmaid/spatial_skeleton_commands.ts
+++ b/src/datasource/catmaid/spatial_skeleton_commands.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import type { CatmaidClient } from "#src/datasource/catmaid/api.js";
+import {
+  toCatmaidPositionInModelSpace,
+  type CatmaidClient,
+} from "#src/datasource/catmaid/api.js";
 import {
   buildCatmaidInsertEditContext,
   buildCatmaidMultiNodeEditContext,
@@ -445,24 +448,6 @@ function requireCatmaidMergeCommandPayload(payload: object) {
   );
 }
 
-function toCatmaidPositionInModelSpace(
-  position: SpatialSkeletonVector,
-  label: string,
-) {
-  if (position.length < 3) {
-    throw new Error(`CATMAID ${label} requires at least 3 coordinates.`);
-  }
-  const values = [
-    Number(position[0]),
-    Number(position[1]),
-    Number(position[2]),
-  ];
-  if (values.some((value) => !Number.isFinite(value))) {
-    throw new Error(`CATMAID ${label} coordinates must be finite.`);
-  }
-  return new Float32Array(values);
-}
-
 function cloneNodeSnapshot(
   node: SpatiallyIndexedSkeletonNode,
 ): SpatiallyIndexedSkeletonNode {
@@ -496,20 +481,27 @@ function getEditableSkeletonSourceForLayer(layer: SegmentationUserLayer): {
   return { skeletonLayer };
 }
 
+function normalizePositiveSegmentId(segmentId: number | undefined) {
+  if (segmentId === undefined) {
+    return undefined;
+  }
+  const normalizedSegmentId = Math.round(Number(segmentId));
+  return Number.isSafeInteger(normalizedSegmentId) && normalizedSegmentId > 0
+    ? normalizedSegmentId
+    : undefined;
+}
+
 function ensureVisibleSegment(
   layer: SegmentationUserLayer,
   segmentId: number | undefined,
 ) {
-  if (
-    segmentId === undefined ||
-    !Number.isSafeInteger(Math.round(Number(segmentId))) ||
-    Math.round(Number(segmentId)) <= 0
-  ) {
+  const normalizedSegmentId = normalizePositiveSegmentId(segmentId);
+  if (normalizedSegmentId === undefined) {
     return;
   }
   addSegmentToVisibleSets(
     layer.displayState.segmentationGroupState.value,
-    BigInt(Math.round(Number(segmentId))),
+    BigInt(normalizedSegmentId),
   );
 }
 
@@ -518,14 +510,11 @@ function selectSegment(
   segmentId: number | undefined,
   pin: boolean,
 ) {
-  if (
-    segmentId === undefined ||
-    !Number.isSafeInteger(Math.round(Number(segmentId))) ||
-    Math.round(Number(segmentId)) <= 0
-  ) {
+  const normalizedSegmentId = normalizePositiveSegmentId(segmentId);
+  if (normalizedSegmentId === undefined) {
     return;
   }
-  layer.selectSegment(BigInt(Math.round(Number(segmentId))), pin);
+  layer.selectSegment(BigInt(normalizedSegmentId), pin);
 }
 
 function removeVisibleSegment(
@@ -535,16 +524,13 @@ function removeVisibleSegment(
     deselect?: boolean;
   } = {},
 ) {
-  if (
-    segmentId === undefined ||
-    !Number.isSafeInteger(Math.round(Number(segmentId))) ||
-    Math.round(Number(segmentId)) <= 0
-  ) {
+  const normalizedSegmentId = normalizePositiveSegmentId(segmentId);
+  if (normalizedSegmentId === undefined) {
     return;
   }
   removeSegmentFromVisibleSets(
     layer.displayState.segmentationGroupState.value,
-    BigInt(Math.round(Number(segmentId))),
+    BigInt(normalizedSegmentId),
     options,
   );
 }
@@ -721,9 +707,11 @@ async function refreshTopologySegments(
   const preRefreshPositions = [...affectedPositions];
   const normalizedSegmentIds = [
     ...new Set(
-      segmentIds.filter((value) => Number.isSafeInteger(Math.round(value))),
+      segmentIds
+        .map(normalizePositiveSegmentId)
+        .filter((value): value is number => value !== undefined),
     ),
-  ].map((value) => Math.round(value));
+  ];
   if (normalizedSegmentIds.length === 0) {
     return;
   }
@@ -740,16 +728,20 @@ async function refreshTopologySegments(
   );
 }
 
-function applyAddNodeToCache(
+function applyCreatedNodeToCache(
   layer: SegmentationUserLayer,
   skeletonLayer: SpatiallyIndexedSkeletonLayer,
   committedNode: CatmaidSpatialSkeletonAddNodeResult,
   parentNodeId: number | undefined,
-  positionInModelSpace: Float32Array,
+  positionInModelSpace: SpatialSkeletonVector,
   options: {
-    focusSelection: boolean;
+    childNodes?: readonly SpatiallyIndexedSkeletonNode[];
+    focusSelection?: boolean;
+    markChanged?: boolean;
     moveView: boolean;
     pinSegment: boolean;
+    retainOverlaySegment?: boolean;
+    selectSegment?: boolean;
   },
 ) {
   const newNode: SpatiallyIndexedSkeletonNode = {
@@ -765,6 +757,12 @@ function applyAddNodeToCache(
   layer.spatialSkeletonState.upsertCachedNode(newNode, {
     allowUncachedSegment: parentNodeId === undefined,
   });
+  for (const childNode of options.childNodes ?? []) {
+    layer.spatialSkeletonState.setCachedNodeParent(
+      childNode.nodeId,
+      newNode.nodeId,
+    );
+  }
   if (
     parentNodeId !== undefined &&
     committedNode.parentSourceState !== undefined
@@ -774,8 +772,15 @@ function applyAddNodeToCache(
       committedNode.parentSourceState,
     );
   }
+  if (committedNode.nodeSourceStateUpdates?.length) {
+    layer.spatialSkeletonState.setCachedNodeSourceStates(
+      committedNode.nodeSourceStateUpdates,
+    );
+  }
   ensureVisibleSegment(layer, newNode.segmentId);
-  selectSegment(layer, newNode.segmentId, options.pinSegment);
+  if (options.selectSegment ?? true) {
+    selectSegment(layer, newNode.segmentId, options.pinSegment);
+  }
   if (options.focusSelection) {
     layer.selectSpatialSkeletonNode(
       newNode.nodeId,
@@ -789,12 +794,15 @@ function applyAddNodeToCache(
       layer.moveViewToSpatialSkeletonNodePosition(newNode.position);
     }
   }
-  if (parentNodeId !== undefined) {
+  if (options.retainOverlaySegment) {
     skeletonLayer.retainOverlaySegment(newNode.segmentId);
   }
-  layer.markSpatialSkeletonNodeDataChanged({
-    invalidateFullSkeletonCache: false,
-  });
+  if (options.markChanged ?? true) {
+    layer.markSpatialSkeletonNodeDataChanged({
+      invalidateFullSkeletonCache: false,
+    });
+  }
+  return newNode;
 }
 
 function applyDeleteNodeToCache(
@@ -864,6 +872,42 @@ function invalidateDeletedNodeSourceCells(
     deleteContext.parentNode?.position,
     ...deleteContext.childNodes.map((child) => child.position),
   ]);
+}
+
+async function commitAndApplyDeleteNode(
+  layer: SegmentationUserLayer,
+  editOperations: CatmaidSpatialSkeletonEditOperations,
+  stableNodeId: number,
+  stableSegmentId: number | undefined,
+  options: {
+    childMode: "none" | "context";
+    invalidateSourceCells: boolean;
+    moveView: boolean;
+  },
+) {
+  const resolvedNode = await getResolvedNodeForEdit(
+    layer,
+    stableNodeId,
+    stableSegmentId,
+  );
+  const deleteContext = await layer.getSpatialSkeletonDeleteOperationContext(
+    resolvedNode.node,
+  );
+  const result = await editOperations.commitDeleteNode({
+    node: deleteContext.node,
+    childNodes: options.childMode === "none" ? [] : deleteContext.childNodes,
+    segmentNodes: resolvedNode.segmentNodes,
+  });
+  applyDeleteNodeToCache(
+    layer,
+    deleteContext,
+    { moveView: options.moveView },
+    result.nodeSourceStateUpdates,
+  );
+  if (options.invalidateSourceCells) {
+    invalidateDeletedNodeSourceCells(resolvedNode.skeletonLayer, deleteContext);
+  }
+  return { resolvedNode };
 }
 
 async function applyNodeDescriptionAndTrueEnd(
@@ -1016,16 +1060,17 @@ class AddNodeCommand implements SpatialSkeletonCommand {
         result.segmentId,
       );
     }
-    applyAddNodeToCache(
+    applyCreatedNodeToCache(
       this.layer,
       skeletonLayer,
       result,
-      currentParentNodeId,
+      parentNode?.nodeId,
       this.positionInModelSpace,
       {
         focusSelection: true,
         moveView: options.moveView,
         pinSegment: options.pinSegment,
+        retainOverlaySegment: parentNode !== undefined,
       },
     );
     StatusMessage.showTemporaryMessage(
@@ -1045,25 +1090,16 @@ class AddNodeCommand implements SpatialSkeletonCommand {
     if (this.stableNodeId === undefined) {
       throw new Error("Add-node undo is missing the created node id.");
     }
-    const resolvedNode = await getResolvedNodeForEdit(
+    const { resolvedNode } = await commitAndApplyDeleteNode(
       this.layer,
+      this.editOperations,
       this.stableNodeId,
       this.stableSegmentId,
-    );
-    const deleteContext =
-      await this.layer.getSpatialSkeletonDeleteOperationContext(
-        resolvedNode.node,
-      );
-    const result = await this.editOperations.commitDeleteNode({
-      node: deleteContext.node,
-      childNodes: [],
-      segmentNodes: resolvedNode.segmentNodes,
-    });
-    applyDeleteNodeToCache(
-      this.layer,
-      deleteContext,
-      { moveView: true },
-      result.nodeSourceStateUpdates,
+      {
+        childMode: "none",
+        invalidateSourceCells: false,
+        moveView: true,
+      },
     );
     StatusMessage.showTemporaryMessage(
       `Undid add node ${resolvedNode.node.nodeId}.`,
@@ -1137,51 +1173,20 @@ class InsertNodeCommand implements SpatialSkeletonCommand {
         result.segmentId,
       );
     }
-    const newNode: SpatiallyIndexedSkeletonNode = {
-      nodeId: result.nodeId,
-      segmentId: result.segmentId,
-      position: new Float32Array(this.positionInModelSpace),
-      parentNodeId: parentNode.nodeId,
-      isTrueEnd: false,
-      ...(result.sourceState === undefined
-        ? {}
-        : { sourceState: result.sourceState }),
-    };
-    this.layer.spatialSkeletonState.upsertCachedNode(newNode);
-    for (const childNode of childNodes) {
-      this.layer.spatialSkeletonState.setCachedNodeParent(
-        childNode.nodeId,
-        newNode.nodeId,
-      );
-    }
-    if (result.parentSourceState !== undefined) {
-      this.layer.spatialSkeletonState.setCachedNodeSourceState(
-        parentNode.nodeId,
-        result.parentSourceState,
-      );
-    }
-    if (result.nodeSourceStateUpdates?.length) {
-      this.layer.spatialSkeletonState.setCachedNodeSourceStates(
-        result.nodeSourceStateUpdates,
-      );
-    }
-    ensureVisibleSegment(this.layer, newNode.segmentId);
-    selectSegment(this.layer, newNode.segmentId, options.pinSegment);
-    this.layer.selectSpatialSkeletonNode(
-      newNode.nodeId,
-      this.layer.manager.root.selectionState.pin.value,
+    applyCreatedNodeToCache(
+      this.layer,
+      skeletonLayer,
+      result,
+      parentNode.nodeId,
+      this.positionInModelSpace,
       {
-        segmentId: newNode.segmentId,
-        position: newNode.position,
+        childNodes,
+        focusSelection: true,
+        moveView: options.moveView,
+        pinSegment: options.pinSegment,
+        retainOverlaySegment: true,
       },
     );
-    if (options.moveView) {
-      this.layer.moveViewToSpatialSkeletonNodePosition(newNode.position);
-    }
-    skeletonLayer.retainOverlaySegment(newNode.segmentId);
-    this.layer.markSpatialSkeletonNodeDataChanged({
-      invalidateFullSkeletonCache: false,
-    });
     StatusMessage.showTemporaryMessage(
       `${options.statusPrefix} node ${result.nodeId} on segment ${result.segmentId}.`,
     );
@@ -1191,27 +1196,17 @@ class InsertNodeCommand implements SpatialSkeletonCommand {
     if (this.stableNodeId === undefined) {
       throw new Error("Insert-node undo is missing the created node id.");
     }
-    const resolvedNode = await getResolvedNodeForEdit(
+    const { resolvedNode } = await commitAndApplyDeleteNode(
       this.layer,
+      this.editOperations,
       this.stableNodeId,
       this.stableSegmentId,
+      {
+        childMode: "context",
+        invalidateSourceCells: true,
+        moveView: false,
+      },
     );
-    const deleteContext =
-      await this.layer.getSpatialSkeletonDeleteOperationContext(
-        resolvedNode.node,
-      );
-    const result = await this.editOperations.commitDeleteNode({
-      node: deleteContext.node,
-      childNodes: deleteContext.childNodes,
-      segmentNodes: resolvedNode.segmentNodes,
-    });
-    applyDeleteNodeToCache(
-      this.layer,
-      deleteContext,
-      { moveView: false },
-      result.nodeSourceStateUpdates,
-    );
-    invalidateDeletedNodeSourceCells(resolvedNode.skeletonLayer, deleteContext);
     StatusMessage.showTemporaryMessage(
       `${statusPrefix} inserted node ${resolvedNode.node.nodeId}.`,
     );
@@ -1329,34 +1324,24 @@ class DeleteNodeCommand implements SpatialSkeletonCommand {
     moveView: boolean;
     statusPrefix: string;
   }) {
-    const resolvedNode = await getResolvedNodeForEdit(
+    const { resolvedNode } = await commitAndApplyDeleteNode(
       this.layer,
+      this.editOperations,
       this.stableDeletedNodeId,
       this.stableSegmentId,
+      {
+        childMode: "context",
+        invalidateSourceCells: true,
+        moveView: options.moveView,
+      },
     );
-    const deleteContext =
-      await this.layer.getSpatialSkeletonDeleteOperationContext(
-        resolvedNode.node,
-      );
-    const result = await this.editOperations.commitDeleteNode({
-      node: deleteContext.node,
-      childNodes: deleteContext.childNodes,
-      segmentNodes: resolvedNode.segmentNodes,
-    });
-    applyDeleteNodeToCache(
-      this.layer,
-      deleteContext,
-      { moveView: options.moveView },
-      result.nodeSourceStateUpdates,
-    );
-    invalidateDeletedNodeSourceCells(resolvedNode.skeletonLayer, deleteContext);
     StatusMessage.showTemporaryMessage(
       `${options.statusPrefix} node ${resolvedNode.node.nodeId}.`,
     );
   }
 
   private async restoreDeletedNode(statusPrefix: string) {
-    getEditableSkeletonSourceForLayer(this.layer);
+    const { skeletonLayer } = getEditableSkeletonSourceForLayer(this.layer);
     const currentParentNode =
       this.stableParentNodeId === undefined
         ? undefined
@@ -1410,37 +1395,22 @@ class DeleteNodeCommand implements SpatialSkeletonCommand {
         createResult.segmentId,
       );
     }
-    const restoredNode: SpatiallyIndexedSkeletonNode = {
-      nodeId: createResult.nodeId,
-      segmentId: createResult.segmentId,
-      position: new Float32Array(this.deletedSnapshot.position),
-      parentNodeId: currentParentNode?.nodeId,
-      sourceState: createResult.sourceState,
-      radius: undefined,
-      confidence: undefined,
-      description: undefined,
-      isTrueEnd: false,
-    };
-    this.layer.spatialSkeletonState.upsertCachedNode(restoredNode, {
-      allowUncachedSegment: currentParentNode === undefined,
-    });
-    for (const childNode of currentChildNodes) {
-      this.layer.spatialSkeletonState.setCachedNodeParent(
-        childNode.nodeId,
-        restoredNode.nodeId,
-      );
-    }
-    if (createResult.parentSourceState !== undefined && currentParentNode) {
-      this.layer.spatialSkeletonState.setCachedNodeSourceState(
-        currentParentNode.nodeId,
-        createResult.parentSourceState,
-      );
-    }
-    if (createResult.nodeSourceStateUpdates?.length) {
-      this.layer.spatialSkeletonState.setCachedNodeSourceStates(
-        createResult.nodeSourceStateUpdates,
-      );
-    }
+    const restoredNode = applyCreatedNodeToCache(
+      this.layer,
+      skeletonLayer,
+      createResult,
+      currentParentNode?.nodeId,
+      this.deletedSnapshot.position,
+      {
+        childNodes: currentChildNodes,
+        focusSelection: false,
+        markChanged: false,
+        moveView: false,
+        pinSegment: false,
+        retainOverlaySegment: false,
+        selectSegment: false,
+      },
+    );
     const restoredNodeWithAttributes = await restoreNodeAttributes(
       this.layer,
       this.editOperations,

--- a/src/datasource/catmaid/spatial_skeleton_edit_api.ts
+++ b/src/datasource/catmaid/spatial_skeleton_edit_api.ts
@@ -15,20 +15,27 @@
  */
 
 import type {
+  CatmaidAddNodeResult,
+  CatmaidDeleteNodeResult,
+  CatmaidDescriptionUpdateResult,
+  CatmaidInsertNodeResult,
+  CatmaidMergeResult,
+  CatmaidNodeSourceStateResult,
+  CatmaidRerootResult,
+  CatmaidSkeletonEditResult,
+  CatmaidSkeletonNodeSourceStateUpdate,
+  CatmaidSplitResult,
+} from "#src/datasource/catmaid/api.js";
+import type {
   SpatiallyIndexedSkeletonNode,
-  SpatialSkeletonSourceState,
   SpatialSkeletonVector,
 } from "#src/skeleton/api.js";
 
 // CATMAID owns these payloads; the generic skeleton API only promises named edit operations.
-export interface CatmaidSpatialSkeletonNodeSourceStateUpdate {
-  nodeId: number;
-  sourceState: SpatialSkeletonSourceState;
-}
+export type CatmaidSpatialSkeletonNodeSourceStateUpdate =
+  CatmaidSkeletonNodeSourceStateUpdate;
 
-export interface CatmaidSpatialSkeletonEditResult {
-  nodeSourceStateUpdates?: readonly CatmaidSpatialSkeletonNodeSourceStateUpdate[];
-}
+export type CatmaidSpatialSkeletonEditResult = CatmaidSkeletonEditResult;
 
 export interface CatmaidSpatialSkeletonAddNodeRequest {
   segmentId: number;
@@ -36,13 +43,7 @@ export interface CatmaidSpatialSkeletonAddNodeRequest {
   parentNode?: SpatiallyIndexedSkeletonNode;
 }
 
-export interface CatmaidSpatialSkeletonAddNodeResult
-  extends CatmaidSpatialSkeletonEditResult {
-  nodeId: number;
-  segmentId: number;
-  sourceState?: SpatialSkeletonSourceState;
-  parentSourceState?: SpatialSkeletonSourceState;
-}
+export type CatmaidSpatialSkeletonAddNodeResult = CatmaidAddNodeResult;
 
 export interface CatmaidSpatialSkeletonInsertNodeRequest {
   segmentId: number;
@@ -51,18 +52,15 @@ export interface CatmaidSpatialSkeletonInsertNodeRequest {
   childNodes: readonly SpatiallyIndexedSkeletonNode[];
 }
 
-export type CatmaidSpatialSkeletonInsertNodeResult =
-  CatmaidSpatialSkeletonAddNodeResult;
+export type CatmaidSpatialSkeletonInsertNodeResult = CatmaidInsertNodeResult;
 
 export interface CatmaidSpatialSkeletonMoveNodeRequest {
   node: SpatiallyIndexedSkeletonNode;
   position: SpatialSkeletonVector;
 }
 
-export interface CatmaidSpatialSkeletonNodeSourceStateResult
-  extends CatmaidSpatialSkeletonEditResult {
-  sourceState?: SpatialSkeletonSourceState;
-}
+export type CatmaidSpatialSkeletonNodeSourceStateResult =
+  CatmaidNodeSourceStateResult;
 
 export interface CatmaidSpatialSkeletonDeleteNodeRequest {
   node: SpatiallyIndexedSkeletonNode;
@@ -70,39 +68,28 @@ export interface CatmaidSpatialSkeletonDeleteNodeRequest {
   segmentNodes: readonly SpatiallyIndexedSkeletonNode[];
 }
 
-export type CatmaidSpatialSkeletonDeleteNodeResult =
-  CatmaidSpatialSkeletonEditResult;
+export type CatmaidSpatialSkeletonDeleteNodeResult = CatmaidDeleteNodeResult;
 
 export interface CatmaidSpatialSkeletonSplitRequest {
   node: SpatiallyIndexedSkeletonNode;
   segmentNodes: readonly SpatiallyIndexedSkeletonNode[];
 }
 
-export interface CatmaidSpatialSkeletonSplitResult
-  extends CatmaidSpatialSkeletonEditResult {
-  existingSegmentId: number | undefined;
-  newSegmentId: number | undefined;
-}
+export type CatmaidSpatialSkeletonSplitResult = CatmaidSplitResult;
 
 export interface CatmaidSpatialSkeletonMergeRequest {
   fromNode: SpatiallyIndexedSkeletonNode;
   toNode: SpatiallyIndexedSkeletonNode;
 }
 
-export interface CatmaidSpatialSkeletonMergeResult
-  extends CatmaidSpatialSkeletonEditResult {
-  resultSegmentId: number | undefined;
-  deletedSegmentId: number | undefined;
-  directionAdjusted: boolean;
-}
+export type CatmaidSpatialSkeletonMergeResult = CatmaidMergeResult;
 
 export interface CatmaidSpatialSkeletonRerootRequest {
   node: SpatiallyIndexedSkeletonNode;
   segmentNodes: readonly SpatiallyIndexedSkeletonNode[];
 }
 
-export type CatmaidSpatialSkeletonRerootResult =
-  CatmaidSpatialSkeletonEditResult;
+export type CatmaidSpatialSkeletonRerootResult = CatmaidRerootResult;
 
 export interface CatmaidSpatialSkeletonDescriptionUpdateRequest {
   node: SpatiallyIndexedSkeletonNode;
@@ -110,10 +97,8 @@ export interface CatmaidSpatialSkeletonDescriptionUpdateRequest {
   isTrueEnd?: boolean;
 }
 
-export interface CatmaidSpatialSkeletonDescriptionUpdateResult
-  extends CatmaidSpatialSkeletonNodeSourceStateResult {
-  description?: string;
-}
+export type CatmaidSpatialSkeletonDescriptionUpdateResult =
+  CatmaidDescriptionUpdateResult;
 
 export interface CatmaidSpatialSkeletonTrueEndUpdateRequest {
   node: SpatiallyIndexedSkeletonNode;

--- a/src/layer/segmentation/index.ts
+++ b/src/layer/segmentation/index.ts
@@ -140,6 +140,7 @@ import {
   SpatialSkeletonNodeFilterType,
 } from "#src/skeleton/node_types.js";
 import {
+  editableSpatiallyIndexedSkeletonSourceSupportsAction,
   getEditableSpatiallyIndexedSkeletonSource,
   getSpatiallyIndexedSkeletonSource,
   isSpatiallyIndexedSkeletonSourceReadOnly,
@@ -1593,29 +1594,7 @@ export class SegmentationUserLayer extends Base {
     }
     const source = getEditableSpatiallyIndexedSkeletonSource(skeletonLayer);
     if (source === undefined) return false;
-    switch (action) {
-      case SpatialSkeletonActions.addNodes:
-      case SpatialSkeletonActions.deleteNodes:
-      case SpatialSkeletonActions.moveNodes:
-      case SpatialSkeletonActions.splitSkeletons:
-      case SpatialSkeletonActions.mergeSkeletons:
-        return true;
-      case SpatialSkeletonActions.insertNodes:
-        return source.insertNodesCommand !== undefined;
-      case SpatialSkeletonActions.reroot:
-        return source.rerootCommand !== undefined;
-      case SpatialSkeletonActions.editNodeDescription:
-        return source.editNodeDescriptionCommand !== undefined;
-      case SpatialSkeletonActions.editNodeTrueEnd:
-        return source.editNodeTrueEndCommand !== undefined;
-      case SpatialSkeletonActions.editNodeRadius:
-        return source.editNodeRadiusCommand !== undefined;
-      case SpatialSkeletonActions.editNodeConfidence:
-        return (
-          source.editNodeConfidenceCommand !== undefined &&
-          source.spatialSkeletonConfidenceConfiguration !== undefined
-        );
-    }
+    return editableSpatiallyIndexedSkeletonSourceSupportsAction(source, action);
   }
 
   private getMissingSpatialSkeletonSupportReason(

--- a/src/layer/segmentation/index.ts
+++ b/src/layer/segmentation/index.ts
@@ -146,6 +146,12 @@ import {
   isSpatiallyIndexedSkeletonSourceReadOnly,
   SpatialSkeletonState,
 } from "#src/skeleton/spatial_skeleton_manager.js";
+import {
+  buildSpatialSkeletonGridLevels,
+  getSpatialSkeletonGridSpacing,
+  type SpatialSkeletonGridLevel,
+  type SpatialSkeletonGridSize,
+} from "#src/skeleton/spatial_chunk_sizing.js";
 import { DataType, VolumeType } from "#src/sliceview/volume/base.js";
 import { MultiscaleVolumeChunkSource } from "#src/sliceview/volume/frontend.js";
 import { SegmentationRenderLayer } from "#src/sliceview/volume/segmentation_renderlayer.js";
@@ -578,24 +584,6 @@ class LinkedSegmentationGroupState<
   }
 }
 
-type SpatialSkeletonGridSize = { x: number; y: number; z: number };
-type SpatialSkeletonGridLevel = { size: SpatialSkeletonGridSize; lod: number };
-
-function getSpatialSkeletonGridSpacing(size: SpatialSkeletonGridSize) {
-  return Math.min(size.x, size.y, size.z);
-}
-
-function buildSpatialSkeletonGridLevels(
-  gridSizes: SpatialSkeletonGridSize[],
-): SpatialSkeletonGridLevel[] {
-  if (gridSizes.length === 0) return [];
-  const lastIndex = gridSizes.length - 1;
-  return gridSizes.map((size, index) => ({
-    size,
-    lod: lastIndex === 0 ? 0 : index / lastIndex,
-  }));
-}
-
 function findClosestSpatialSkeletonGridLevelBySpacing(
   levels: SpatialSkeletonGridLevel[],
   spacing: number,
@@ -886,10 +874,7 @@ class SegmentationUserLayerDisplayState implements SegmentationDisplayState {
   };
 
   setSpatialSkeletonGridSizes(gridSizes: SpatialSkeletonGridSize[]) {
-    const sortedSizes = [...gridSizes].sort(
-      (a, b) => Math.min(b.x, b.y, b.z) - Math.min(a.x, a.y, a.z),
-    );
-    const levels = buildSpatialSkeletonGridLevels(sortedSizes);
+    const levels = buildSpatialSkeletonGridLevels(gridSizes);
     const { origin: histogramOrigin, binSize: histogramBinSize } =
       getSpatialSkeletonGridHistogramConfig(levels);
     if (

--- a/src/layer/segmentation/spatial_skeleton_commands.spec.ts
+++ b/src/layer/segmentation/spatial_skeleton_commands.spec.ts
@@ -22,11 +22,14 @@ import { CatmaidSpatialSkeletonEditCommands } from "#src/datasource/catmaid/spat
 import {
   executeSpatialSkeletonAddNode,
   executeSpatialSkeletonDeleteNode,
+  executeSpatialSkeletonInsertNode,
   executeSpatialSkeletonMerge,
   executeSpatialSkeletonMoveNode,
   executeSpatialSkeletonNodeConfidenceUpdate,
   executeSpatialSkeletonNodeDescriptionUpdate,
   executeSpatialSkeletonNodeRadiusUpdate,
+  executeSpatialSkeletonNodeTrueEndUpdate,
+  executeSpatialSkeletonReroot,
   executeSpatialSkeletonSplit,
   redoSpatialSkeletonCommand,
   undoSpatialSkeletonCommand,
@@ -311,6 +314,165 @@ describe("spatial_skeleton_commands", () => {
     ).toThrow(
       "The active skeleton source does not support node description editing.",
     );
+  });
+
+  it("routes public wrappers through shared execution metadata", async () => {
+    const showMessage = vi.spyOn(StatusMessage, "showMessage").mockReturnValue({
+      dispose: vi.fn(),
+    } as unknown as StatusMessage);
+    const makeCommandFactory = (action: string) => ({
+      action,
+      createCommand: vi.fn(() => ({
+        label: action,
+        execute: vi.fn(async () => {}),
+        undo: vi.fn(async () => {}),
+      })),
+    });
+    const source = {
+      readonly: false,
+      addNodesCommand: makeCommandFactory(SpatialSkeletonActions.addNodes),
+      insertNodesCommand: makeCommandFactory(
+        SpatialSkeletonActions.insertNodes,
+      ),
+      moveNodesCommand: makeCommandFactory(SpatialSkeletonActions.moveNodes),
+      deleteNodesCommand: makeCommandFactory(
+        SpatialSkeletonActions.deleteNodes,
+      ),
+      rerootCommand: makeCommandFactory(SpatialSkeletonActions.reroot),
+      editNodeDescriptionCommand: makeCommandFactory(
+        SpatialSkeletonActions.editNodeDescription,
+      ),
+      editNodeTrueEndCommand: makeCommandFactory(
+        SpatialSkeletonActions.editNodeTrueEnd,
+      ),
+      editNodeRadiusCommand: makeCommandFactory(
+        SpatialSkeletonActions.editNodeRadius,
+      ),
+      editNodeConfidenceCommand: makeCommandFactory(
+        SpatialSkeletonActions.editNodeConfidence,
+      ),
+      mergeSkeletonsCommand: makeCommandFactory(
+        SpatialSkeletonActions.mergeSkeletons,
+      ),
+      splitSkeletonsCommand: makeCommandFactory(
+        SpatialSkeletonActions.splitSkeletons,
+      ),
+      listSkeletons: vi.fn(),
+      getSkeleton: vi.fn(),
+      fetchNodes: vi.fn(),
+      getSpatialIndexMetadata: vi.fn(),
+    };
+    const layer = {
+      spatialSkeletonState: {
+        commandHistory: new SpatialSkeletonCommandHistory(),
+      },
+      getSpatiallyIndexedSkeletonLayer: () => ({ source }),
+    };
+    const node: SpatiallyIndexedSkeletonNode = {
+      nodeId: 17,
+      segmentId: 23,
+      position: new Float32Array([1, 2, 3]),
+    };
+    const firstNode = { nodeId: 17, segmentId: 23 };
+    const secondNode = { nodeId: 29, segmentId: 31 };
+    const cases = [
+      {
+        commandFactory: source.addNodesCommand,
+        execute: () =>
+          executeSpatialSkeletonAddNode(layer as any, {
+            skeletonId: 23,
+            positionInModelSpace: new Float32Array([4, 5, 6]),
+          }),
+        pendingMessage: "Creating node...",
+      },
+      {
+        commandFactory: source.insertNodesCommand,
+        execute: () =>
+          executeSpatialSkeletonInsertNode(layer as any, {
+            skeletonId: 23,
+            parentNodeId: 17,
+            childNodeIds: [29],
+            positionInModelSpace: new Float32Array([4, 5, 6]),
+          }),
+        pendingMessage: "Inserting node...",
+      },
+      {
+        commandFactory: source.moveNodesCommand,
+        execute: () =>
+          executeSpatialSkeletonMoveNode(layer as any, {
+            node,
+            nextPositionInModelSpace: new Float32Array([7, 8, 9]),
+          }),
+      },
+      {
+        commandFactory: source.deleteNodesCommand,
+        execute: () => executeSpatialSkeletonDeleteNode(layer as any, node),
+        pendingMessage: "Deleting node...",
+      },
+      {
+        commandFactory: source.editNodeDescriptionCommand,
+        execute: () =>
+          executeSpatialSkeletonNodeDescriptionUpdate(layer as any, {
+            node,
+            nextDescription: "next",
+          }),
+      },
+      {
+        commandFactory: source.editNodeTrueEndCommand,
+        execute: () =>
+          executeSpatialSkeletonNodeTrueEndUpdate(layer as any, {
+            node,
+            nextIsTrueEnd: true,
+          }),
+      },
+      {
+        commandFactory: source.editNodeRadiusCommand,
+        execute: () =>
+          executeSpatialSkeletonNodeRadiusUpdate(layer as any, {
+            node,
+            nextRadius: 42,
+          }),
+      },
+      {
+        commandFactory: source.editNodeConfidenceCommand,
+        execute: () =>
+          executeSpatialSkeletonNodeConfidenceUpdate(layer as any, {
+            node,
+            nextConfidence: 5,
+          }),
+      },
+      {
+        commandFactory: source.rerootCommand,
+        execute: () => executeSpatialSkeletonReroot(layer as any, node),
+      },
+      {
+        commandFactory: source.splitSkeletonsCommand,
+        execute: () => executeSpatialSkeletonSplit(layer as any, node),
+        pendingMessage: "Splitting skeleton...",
+      },
+      {
+        commandFactory: source.mergeSkeletonsCommand,
+        execute: () =>
+          executeSpatialSkeletonMerge(layer as any, firstNode, secondNode),
+        pendingMessage: "Merging skeletons...",
+      },
+    ];
+
+    for (const testCase of cases) {
+      const dispose = vi.fn();
+      showMessage.mockReturnValue({ dispose } as unknown as StatusMessage);
+      showMessage.mockClear();
+
+      await testCase.execute();
+
+      expect(testCase.commandFactory.createCommand).toHaveBeenCalledTimes(1);
+      if (testCase.pendingMessage === undefined) {
+        expect(showMessage).not.toHaveBeenCalled();
+      } else {
+        expect(showMessage).toHaveBeenCalledWith(testCase.pendingMessage);
+        expect(dispose).toHaveBeenCalledTimes(1);
+      }
+    }
   });
 
   it("exposes CATMAID command factories for supported edit actions", () => {

--- a/src/layer/segmentation/spatial_skeleton_commands.ts
+++ b/src/layer/segmentation/spatial_skeleton_commands.ts
@@ -29,7 +29,10 @@ import type {
 } from "#src/skeleton/command_factories.js";
 import type { SpatialSkeletonCommand } from "#src/skeleton/command_history.js";
 import { getSpatialSkeletonActionErrorMessage } from "#src/skeleton/edit_errors.js";
-import { getEditableSpatiallyIndexedSkeletonSource } from "#src/skeleton/spatial_skeleton_manager.js";
+import {
+  getEditableSpatiallyIndexedSkeletonSource,
+  getSpatialSkeletonEditCommandFactoryForAction,
+} from "#src/skeleton/spatial_skeleton_manager.js";
 import { StatusMessage } from "#src/status.js";
 
 interface SpatialSkeletonSourceAccess {
@@ -56,32 +59,7 @@ export function getSpatialSkeletonEditCommandFactory(
 ): SpatialSkeletonEditCommandFactory | undefined {
   const source = getEditableSpatiallyIndexedSkeletonSource(value);
   if (source === undefined) return undefined;
-  switch (action) {
-    case SpatialSkeletonActions.addNodes:
-      return source.addNodesCommand;
-    case SpatialSkeletonActions.insertNodes:
-      return source.insertNodesCommand;
-    case SpatialSkeletonActions.moveNodes:
-      return source.moveNodesCommand;
-    case SpatialSkeletonActions.deleteNodes:
-      return source.deleteNodesCommand;
-    case SpatialSkeletonActions.reroot:
-      return source.rerootCommand;
-    case SpatialSkeletonActions.editNodeDescription:
-      return source.editNodeDescriptionCommand;
-    case SpatialSkeletonActions.editNodeTrueEnd:
-      return source.editNodeTrueEndCommand;
-    case SpatialSkeletonActions.editNodeRadius:
-      return source.editNodeRadiusCommand;
-    case SpatialSkeletonActions.editNodeConfidence:
-      return source.editNodeConfidenceCommand;
-    case SpatialSkeletonActions.mergeSkeletons:
-      return source.mergeSkeletonsCommand;
-    case SpatialSkeletonActions.splitSkeletons:
-      return source.splitSkeletonsCommand;
-    case SpatialSkeletonActions.inspect:
-      return undefined;
-  }
+  return getSpatialSkeletonEditCommandFactoryForAction(source, action);
 }
 
 function executeCommand(
@@ -126,19 +104,128 @@ function createSpatialSkeletonCommand(
   return commandFactory.createCommand(layer, payload);
 }
 
+interface SpatialSkeletonExecutionMetadata {
+  readonly unsupportedMessage: string;
+  readonly pendingMessage?: string;
+}
+
+const spatialSkeletonExecutionMetadata = new Map<
+  SpatialSkeletonAction,
+  SpatialSkeletonExecutionMetadata
+>([
+  [
+    SpatialSkeletonActions.addNodes,
+    {
+      unsupportedMessage:
+        "The active skeleton source does not support node creation.",
+      pendingMessage: "Creating node...",
+    },
+  ],
+  [
+    SpatialSkeletonActions.insertNodes,
+    {
+      unsupportedMessage:
+        "The active skeleton source does not support node insertion.",
+      pendingMessage: "Inserting node...",
+    },
+  ],
+  [
+    SpatialSkeletonActions.moveNodes,
+    {
+      unsupportedMessage:
+        "The active skeleton source does not support node movement.",
+    },
+  ],
+  [
+    SpatialSkeletonActions.deleteNodes,
+    {
+      unsupportedMessage:
+        "The active skeleton source does not support node deletion.",
+      pendingMessage: "Deleting node...",
+    },
+  ],
+  [
+    SpatialSkeletonActions.editNodeDescription,
+    {
+      unsupportedMessage:
+        "The active skeleton source does not support node description editing.",
+    },
+  ],
+  [
+    SpatialSkeletonActions.editNodeTrueEnd,
+    {
+      unsupportedMessage:
+        "The active skeleton source does not support node true-end editing.",
+    },
+  ],
+  [
+    SpatialSkeletonActions.editNodeRadius,
+    {
+      unsupportedMessage:
+        "The active skeleton source does not support node radius editing.",
+    },
+  ],
+  [
+    SpatialSkeletonActions.editNodeConfidence,
+    {
+      unsupportedMessage:
+        "The active skeleton source does not support node confidence editing.",
+    },
+  ],
+  [
+    SpatialSkeletonActions.reroot,
+    {
+      unsupportedMessage:
+        "The active skeleton source does not support skeleton rerooting.",
+    },
+  ],
+  [
+    SpatialSkeletonActions.splitSkeletons,
+    {
+      unsupportedMessage:
+        "The active skeleton source does not support skeleton splitting.",
+      pendingMessage: "Splitting skeleton...",
+    },
+  ],
+  [
+    SpatialSkeletonActions.mergeSkeletons,
+    {
+      unsupportedMessage:
+        "The active skeleton source does not support skeleton merging.",
+      pendingMessage: "Merging skeletons...",
+    },
+  ],
+]);
+
+function executeSpatialSkeletonAction(
+  layer: SegmentationUserLayer,
+  action: SpatialSkeletonAction,
+  payload: SpatialSkeletonCommandPayload,
+) {
+  const metadata = spatialSkeletonExecutionMetadata.get(action);
+  if (metadata === undefined) {
+    throw new Error(`Unsupported spatial skeleton edit action: ${action}`);
+  }
+  const command = createSpatialSkeletonCommand(
+    layer,
+    action,
+    payload,
+    metadata.unsupportedMessage,
+  );
+  const execution = executeCommand(layer, command);
+  return metadata.pendingMessage === undefined
+    ? execution
+    : executeCommandWithPendingMessage(execution, metadata.pendingMessage);
+}
+
 export function executeSpatialSkeletonAddNode(
   layer: SegmentationUserLayer,
   options: SpatialSkeletonCommandPayload,
 ) {
-  const command = createSpatialSkeletonCommand(
+  return executeSpatialSkeletonAction(
     layer,
     SpatialSkeletonActions.addNodes,
     options,
-    "The active skeleton source does not support node creation.",
-  );
-  return executeCommandWithPendingMessage(
-    executeCommand(layer, command),
-    "Creating node...",
   );
 }
 
@@ -146,15 +233,10 @@ export function executeSpatialSkeletonInsertNode(
   layer: SegmentationUserLayer,
   options: SpatialSkeletonCommandPayload,
 ) {
-  const command = createSpatialSkeletonCommand(
+  return executeSpatialSkeletonAction(
     layer,
     SpatialSkeletonActions.insertNodes,
     options,
-    "The active skeleton source does not support node insertion.",
-  );
-  return executeCommandWithPendingMessage(
-    executeCommand(layer, command),
-    "Inserting node...",
   );
 }
 
@@ -162,28 +244,21 @@ export function executeSpatialSkeletonMoveNode(
   layer: SegmentationUserLayer,
   options: SpatialSkeletonCommandPayload,
 ) {
-  const command = createSpatialSkeletonCommand(
+  return executeSpatialSkeletonAction(
     layer,
     SpatialSkeletonActions.moveNodes,
     options,
-    "The active skeleton source does not support node movement.",
   );
-  return executeCommand(layer, command);
 }
 
 export function executeSpatialSkeletonDeleteNode(
   layer: SegmentationUserLayer,
   node: SpatiallyIndexedSkeletonNode,
 ) {
-  const command = createSpatialSkeletonCommand(
+  return executeSpatialSkeletonAction(
     layer,
     SpatialSkeletonActions.deleteNodes,
     node,
-    "The active skeleton source does not support node deletion.",
-  );
-  return executeCommandWithPendingMessage(
-    executeCommand(layer, command),
-    "Deleting node...",
   );
 }
 
@@ -191,80 +266,65 @@ export function executeSpatialSkeletonNodeDescriptionUpdate(
   layer: SegmentationUserLayer,
   options: SpatialSkeletonCommandPayload,
 ) {
-  const command = createSpatialSkeletonCommand(
+  return executeSpatialSkeletonAction(
     layer,
     SpatialSkeletonActions.editNodeDescription,
     options,
-    "The active skeleton source does not support node description editing.",
   );
-  return executeCommand(layer, command);
 }
 
 export function executeSpatialSkeletonNodeTrueEndUpdate(
   layer: SegmentationUserLayer,
   options: SpatialSkeletonCommandPayload,
 ) {
-  const command = createSpatialSkeletonCommand(
+  return executeSpatialSkeletonAction(
     layer,
     SpatialSkeletonActions.editNodeTrueEnd,
     options,
-    "The active skeleton source does not support node true-end editing.",
   );
-  return executeCommand(layer, command);
 }
 
 export function executeSpatialSkeletonNodeRadiusUpdate(
   layer: SegmentationUserLayer,
   options: SpatialSkeletonCommandPayload,
 ) {
-  const command = createSpatialSkeletonCommand(
+  return executeSpatialSkeletonAction(
     layer,
     SpatialSkeletonActions.editNodeRadius,
     options,
-    "The active skeleton source does not support node radius editing.",
   );
-  return executeCommand(layer, command);
 }
 
 export function executeSpatialSkeletonNodeConfidenceUpdate(
   layer: SegmentationUserLayer,
   options: SpatialSkeletonCommandPayload,
 ) {
-  const command = createSpatialSkeletonCommand(
+  return executeSpatialSkeletonAction(
     layer,
     SpatialSkeletonActions.editNodeConfidence,
     options,
-    "The active skeleton source does not support node confidence editing.",
   );
-  return executeCommand(layer, command);
 }
 
 export function executeSpatialSkeletonReroot(
   layer: SegmentationUserLayer,
   node: SpatialSkeletonCommandPayload,
 ) {
-  const command = createSpatialSkeletonCommand(
+  return executeSpatialSkeletonAction(
     layer,
     SpatialSkeletonActions.reroot,
     node,
-    "The active skeleton source does not support skeleton rerooting.",
   );
-  return executeCommand(layer, command);
 }
 
 export function executeSpatialSkeletonSplit(
   layer: SegmentationUserLayer,
   node: SpatialSkeletonCommandPayload,
 ) {
-  const command = createSpatialSkeletonCommand(
+  return executeSpatialSkeletonAction(
     layer,
     SpatialSkeletonActions.splitSkeletons,
     node,
-    "The active skeleton source does not support skeleton splitting.",
-  );
-  return executeCommandWithPendingMessage(
-    executeCommand(layer, command),
-    "Splitting skeleton...",
   );
 }
 
@@ -273,15 +333,10 @@ export function executeSpatialSkeletonMerge(
   firstNode: SpatialSkeletonCommandPayload,
   secondNode: SpatialSkeletonCommandPayload,
 ) {
-  const command = createSpatialSkeletonCommand(
+  return executeSpatialSkeletonAction(
     layer,
     SpatialSkeletonActions.mergeSkeletons,
     { firstNode, secondNode },
-    "The active skeleton source does not support skeleton merging.",
-  );
-  return executeCommandWithPendingMessage(
-    executeCommand(layer, command),
-    "Merging skeletons...",
   );
 }
 

--- a/src/skeleton/command_factories.ts
+++ b/src/skeleton/command_factories.ts
@@ -15,9 +15,9 @@
  */
 
 import type { SegmentationUserLayer } from "#src/layer/segmentation/index.js";
-import type {
+import {
   SpatialSkeletonActions,
-  SpatialSkeletonAction,
+  type SpatialSkeletonAction,
 } from "#src/skeleton/actions.js";
 import type { SpatialSkeletonCommand } from "#src/skeleton/command_history.js";
 
@@ -54,6 +54,115 @@ export function isSpatialSkeletonEditCommandFactory<
     typeof (value as SpatialSkeletonEditCommandFactoryCandidate)
       .createCommand === "function"
   );
+}
+
+export type SpatialSkeletonEditCommandProperty =
+  | "addNodesCommand"
+  | "insertNodesCommand"
+  | "moveNodesCommand"
+  | "deleteNodesCommand"
+  | "rerootCommand"
+  | "editNodeDescriptionCommand"
+  | "editNodeTrueEndCommand"
+  | "editNodeRadiusCommand"
+  | "editNodeConfidenceCommand"
+  | "mergeSkeletonsCommand"
+  | "splitSkeletonsCommand";
+
+export interface SpatialSkeletonEditCommandMetadata {
+  readonly action: SpatialSkeletonAction;
+  readonly commandProperty: SpatialSkeletonEditCommandProperty;
+  readonly required: boolean;
+  readonly requiresConfidenceConfiguration?: boolean;
+}
+
+export const SPATIAL_SKELETON_EDIT_COMMAND_METADATA = [
+  {
+    action: SpatialSkeletonActions.addNodes,
+    commandProperty: "addNodesCommand",
+    required: true,
+  },
+  {
+    action: SpatialSkeletonActions.insertNodes,
+    commandProperty: "insertNodesCommand",
+    required: false,
+  },
+  {
+    action: SpatialSkeletonActions.moveNodes,
+    commandProperty: "moveNodesCommand",
+    required: true,
+  },
+  {
+    action: SpatialSkeletonActions.deleteNodes,
+    commandProperty: "deleteNodesCommand",
+    required: true,
+  },
+  {
+    action: SpatialSkeletonActions.reroot,
+    commandProperty: "rerootCommand",
+    required: false,
+  },
+  {
+    action: SpatialSkeletonActions.editNodeDescription,
+    commandProperty: "editNodeDescriptionCommand",
+    required: false,
+  },
+  {
+    action: SpatialSkeletonActions.editNodeTrueEnd,
+    commandProperty: "editNodeTrueEndCommand",
+    required: false,
+  },
+  {
+    action: SpatialSkeletonActions.editNodeRadius,
+    commandProperty: "editNodeRadiusCommand",
+    required: false,
+  },
+  {
+    action: SpatialSkeletonActions.editNodeConfidence,
+    commandProperty: "editNodeConfidenceCommand",
+    required: false,
+    requiresConfidenceConfiguration: true,
+  },
+  {
+    action: SpatialSkeletonActions.mergeSkeletons,
+    commandProperty: "mergeSkeletonsCommand",
+    required: true,
+  },
+  {
+    action: SpatialSkeletonActions.splitSkeletons,
+    commandProperty: "splitSkeletonsCommand",
+    required: true,
+  },
+] as const satisfies readonly SpatialSkeletonEditCommandMetadata[];
+
+const spatialSkeletonEditCommandMetadataByAction = new Map<
+  SpatialSkeletonAction,
+  SpatialSkeletonEditCommandMetadata
+>(
+  SPATIAL_SKELETON_EDIT_COMMAND_METADATA.map((metadata) => [
+    metadata.action,
+    metadata,
+  ]),
+);
+
+export function getSpatialSkeletonEditCommandMetadata(
+  action: SpatialSkeletonAction,
+): SpatialSkeletonEditCommandMetadata | undefined {
+  return spatialSkeletonEditCommandMetadataByAction.get(action);
+}
+
+export function getSpatialSkeletonEditCommandFactoryFromSource(
+  source: object,
+  action: SpatialSkeletonAction,
+): SpatialSkeletonEditCommandFactory | undefined {
+  const metadata = getSpatialSkeletonEditCommandMetadata(action);
+  if (metadata === undefined) return undefined;
+  const commandFactory = (
+    source as Record<SpatialSkeletonEditCommandProperty, unknown>
+  )[metadata.commandProperty];
+  return isSpatialSkeletonEditCommandFactory(commandFactory, metadata.action)
+    ? commandFactory
+    : undefined;
 }
 
 export type SpatialSkeletonAddNodesCommandFactory =

--- a/src/skeleton/source_selection.ts
+++ b/src/skeleton/source_selection.ts
@@ -121,18 +121,3 @@ export function selectSpatiallyIndexedSkeletonEntriesForView<T>(
     getGridIndex,
   );
 }
-
-export function dedupeSpatiallyIndexedSkeletonEntries<T>(
-  entries: Iterable<T>,
-  getKey: (entry: T) => string,
-) {
-  const deduped: T[] = [];
-  const seenKeys = new Set<string>();
-  for (const entry of entries) {
-    const key = getKey(entry);
-    if (seenKeys.has(key)) continue;
-    seenKeys.add(key);
-    deduped.push(entry);
-  }
-  return deduped;
-}

--- a/src/skeleton/spatial_chunk_sizing.ts
+++ b/src/skeleton/spatial_chunk_sizing.ts
@@ -23,10 +23,40 @@ const DEFAULT_SPATIALLY_INDEXED_SKELETON_MAX_CHUNKS = 64;
 const DEFAULT_SPATIALLY_INDEXED_SKELETON_MIN_CHUNK_SIZE = 1;
 
 export type SpatiallyIndexedSkeletonChunkSize = number[];
+export type SpatialSkeletonGridSize = { x: number; y: number; z: number };
+export type SpatialSkeletonGridLevel = {
+  size: SpatialSkeletonGridSize;
+  lod: number;
+};
 
 export interface DefaultSpatiallyIndexedSkeletonChunkSizeOptions {
   maxChunks?: number;
   minChunkSize?: number;
+}
+
+export function getSpatialSkeletonGridSpacing(size: SpatialSkeletonGridSize) {
+  return Math.min(size.x, size.y, size.z);
+}
+
+export function sortSpatialSkeletonGridSizes(
+  gridSizes: readonly SpatialSkeletonGridSize[],
+): SpatialSkeletonGridSize[] {
+  return [...gridSizes].sort(
+    (a, b) =>
+      getSpatialSkeletonGridSpacing(b) - getSpatialSkeletonGridSpacing(a),
+  );
+}
+
+export function buildSpatialSkeletonGridLevels(
+  gridSizes: readonly SpatialSkeletonGridSize[],
+): SpatialSkeletonGridLevel[] {
+  const sortedSizes = sortSpatialSkeletonGridSizes(gridSizes);
+  if (sortedSizes.length === 0) return [];
+  const lastIndex = sortedSizes.length - 1;
+  return sortedSizes.map((size, index) => ({
+    size,
+    lod: lastIndex === 0 ? 0 : index / lastIndex,
+  }));
 }
 
 function validateFiniteOptions(

--- a/src/skeleton/spatial_skeleton_manager.spec.ts
+++ b/src/skeleton/spatial_skeleton_manager.spec.ts
@@ -23,7 +23,9 @@ import {
   getSkeletonRootNode,
 } from "#src/skeleton/navigation_graph.js";
 import {
+  editableSpatiallyIndexedSkeletonSourceSupportsAction,
   getEditableSpatiallyIndexedSkeletonSource,
+  getSpatialSkeletonEditCommandFactoryForAction,
   isSpatiallyIndexedSkeletonSourceReadOnly,
   SpatialSkeletonState,
 } from "#src/skeleton/spatial_skeleton_manager.js";
@@ -108,6 +110,40 @@ describe("skeleton/spatial_skeleton_manager", () => {
     expect(getEditableSpatiallyIndexedSkeletonSource({ source })).toBe(source);
   });
 
+  it("looks up edit command factories from shared action metadata", () => {
+    const source = {
+      ...makeEditableSourceCommands(),
+      insertNodesCommand: makeCommandFactory(
+        SpatialSkeletonActions.insertNodes,
+      ),
+      rerootCommand: makeCommandFactory(SpatialSkeletonActions.reroot),
+      readonly: false,
+      listSkeletons: async () => [],
+      getSkeleton: async () => [],
+      fetchNodes: async () => [],
+      getSpatialIndexMetadata: async () => null,
+    };
+
+    expect(
+      getSpatialSkeletonEditCommandFactoryForAction(
+        source as any,
+        SpatialSkeletonActions.moveNodes,
+      ),
+    ).toBe(source.moveNodesCommand);
+    expect(
+      getSpatialSkeletonEditCommandFactoryForAction(
+        source as any,
+        SpatialSkeletonActions.insertNodes,
+      ),
+    ).toBe(source.insertNodesCommand);
+    expect(
+      getSpatialSkeletonEditCommandFactoryForAction(
+        source as any,
+        SpatialSkeletonActions.inspect,
+      ),
+    ).toBeUndefined();
+  });
+
   it("validates optional confidence configuration for editable sources", () => {
     const source = {
       ...makeEditableSourceCommands(),
@@ -136,6 +172,46 @@ describe("skeleton/spatial_skeleton_manager", () => {
         },
       }),
     ).toBeUndefined();
+  });
+
+  it("requires confidence configuration only for confidence edit support", () => {
+    const source = {
+      ...makeEditableSourceCommands(),
+      editNodeConfidenceCommand: makeCommandFactory(
+        SpatialSkeletonActions.editNodeConfidence,
+      ),
+      readonly: false,
+      listSkeletons: async () => [],
+      getSkeleton: async () => [],
+      fetchNodes: async () => [],
+      getSpatialIndexMetadata: async () => null,
+    };
+
+    expect(getEditableSpatiallyIndexedSkeletonSource({ source })).toBe(source);
+    expect(
+      editableSpatiallyIndexedSkeletonSourceSupportsAction(
+        source as any,
+        SpatialSkeletonActions.addNodes,
+      ),
+    ).toBe(true);
+    expect(
+      editableSpatiallyIndexedSkeletonSourceSupportsAction(
+        source as any,
+        SpatialSkeletonActions.editNodeConfidence,
+      ),
+    ).toBe(false);
+
+    expect(
+      editableSpatiallyIndexedSkeletonSourceSupportsAction(
+        {
+          ...source,
+          spatialSkeletonConfidenceConfiguration: {
+            values: [0, 50, 100],
+          },
+        } as any,
+        SpatialSkeletonActions.editNodeConfidence,
+      ),
+    ).toBe(true);
   });
 
   it("does not treat a read-only source with edit commands as editable", () => {

--- a/src/skeleton/spatial_skeleton_manager.ts
+++ b/src/skeleton/spatial_skeleton_manager.ts
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  SpatialSkeletonActions,
-  type SpatialSkeletonAction,
-} from "#src/skeleton/actions.js";
+import type { SpatialSkeletonAction } from "#src/skeleton/actions.js";
 import type {
   EditableSpatiallyIndexedSkeletonSource,
   SpatialSkeletonConfidenceConfiguration,
@@ -25,7 +22,12 @@ import type {
   SpatialSkeletonSourceState,
   SpatiallyIndexedSkeletonSource,
 } from "#src/skeleton/api.js";
-import { isSpatialSkeletonEditCommandFactory } from "#src/skeleton/command_factories.js";
+import {
+  getSpatialSkeletonEditCommandFactoryFromSource,
+  getSpatialSkeletonEditCommandMetadata,
+  isSpatialSkeletonEditCommandFactory,
+  SPATIAL_SKELETON_EDIT_COMMAND_METADATA,
+} from "#src/skeleton/command_factories.js";
 import { SpatialSkeletonCommandHistory } from "#src/skeleton/command_history.js";
 import type { SpatiallyIndexedSkeletonLayer } from "#src/skeleton/frontend.js";
 import { WatchableValue } from "#src/trackable_value.js";
@@ -52,26 +54,14 @@ function getProperty<T extends string>(value: unknown, property: T): unknown {
     : undefined;
 }
 
-function hasCommandFactory<T extends string>(
+function hasValidCommandFactory(
   value: unknown,
-  property: T,
-  action: SpatialSkeletonAction,
+  metadata: (typeof SPATIAL_SKELETON_EDIT_COMMAND_METADATA)[number],
 ) {
-  return isSpatialSkeletonEditCommandFactory(
-    getProperty(value, property),
-    action,
-  );
-}
-
-function hasOptionalCommandFactory<T extends string>(
-  value: unknown,
-  property: T,
-  action: SpatialSkeletonAction,
-) {
-  const commandFactory = getProperty(value, property);
+  const commandFactory = getProperty(value, metadata.commandProperty);
   return (
-    commandFactory === undefined ||
-    isSpatialSkeletonEditCommandFactory(commandFactory, action)
+    (commandFactory === undefined && !metadata.required) ||
+    isSpatialSkeletonEditCommandFactory(commandFactory, metadata.action)
   );
 }
 
@@ -121,60 +111,8 @@ export function isEditableSpatiallyIndexedSkeletonSource(
   return (
     isSpatiallyIndexedSkeletonSource(value) &&
     !value.readonly &&
-    hasCommandFactory(
-      value,
-      "addNodesCommand",
-      SpatialSkeletonActions.addNodes,
-    ) &&
-    hasCommandFactory(
-      value,
-      "deleteNodesCommand",
-      SpatialSkeletonActions.deleteNodes,
-    ) &&
-    hasCommandFactory(
-      value,
-      "moveNodesCommand",
-      SpatialSkeletonActions.moveNodes,
-    ) &&
-    hasCommandFactory(
-      value,
-      "splitSkeletonsCommand",
-      SpatialSkeletonActions.splitSkeletons,
-    ) &&
-    hasCommandFactory(
-      value,
-      "mergeSkeletonsCommand",
-      SpatialSkeletonActions.mergeSkeletons,
-    ) &&
-    hasOptionalCommandFactory(
-      value,
-      "insertNodesCommand",
-      SpatialSkeletonActions.insertNodes,
-    ) &&
-    hasOptionalCommandFactory(
-      value,
-      "rerootCommand",
-      SpatialSkeletonActions.reroot,
-    ) &&
-    hasOptionalCommandFactory(
-      value,
-      "editNodeDescriptionCommand",
-      SpatialSkeletonActions.editNodeDescription,
-    ) &&
-    hasOptionalCommandFactory(
-      value,
-      "editNodeTrueEndCommand",
-      SpatialSkeletonActions.editNodeTrueEnd,
-    ) &&
-    hasOptionalCommandFactory(
-      value,
-      "editNodeRadiusCommand",
-      SpatialSkeletonActions.editNodeRadius,
-    ) &&
-    hasOptionalCommandFactory(
-      value,
-      "editNodeConfidenceCommand",
-      SpatialSkeletonActions.editNodeConfidence,
+    SPATIAL_SKELETON_EDIT_COMMAND_METADATA.every((metadata) =>
+      hasValidCommandFactory(value, metadata),
     ) &&
     hasOptionalConfidenceConfiguration(value)
   );
@@ -202,6 +140,29 @@ export function getEditableSpatiallyIndexedSkeletonSource(
   return isEditableSpatiallyIndexedSkeletonSource(value.source)
     ? value.source
     : undefined;
+}
+
+export function getSpatialSkeletonEditCommandFactoryForAction(
+  source: EditableSpatiallyIndexedSkeletonSource,
+  action: SpatialSkeletonAction,
+) {
+  return getSpatialSkeletonEditCommandFactoryFromSource(source, action);
+}
+
+export function editableSpatiallyIndexedSkeletonSourceSupportsAction(
+  source: EditableSpatiallyIndexedSkeletonSource,
+  action: SpatialSkeletonAction,
+) {
+  const commandFactory = getSpatialSkeletonEditCommandFactoryForAction(
+    source,
+    action,
+  );
+  if (commandFactory === undefined) return false;
+  const metadata = getSpatialSkeletonEditCommandMetadata(action);
+  return (
+    metadata?.requiresConfidenceConfiguration !== true ||
+    source.spatialSkeletonConfidenceConfiguration !== undefined
+  );
 }
 
 export function normalizeSpatiallyIndexedSkeletonNode(


### PR DESCRIPTION

- Centralizes spatial skeleton edit action metadata in `command_factories.ts`, including the action-to-command-property mapping, required vs optional command support, and confidence-configuration requirements.
- Reuses that metadata for editable source validation, command factory lookup, UI support checks, and public command execution wrappers.
- Replaces repeated per-action execution logic with shared execution metadata for unsupported-action errors and pending status messages.
- Consolidates CATMAID spatial skeleton command helpers for created-node cache updates, delete/undo flows, positive segment ID normalization, and CATMAID model-space position validation.
- Moves shared CATMAID/client, skeleton metadata, and grid-level helpers into reusable modules used by both frontend and backend paths.
- Renames the CATMAID node-list client method to the generic `fetchNodes`.
- Removes the now-unused `dedupeSpatiallyIndexedSkeletonEntries` helper.
- Adds/updates tests around shared action routing, editable-source support detection, confidence editing support, and CATMAID API expectations.