### PR TITLE
feat: Add dynamic highlight color

### DIFF
--- a/src/skeleton/frontend.spec.ts
+++ b/src/skeleton/frontend.spec.ts
@@ -148,7 +148,9 @@ describe("SpatiallyIndexedSkeletonLayer selected node outline color", () => {
     const outlineColor = (layer as any).getSelectedNodeOutlineColor();
 
     expect(getCachedNodeSnapshot).toHaveBeenCalledWith(101);
-    expect([...outlineColor]).toEqual([1, 1, 1]);
+    expect(outlineColor[0]).toBeCloseTo(1);
+    expect(outlineColor[1]).toBeCloseTo(0.95);
+    expect(outlineColor[2]).toBeCloseTo(0.35);
     expect(getContrastRatio(outlineColor, sourceColor)).toBeGreaterThanOrEqual(
       3,
     );

--- a/src/skeleton/frontend.spec.ts
+++ b/src/skeleton/frontend.spec.ts
@@ -140,20 +140,114 @@ describe("SpatiallyIndexedSkeletonLayer selected node outline color", () => {
       {
         selectedNodeId: { value: 101 },
         selectedNodeOutlineColor: vec3.create(),
+        selectedNodeOutlineColorGeneration: 0,
+        selectedNodeOutlineColorCacheGeneration: -1,
         displayState,
         getCachedNodeSnapshot,
       },
     );
 
     const outlineColor = (layer as any).getSelectedNodeOutlineColor();
+    const cachedOutlineColor = (layer as any).getSelectedNodeOutlineColor();
 
     expect(getCachedNodeSnapshot).toHaveBeenCalledWith(101);
+    expect(getCachedNodeSnapshot).toHaveBeenCalledTimes(1);
+    expect(cachedOutlineColor).toBe(outlineColor);
     expect(outlineColor[0]).toBeCloseTo(1);
     expect(outlineColor[1]).toBeCloseTo(0.95);
     expect(outlineColor[2]).toBeCloseTo(0.35);
     expect(getContrastRatio(outlineColor, sourceColor)).toBeGreaterThanOrEqual(
       3,
     );
+  });
+
+  it("reuses the cached outline color when the selected node changes within the same segment", () => {
+    const computeSegmentColor = vi.fn((color: Float32Array) => {
+      color[0] = 1;
+      color[1] = 0;
+      color[2] = 0;
+      return color;
+    });
+    const selectedNodeId = { value: 101 };
+    const displayState = {
+      segmentationColorGroupState: {
+        value: {
+          segmentStatedColors: new Map(),
+          segmentDefaultColor: { value: undefined },
+          segmentColorHash: { compute: computeSegmentColor },
+        },
+      },
+      saturation: { value: 1 },
+      hoverHighlight: { value: false },
+      segmentSelectionState: { isSelected: vi.fn(() => false) },
+    };
+    const getCachedNodeSnapshot = vi.fn((nodeId: number) => ({
+      nodeId,
+      segmentId: 11,
+      position: new Float32Array([1, 2, 3]),
+    }));
+    const layer = Object.assign(
+      Object.create(SpatiallyIndexedSkeletonLayer.prototype),
+      {
+        selectedNodeId,
+        selectedNodeOutlineColor: vec3.create(),
+        selectedNodeOutlineColorGeneration: 0,
+        selectedNodeOutlineColorCacheGeneration: -1,
+        displayState,
+        getCachedNodeSnapshot,
+      },
+    );
+
+    (layer as any).getSelectedNodeOutlineColor();
+    selectedNodeId.value = 202;
+    (layer as any).getSelectedNodeOutlineColor();
+
+    expect(getCachedNodeSnapshot).toHaveBeenCalledTimes(2);
+    expect(computeSegmentColor).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidates the selected-node outline cache when the generation changes", () => {
+    const computeSegmentColor = vi.fn((color: Float32Array) => {
+      color[0] = 1;
+      color[1] = 0;
+      color[2] = 0;
+      return color;
+    });
+    const displayState = {
+      segmentationColorGroupState: {
+        value: {
+          segmentStatedColors: new Map(),
+          segmentDefaultColor: { value: undefined },
+          segmentColorHash: { compute: computeSegmentColor },
+        },
+      },
+      saturation: { value: 1 },
+      hoverHighlight: { value: false },
+      segmentSelectionState: { isSelected: vi.fn(() => false) },
+    };
+    const getCachedNodeSnapshot = vi.fn(() => ({
+      nodeId: 101,
+      segmentId: 11,
+      position: new Float32Array([1, 2, 3]),
+    }));
+    const layer = Object.assign(
+      Object.create(SpatiallyIndexedSkeletonLayer.prototype),
+      {
+        selectedNodeId: { value: 101 },
+        selectedNodeOutlineColor: vec3.create(),
+        selectedNodeOutlineColorGeneration: 0,
+        selectedNodeOutlineColorCacheGeneration: -1,
+        displayState,
+        getCachedNodeSnapshot,
+      },
+    );
+
+    (layer as any).getSelectedNodeOutlineColor();
+    ++(layer as any).selectedNodeOutlineColorGeneration;
+    (layer as any).getSelectedNodeOutlineColor();
+
+    expect(getCachedNodeSnapshot).toHaveBeenCalledTimes(2);
+    expect(computeSegmentColor).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/src/skeleton/frontend.spec.ts
+++ b/src/skeleton/frontend.spec.ts
@@ -118,6 +118,7 @@ describe("SpatiallyIndexedSkeletonLayer browse node picks", () => {
 describe("SpatiallyIndexedSkeletonLayer selected node outline color", () => {
   it("derives the selected-node outline color from the selected segment color", () => {
     const sourceColor = vec3.fromValues(1, 0, 0);
+    const isSelected = vi.fn(() => true);
     const displayState = {
       segmentationColorGroupState: {
         value: {
@@ -126,9 +127,9 @@ describe("SpatiallyIndexedSkeletonLayer selected node outline color", () => {
           segmentColorHash: { compute: vi.fn() },
         },
       },
-      saturation: { value: 1 },
-      hoverHighlight: { value: false },
-      segmentSelectionState: { isSelected: vi.fn(() => false) },
+      saturation: { value: 0 },
+      hoverHighlight: { value: true },
+      segmentSelectionState: { isSelected },
     };
     const getCachedNodeSnapshot = vi.fn(() => ({
       nodeId: 101,
@@ -152,6 +153,7 @@ describe("SpatiallyIndexedSkeletonLayer selected node outline color", () => {
 
     expect(getCachedNodeSnapshot).toHaveBeenCalledWith(101);
     expect(getCachedNodeSnapshot).toHaveBeenCalledTimes(1);
+    expect(isSelected).not.toHaveBeenCalled();
     expect(cachedOutlineColor).toBe(outlineColor);
     expect(outlineColor[0]).toBeCloseTo(1);
     expect(outlineColor[1]).toBeCloseTo(0.95);

--- a/src/skeleton/frontend.spec.ts
+++ b/src/skeleton/frontend.spec.ts
@@ -142,7 +142,7 @@ describe("SpatiallyIndexedSkeletonLayer selected node outline color", () => {
         selectedNodeId: { value: 101 },
         selectedNodeOutlineColor: vec3.create(),
         selectedNodeOutlineColorGeneration: 0,
-        selectedNodeOutlineColorCacheGeneration: -1,
+        cachedSelectedNodeOutlineColorGeneration: -1,
         displayState,
         getCachedNodeSnapshot,
       },
@@ -163,7 +163,7 @@ describe("SpatiallyIndexedSkeletonLayer selected node outline color", () => {
     );
   });
 
-  it("reuses the cached outline color when the selected node changes within the same segment", () => {
+  it("recomputes the outline color when the selected node changes", () => {
     const computeSegmentColor = vi.fn((color: Float32Array) => {
       color[0] = 1;
       color[1] = 0;
@@ -194,7 +194,7 @@ describe("SpatiallyIndexedSkeletonLayer selected node outline color", () => {
         selectedNodeId,
         selectedNodeOutlineColor: vec3.create(),
         selectedNodeOutlineColorGeneration: 0,
-        selectedNodeOutlineColorCacheGeneration: -1,
+        cachedSelectedNodeOutlineColorGeneration: -1,
         displayState,
         getCachedNodeSnapshot,
       },
@@ -202,13 +202,14 @@ describe("SpatiallyIndexedSkeletonLayer selected node outline color", () => {
 
     (layer as any).getSelectedNodeOutlineColor();
     selectedNodeId.value = 202;
+    ++(layer as any).selectedNodeOutlineColorGeneration;
     (layer as any).getSelectedNodeOutlineColor();
 
     expect(getCachedNodeSnapshot).toHaveBeenCalledTimes(2);
-    expect(computeSegmentColor).toHaveBeenCalledTimes(1);
+    expect(computeSegmentColor).toHaveBeenCalledTimes(2);
   });
 
-  it("invalidates the selected-node outline cache when the generation changes", () => {
+  it("invalidates the selected-node outline cache when the input generation changes", () => {
     const computeSegmentColor = vi.fn((color: Float32Array) => {
       color[0] = 1;
       color[1] = 0;
@@ -238,7 +239,7 @@ describe("SpatiallyIndexedSkeletonLayer selected node outline color", () => {
         selectedNodeId: { value: 101 },
         selectedNodeOutlineColor: vec3.create(),
         selectedNodeOutlineColorGeneration: 0,
-        selectedNodeOutlineColorCacheGeneration: -1,
+        cachedSelectedNodeOutlineColorGeneration: -1,
         displayState,
         getCachedNodeSnapshot,
       },
@@ -250,6 +251,51 @@ describe("SpatiallyIndexedSkeletonLayer selected node outline color", () => {
 
     expect(getCachedNodeSnapshot).toHaveBeenCalledTimes(2);
     expect(computeSegmentColor).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns the fallback outline color for an invalid selected segment", () => {
+    const computeSegmentColor = vi.fn();
+    const displayState = {
+      segmentationColorGroupState: {
+        value: {
+          segmentStatedColors: new Map(),
+          segmentDefaultColor: { value: undefined },
+          segmentColorHash: { compute: computeSegmentColor },
+        },
+      },
+      saturation: { value: 1 },
+      hoverHighlight: { value: false },
+      segmentSelectionState: { isSelected: vi.fn(() => false) },
+    };
+    const getCachedNodeSnapshot = vi.fn(() => ({
+      nodeId: 101,
+      segmentId: 0,
+      position: new Float32Array([1, 2, 3]),
+    }));
+    const layer = Object.assign(
+      Object.create(SpatiallyIndexedSkeletonLayer.prototype),
+      {
+        selectedNodeId: { value: 101 },
+        selectedNodeOutlineColor: vec3.create(),
+        selectedNodeOutlineColorGeneration: 0,
+        cachedSelectedNodeOutlineColorGeneration: -1,
+        displayState,
+        getCachedNodeSnapshot,
+      },
+    );
+
+    const outlineColor = (layer as any).getSelectedNodeOutlineColor();
+    const cachedOutlineColor = (layer as any).getSelectedNodeOutlineColor();
+
+    expect(getCachedNodeSnapshot).toHaveBeenCalledWith(101);
+    expect(getCachedNodeSnapshot).toHaveBeenCalledTimes(1);
+    expect(computeSegmentColor).not.toHaveBeenCalled();
+    expect(outlineColor[0]).toBeCloseTo(1);
+    expect(outlineColor[1]).toBeCloseTo(0.95);
+    expect(outlineColor[2]).toBeCloseTo(0.35);
+    expect(cachedOutlineColor[0]).toBeCloseTo(1);
+    expect(cachedOutlineColor[1]).toBeCloseTo(0.95);
+    expect(cachedOutlineColor[2]).toBeCloseTo(0.35);
   });
 });
 

--- a/src/skeleton/frontend.spec.ts
+++ b/src/skeleton/frontend.spec.ts
@@ -17,6 +17,8 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { Uint64Set } from "#src/uint64_set.js";
+import { getContrastRatio } from "#src/util/color.js";
+import { vec3 } from "#src/util/geom.js";
 
 if (!("WebGL2RenderingContext" in globalThis)) {
   Object.defineProperty(globalThis, "WebGL2RenderingContext", {
@@ -110,6 +112,46 @@ describe("SpatiallyIndexedSkeletonLayer browse node picks", () => {
       position: new Float32Array([4, 5, 6]),
       sourceState: { revisionToken: "2026-03-29T11:51:00Z" },
     });
+  });
+});
+
+describe("SpatiallyIndexedSkeletonLayer selected node outline color", () => {
+  it("derives the selected-node outline color from the selected segment color", () => {
+    const sourceColor = vec3.fromValues(1, 0, 0);
+    const displayState = {
+      segmentationColorGroupState: {
+        value: {
+          segmentStatedColors: new Map(),
+          segmentDefaultColor: { value: sourceColor },
+          segmentColorHash: { compute: vi.fn() },
+        },
+      },
+      saturation: { value: 1 },
+      hoverHighlight: { value: false },
+      segmentSelectionState: { isSelected: vi.fn(() => false) },
+    };
+    const getCachedNodeSnapshot = vi.fn(() => ({
+      nodeId: 101,
+      segmentId: 11,
+      position: new Float32Array([1, 2, 3]),
+    }));
+    const layer = Object.assign(
+      Object.create(SpatiallyIndexedSkeletonLayer.prototype),
+      {
+        selectedNodeId: { value: 101 },
+        selectedNodeOutlineColor: vec3.create(),
+        displayState,
+        getCachedNodeSnapshot,
+      },
+    );
+
+    const outlineColor = (layer as any).getSelectedNodeOutlineColor();
+
+    expect(getCachedNodeSnapshot).toHaveBeenCalledWith(101);
+    expect([...outlineColor]).toEqual([1, 1, 1]);
+    expect(getContrastRatio(outlineColor, sourceColor)).toBeGreaterThanOrEqual(
+      3,
+    );
   });
 });
 

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -60,7 +60,7 @@ import {
 import type { SegmentationDisplayState3D } from "#src/segmentation_display_state/frontend.js";
 import {
   forEachVisibleSegmentToDraw,
-  getObjectColor,
+  getBaseObjectColor,
   registerRedrawWhenSegmentationDisplayState3DChanged,
   SegmentationLayerSharedObject,
 } from "#src/segmentation_display_state/frontend.js";
@@ -2245,7 +2245,7 @@ export class SpatiallyIndexedSkeletonLayer
     this.selectedNodeOutlineColorCacheSegmentId = normalizedSegmentId;
     return computeHighVisibilityContrastColor(
       this.selectedNodeOutlineColor,
-      getObjectColor(this.displayState, BigInt(normalizedSegmentId), 1),
+      getBaseObjectColor(this.displayState, BigInt(normalizedSegmentId)),
     );
   }
 

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -2149,9 +2149,7 @@ export class SpatiallyIndexedSkeletonLayer
     SELECTED_NODE_OUTLINE_FALLBACK_COLOR,
   );
   private selectedNodeOutlineColorGeneration = 0;
-  private selectedNodeOutlineColorCacheGeneration = -1;
-  private selectedNodeOutlineColorCacheNodeId: number | undefined;
-  private selectedNodeOutlineColorCacheSegmentId: number | undefined;
+  private cachedSelectedNodeOutlineColorGeneration = -1;
 
   private disposeOverlayChunk() {
     this.overlayChunk?.dispose(this.gl);
@@ -2211,16 +2209,11 @@ export class SpatiallyIndexedSkeletonLayer
     if (selectedNodeId === undefined) {
       return SELECTED_NODE_OUTLINE_FALLBACK_COLOR;
     }
+    const currentGeneration = this.selectedNodeOutlineColorGeneration;
     const isCacheValid =
-      this.selectedNodeOutlineColorCacheGeneration ===
-      this.selectedNodeOutlineColorGeneration;
-    if (
-      isCacheValid &&
-      this.selectedNodeOutlineColorCacheNodeId === selectedNodeId
-    ) {
-      return (
-        this.selectedNodeOutlineColor ?? SELECTED_NODE_OUTLINE_FALLBACK_COLOR
-      );
+      this.cachedSelectedNodeOutlineColorGeneration === currentGeneration;
+    if (isCacheValid) {
+      return this.selectedNodeOutlineColor;
     }
     const segmentId = this.getCachedNodeSnapshot(selectedNodeId)?.segmentId;
     const normalizedSegmentId = Math.round(Number(segmentId));
@@ -2228,21 +2221,11 @@ export class SpatiallyIndexedSkeletonLayer
       !Number.isSafeInteger(normalizedSegmentId) ||
       normalizedSegmentId <= 0
     ) {
+      this.cachedSelectedNodeOutlineColorGeneration = currentGeneration;
+      this.selectedNodeOutlineColor.set(SELECTED_NODE_OUTLINE_FALLBACK_COLOR);
       return SELECTED_NODE_OUTLINE_FALLBACK_COLOR;
     }
-    if (
-      isCacheValid &&
-      this.selectedNodeOutlineColorCacheSegmentId === normalizedSegmentId
-    ) {
-      this.selectedNodeOutlineColorCacheNodeId = selectedNodeId;
-      return (
-        this.selectedNodeOutlineColor ?? SELECTED_NODE_OUTLINE_FALLBACK_COLOR
-      );
-    }
-    this.selectedNodeOutlineColorCacheGeneration =
-      this.selectedNodeOutlineColorGeneration;
-    this.selectedNodeOutlineColorCacheNodeId = selectedNodeId;
-    this.selectedNodeOutlineColorCacheSegmentId = normalizedSegmentId;
+    this.cachedSelectedNodeOutlineColorGeneration = currentGeneration;
     return computeHighVisibilityContrastColor(
       this.selectedNodeOutlineColor,
       getBaseObjectColor(this.displayState, BigInt(normalizedSegmentId)),
@@ -2518,11 +2501,9 @@ export class SpatiallyIndexedSkeletonLayer
       ),
     );
     registerRedrawWhenSegmentationDisplayState3DChanged(displayState, this);
-    this.registerDisposer(
-      this.redrawNeeded.add(() => {
-        ++this.selectedNodeOutlineColorGeneration;
-      }),
-    );
+    const invalidateSelectedNodeOutlineColor = () => {
+      ++this.selectedNodeOutlineColorGeneration;
+    };
     this.displayState.shaderError.value = undefined;
     const { skeletonRenderingOptions: renderingOptions } = displayState;
     this.registerDisposer(
@@ -2573,6 +2554,25 @@ export class SpatiallyIndexedSkeletonLayer
       }, this.displayState.segmentationColorGroupState),
     );
     this.registerDisposer(
+      registerNested((context, colorGroupState) => {
+        context.registerDisposer(
+          colorGroupState.segmentColorHash.changed.add(
+            invalidateSelectedNodeOutlineColor,
+          ),
+        );
+        context.registerDisposer(
+          colorGroupState.segmentStatedColors.changed.add(
+            invalidateSelectedNodeOutlineColor,
+          ),
+        );
+        context.registerDisposer(
+          colorGroupState.segmentDefaultColor.changed.add(
+            invalidateSelectedNodeOutlineColor,
+          ),
+        );
+      }, this.displayState.segmentationColorGroupState),
+    );
+    this.registerDisposer(
       this.displayState.hoverHighlight.changed.add(
         updateSkeletonShaderParameters,
       ),
@@ -2602,7 +2602,12 @@ export class SpatiallyIndexedSkeletonLayer
     const requestRedraw = () => this.redrawNeeded.dispatch();
     const selectedNodeWatchable = this.selectedNodeId;
     if (selectedNodeWatchable?.changed) {
-      this.registerDisposer(selectedNodeWatchable.changed.add(requestRedraw));
+      this.registerDisposer(
+        selectedNodeWatchable.changed.add(() => {
+          invalidateSelectedNodeOutlineColor();
+          requestRedraw();
+        }),
+      );
     }
     const pendingNodePositionVersion = options.pendingNodePositionVersion;
     if (pendingNodePositionVersion?.changed) {
@@ -2614,6 +2619,7 @@ export class SpatiallyIndexedSkeletonLayer
     if (inspectionState !== undefined) {
       this.registerDisposer(
         inspectionState.nodeDataVersion.changed.add(() => {
+          invalidateSelectedNodeOutlineColor();
           this.redrawNeeded.dispatch();
         }),
       );

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -60,6 +60,7 @@ import {
 import type { SegmentationDisplayState3D } from "#src/segmentation_display_state/frontend.js";
 import {
   forEachVisibleSegmentToDraw,
+  getObjectColor,
   registerRedrawWhenSegmentationDisplayState3DChanged,
   SegmentationLayerSharedObject,
 } from "#src/segmentation_display_state/frontend.js";
@@ -119,6 +120,7 @@ import {
 } from "#src/trackable_value.js";
 import { Uint64Set } from "#src/uint64_set.js";
 import { gatherUpdate } from "#src/util/array.js";
+import { computeHighVisibilityContrastColor } from "#src/util/color.js";
 import { hsvToRgb } from "#src/util/colorspace.js";
 import { DataType } from "#src/util/data_type.js";
 import { RefCounted } from "#src/util/disposable.js";
@@ -198,7 +200,7 @@ const DEFAULT_FRAGMENT_MAIN = `void main() {
 }
 `;
 
-const SELECTED_NODE_OUTLINE_COLOR_RGB = "1.0, 0.95, 0.35";
+const SELECTED_NODE_OUTLINE_FALLBACK_COLOR = vec3.fromValues(1.0, 0.95, 0.35);
 const SELECTED_NODE_OUTLINE_MIN_WIDTH_2D = "1.75";
 const SELECTED_NODE_OUTLINE_MAX_WIDTH_2D = "3.0";
 const SELECTED_NODE_OUTLINE_MIN_WIDTH_3D = "1.5";
@@ -768,6 +770,7 @@ void emitDefault() {
           builder.addUniform("highp float", "uNodeDiameter");
           let selectedOutlineWidthExpression = "0.0";
           if (this.selectedNodeAttributeIndex !== undefined) {
+            builder.addUniform("highp vec3", "uSelectedNodeOutlineColor");
             builder.addVarying("highp float", "vSelectedNode", "flat");
             const selectedOutlineMinWidth = this.targetIsSliceView
               ? SELECTED_NODE_OUTLINE_MIN_WIDTH_2D
@@ -818,7 +821,7 @@ emitCircle(
             const borderColorExpression =
               selectedNodeExpression === undefined
                 ? "renderColor"
-                : `((${selectedNodeExpression} > 0.5) ? vec4(${SELECTED_NODE_OUTLINE_COLOR_RGB}, renderColor.a) : renderColor)`;
+                : `((${selectedNodeExpression} > 0.5) ? vec4(uSelectedNodeOutlineColor, renderColor.a) : renderColor)`;
             builder.addFragmentCode(`
 vec4 segmentColor() {
   return getSegmentAppearance(${segmentExpression});
@@ -868,7 +871,7 @@ void emitDefault() {
             const borderColorExpression =
               selectedNodeExpression === undefined
                 ? "renderColor"
-                : `((${selectedNodeExpression} > 0.5) ? vec4(${SELECTED_NODE_OUTLINE_COLOR_RGB}, renderColor.a) : renderColor)`;
+                : `((${selectedNodeExpression} > 0.5) ? vec4(uSelectedNodeOutlineColor, renderColor.a) : renderColor)`;
             builder.addFragmentCode(`
 vec4 segmentColor() {
   return ${segmentColorExpression};
@@ -2142,6 +2145,9 @@ export class SpatiallyIndexedSkeletonLayer
   private suppressedBrowseSegmentIds = new Set<number>();
   private retainedOverlaySegmentIds: number[] = [];
   private maxRetainedOverlaySegments: number;
+  private readonly selectedNodeOutlineColor = vec3.clone(
+    SELECTED_NODE_OUTLINE_FALLBACK_COLOR,
+  );
 
   private disposeOverlayChunk() {
     this.overlayChunk?.dispose(this.gl);
@@ -2194,6 +2200,25 @@ export class SpatiallyIndexedSkeletonLayer
     }
     segmentIds.sort((a, b) => a - b);
     return segmentIds;
+  }
+
+  private getSelectedNodeOutlineColor() {
+    const selectedNodeId = this.selectedNodeId?.value;
+    if (selectedNodeId === undefined) {
+      return SELECTED_NODE_OUTLINE_FALLBACK_COLOR;
+    }
+    const segmentId = this.getCachedNodeSnapshot(selectedNodeId)?.segmentId;
+    const normalizedSegmentId = Math.round(Number(segmentId));
+    if (
+      !Number.isSafeInteger(normalizedSegmentId) ||
+      normalizedSegmentId <= 0
+    ) {
+      return SELECTED_NODE_OUTLINE_FALLBACK_COLOR;
+    }
+    return computeHighVisibilityContrastColor(
+      this.selectedNodeOutlineColor,
+      getObjectColor(this.displayState, BigInt(normalizedSegmentId), 1),
+    );
   }
 
   getRetainedOverlaySegmentIds() {
@@ -3149,6 +3174,12 @@ export class SpatiallyIndexedSkeletonLayer
     );
     if (passState === undefined) return;
     const { gl, edgeShader, nodeShader, skeletonParams } = passState;
+
+    nodeShader.bind();
+    gl.uniform3fv(
+      nodeShader.uniform("uSelectedNodeOutlineColor"),
+      this.getSelectedNodeOutlineColor(),
+    );
 
     if (renderContext.emitPickID) {
       const edgePickId =

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -2148,6 +2148,10 @@ export class SpatiallyIndexedSkeletonLayer
   private readonly selectedNodeOutlineColor = vec3.clone(
     SELECTED_NODE_OUTLINE_FALLBACK_COLOR,
   );
+  private selectedNodeOutlineColorGeneration = 0;
+  private selectedNodeOutlineColorCacheGeneration = -1;
+  private selectedNodeOutlineColorCacheNodeId: number | undefined;
+  private selectedNodeOutlineColorCacheSegmentId: number | undefined;
 
   private disposeOverlayChunk() {
     this.overlayChunk?.dispose(this.gl);
@@ -2207,6 +2211,17 @@ export class SpatiallyIndexedSkeletonLayer
     if (selectedNodeId === undefined) {
       return SELECTED_NODE_OUTLINE_FALLBACK_COLOR;
     }
+    const isCacheValid =
+      this.selectedNodeOutlineColorCacheGeneration ===
+      this.selectedNodeOutlineColorGeneration;
+    if (
+      isCacheValid &&
+      this.selectedNodeOutlineColorCacheNodeId === selectedNodeId
+    ) {
+      return (
+        this.selectedNodeOutlineColor ?? SELECTED_NODE_OUTLINE_FALLBACK_COLOR
+      );
+    }
     const segmentId = this.getCachedNodeSnapshot(selectedNodeId)?.segmentId;
     const normalizedSegmentId = Math.round(Number(segmentId));
     if (
@@ -2215,6 +2230,19 @@ export class SpatiallyIndexedSkeletonLayer
     ) {
       return SELECTED_NODE_OUTLINE_FALLBACK_COLOR;
     }
+    if (
+      isCacheValid &&
+      this.selectedNodeOutlineColorCacheSegmentId === normalizedSegmentId
+    ) {
+      this.selectedNodeOutlineColorCacheNodeId = selectedNodeId;
+      return (
+        this.selectedNodeOutlineColor ?? SELECTED_NODE_OUTLINE_FALLBACK_COLOR
+      );
+    }
+    this.selectedNodeOutlineColorCacheGeneration =
+      this.selectedNodeOutlineColorGeneration;
+    this.selectedNodeOutlineColorCacheNodeId = selectedNodeId;
+    this.selectedNodeOutlineColorCacheSegmentId = normalizedSegmentId;
     return computeHighVisibilityContrastColor(
       this.selectedNodeOutlineColor,
       getObjectColor(this.displayState, BigInt(normalizedSegmentId), 1),
@@ -2490,6 +2518,11 @@ export class SpatiallyIndexedSkeletonLayer
       ),
     );
     registerRedrawWhenSegmentationDisplayState3DChanged(displayState, this);
+    this.registerDisposer(
+      this.redrawNeeded.add(() => {
+        ++this.selectedNodeOutlineColorGeneration;
+      }),
+    );
     this.displayState.shaderError.value = undefined;
     const { skeletonRenderingOptions: renderingOptions } = displayState;
     this.registerDisposer(

--- a/src/util/color.browser_test.ts
+++ b/src/util/color.browser_test.ts
@@ -16,6 +16,8 @@
 
 import { describe, it, expect } from "vitest";
 import {
+  computeHighVisibilityContrastColor,
+  getContrastRatio,
   parseColorSerialization,
   parseRGBColorSpecification,
   packColor,
@@ -83,6 +85,12 @@ describe("color", () => {
   });
 });
 
+function expectColorClose(actual: Float32Array, expected: readonly number[]) {
+  for (let i = 0; i < 3; ++i) {
+    expect(actual[i]).toBeCloseTo(expected[i]);
+  }
+}
+
 describe("useWhiteBackground", () => {
   it("works for simple cases", () => {
     expect(useWhiteBackground(vec3.fromValues(0, 0, 0))).toBe(true);
@@ -90,5 +98,95 @@ describe("useWhiteBackground", () => {
     expect(useWhiteBackground(vec3.fromValues(1, 0, 0))).toBe(false);
     expect(useWhiteBackground(vec3.fromValues(0, 1, 0))).toBe(false);
     expect(useWhiteBackground(vec3.fromValues(0, 0, 1))).toBe(true);
+  });
+});
+
+describe("getContrastRatio", () => {
+  it("matches WCAG contrast-ratio reference values", () => {
+    expect(
+      getContrastRatio(vec3.fromValues(0, 0, 0), vec3.fromValues(1, 1, 1)),
+    ).toBeCloseTo(21);
+    expect(
+      getContrastRatio(
+        vec3.fromValues(0.5, 0.5, 0.5),
+        vec3.fromValues(0.5, 0.5, 0.5),
+      ),
+    ).toBeCloseTo(1);
+  });
+});
+
+describe("computeHighVisibilityContrastColor", () => {
+  it("uses white for dark colors", () => {
+    const sourceColor = vec3.fromValues(0, 0, 0);
+    const color = computeHighVisibilityContrastColor(
+      vec3.create(),
+      sourceColor,
+    );
+
+    expectColorClose(color, [1, 1, 1]);
+    expect(getContrastRatio(color, sourceColor)).toBeGreaterThanOrEqual(3);
+  });
+
+  it("uses red for bright colors", () => {
+    const sourceColor = vec3.fromValues(1, 1, 1);
+    const color = computeHighVisibilityContrastColor(
+      vec3.create(),
+      sourceColor,
+    );
+
+    expectColorClose(color, [1, 0, 0]);
+    expect(getContrastRatio(color, sourceColor)).toBeGreaterThanOrEqual(3);
+  });
+
+  it("keeps a bright visible candidate for saturated colors", () => {
+    const sourceColor = vec3.fromValues(1, 0, 0);
+    const color = computeHighVisibilityContrastColor(
+      vec3.create(),
+      sourceColor,
+    );
+
+    expectColorClose(color, [1, 1, 1]);
+    expect(getContrastRatio(color, sourceColor)).toBeGreaterThanOrEqual(3);
+  });
+
+  it("handles low-saturation colors without choosing black", () => {
+    const sourceColor = vec3.fromValues(0.5, 0.5, 0.5);
+    const color = computeHighVisibilityContrastColor(
+      vec3.create(),
+      sourceColor,
+    );
+
+    expectColorClose(color, [1, 1, 1]);
+    expect(getContrastRatio(color, sourceColor)).toBeGreaterThanOrEqual(3);
+  });
+
+  it("uses white for near-black colors", () => {
+    const sourceColor = vec3.fromValues(0.05, 0.05, 0.05);
+    const color = computeHighVisibilityContrastColor(
+      vec3.create(),
+      sourceColor,
+    );
+
+    expectColorClose(color, [1, 1, 1]);
+  });
+
+  it("uses red for near-white colors", () => {
+    const sourceColor = vec3.fromValues(0.95, 0.95, 0.95);
+    const color = computeHighVisibilityContrastColor(
+      vec3.create(),
+      sourceColor,
+    );
+
+    expectColorClose(color, [1, 0, 0]);
+  });
+
+  it("uses red for yellow-like segment colors", () => {
+    const sourceColor = vec3.fromValues(1, 0.95, 0.35);
+    const color = computeHighVisibilityContrastColor(
+      vec3.create(),
+      sourceColor,
+    );
+
+    expectColorClose(color, [1, 0, 0]);
   });
 });

--- a/src/util/color.browser_test.ts
+++ b/src/util/color.browser_test.ts
@@ -116,14 +116,14 @@ describe("getContrastRatio", () => {
 });
 
 describe("computeHighVisibilityContrastColor", () => {
-  it("uses white for dark colors", () => {
+  it("prefers yellow for dark colors", () => {
     const sourceColor = vec3.fromValues(0, 0, 0);
     const color = computeHighVisibilityContrastColor(
       vec3.create(),
       sourceColor,
     );
 
-    expectColorClose(color, [1, 1, 1]);
+    expectColorClose(color, [1, 0.95, 0.35]);
     expect(getContrastRatio(color, sourceColor)).toBeGreaterThanOrEqual(3);
   });
 
@@ -138,36 +138,36 @@ describe("computeHighVisibilityContrastColor", () => {
     expect(getContrastRatio(color, sourceColor)).toBeGreaterThanOrEqual(3);
   });
 
-  it("keeps a bright visible candidate for saturated colors", () => {
+  it("uses yellow for red segment colors", () => {
     const sourceColor = vec3.fromValues(1, 0, 0);
     const color = computeHighVisibilityContrastColor(
       vec3.create(),
       sourceColor,
     );
 
-    expectColorClose(color, [1, 1, 1]);
+    expectColorClose(color, [1, 0.95, 0.35]);
     expect(getContrastRatio(color, sourceColor)).toBeGreaterThanOrEqual(3);
   });
 
-  it("handles low-saturation colors without choosing black", () => {
+  it("uses yellow for low-saturation midtone colors", () => {
     const sourceColor = vec3.fromValues(0.5, 0.5, 0.5);
     const color = computeHighVisibilityContrastColor(
       vec3.create(),
       sourceColor,
     );
 
-    expectColorClose(color, [1, 1, 1]);
+    expectColorClose(color, [1, 0.95, 0.35]);
     expect(getContrastRatio(color, sourceColor)).toBeGreaterThanOrEqual(3);
   });
 
-  it("uses white for near-black colors", () => {
+  it("uses yellow for near-black colors", () => {
     const sourceColor = vec3.fromValues(0.05, 0.05, 0.05);
     const color = computeHighVisibilityContrastColor(
       vec3.create(),
       sourceColor,
     );
 
-    expectColorClose(color, [1, 1, 1]);
+    expectColorClose(color, [1, 0.95, 0.35]);
   });
 
   it("uses red for near-white colors", () => {
@@ -182,6 +182,16 @@ describe("computeHighVisibilityContrastColor", () => {
 
   it("uses red for yellow-like segment colors", () => {
     const sourceColor = vec3.fromValues(1, 0.95, 0.35);
+    const color = computeHighVisibilityContrastColor(
+      vec3.create(),
+      sourceColor,
+    );
+
+    expectColorClose(color, [1, 0, 0]);
+  });
+
+  it("uses red when yellow would be close to the segment color", () => {
+    const sourceColor = vec3.fromValues(0.35, 1, 0.35);
     const color = computeHighVisibilityContrastColor(
       vec3.create(),
       sourceColor,

--- a/src/util/color.ts
+++ b/src/util/color.ts
@@ -152,16 +152,18 @@ export function srgbGammaExpand(value: number) {
 // https://www.w3.org/TR/WCAG20/#relativeluminancedef
 //
 // @param color sRGB color
-export function getRelativeLuminance(color: vec3 | vec4) {
-  const [r, g, b] = color;
+export function getRelativeLuminance(color: ArrayLike<number>) {
   return (
-    0.2126 * srgbGammaExpand(r) +
-    0.7152 * srgbGammaExpand(g) +
-    0.0722 * srgbGammaExpand(b)
+    0.2126 * srgbGammaExpand(color[0]) +
+    0.7152 * srgbGammaExpand(color[1]) +
+    0.0722 * srgbGammaExpand(color[2])
   );
 }
 
-export function getContrastRatio(colorA: vec3 | vec4, colorB: vec3 | vec4) {
+export function getContrastRatio(
+  colorA: ArrayLike<number>,
+  colorB: ArrayLike<number>,
+) {
   const luminanceA = getRelativeLuminance(colorA);
   const luminanceB = getRelativeLuminance(colorB);
   const darker = Math.min(luminanceA, luminanceB);
@@ -186,7 +188,7 @@ const RED_HIGHLIGHT_CONTRAST_BIAS = 1.2;
 
 export function computeHighVisibilityContrastColor<T extends Float32Array>(
   out: T,
-  sourceColor: vec3 | vec4,
+  sourceColor: ArrayLike<number>,
 ) {
   const yellowContrast = getContrastRatio(yellowHighlight, sourceColor);
   const redContrast = getContrastRatio(redHighlight, sourceColor);

--- a/src/util/color.ts
+++ b/src/util/color.ts
@@ -184,25 +184,20 @@ const yellowHighlight = vec3.fromValues(1, 0.95, 0.35);
 const redHighlight = vec3.fromValues(1, 0, 0);
 const RED_HIGHLIGHT_CONTRAST_BIAS = 1.2;
 
-function copyRgb<T extends Float32Array>(out: T, color: ArrayLike<number>) {
-  out[0] = color[0];
-  out[1] = color[1];
-  out[2] = color[2];
-  return out;
-}
-
 export function computeHighVisibilityContrastColor<T extends Float32Array>(
   out: T,
   sourceColor: vec3 | vec4,
 ) {
   const yellowContrast = getContrastRatio(yellowHighlight, sourceColor);
   const redContrast = getContrastRatio(redHighlight, sourceColor);
-  return copyRgb(
-    out,
+  const color =
     redContrast > yellowContrast * RED_HIGHLIGHT_CONTRAST_BIAS
       ? redHighlight
-      : yellowHighlight,
-  );
+      : yellowHighlight;
+  out[0] = color[0];
+  out[1] = color[1];
+  out[2] = color[2];
+  return out;
 }
 
 export class TrackableRGB extends WatchableValue<vec3> {

--- a/src/util/color.ts
+++ b/src/util/color.ts
@@ -180,16 +180,9 @@ export function useWhiteBackground(foregroundColor: vec3 | vec4) {
   return getRelativeLuminance(foregroundColor) <= 0.179;
 }
 
-const whiteAccent = vec3.fromValues(1, 1, 1);
-const visibleHighlightCandidates = [
-  whiteAccent,
-  vec3.fromValues(1, 0.95, 0.35), // yellow
-  vec3.fromValues(0, 1, 1), // cyan
-  vec3.fromValues(1, 0, 1), // magenta
-  vec3.fromValues(1, 0, 0), // red
-  vec3.fromValues(0.35, 1, 0.35), // green
-  vec3.fromValues(1, 0.55, 0), // orange
-];
+const yellowHighlight = vec3.fromValues(1, 0.95, 0.35);
+const redHighlight = vec3.fromValues(1, 0, 0);
+const RED_HIGHLIGHT_CONTRAST_BIAS = 1.2;
 
 function copyRgb<T extends Float32Array>(out: T, color: ArrayLike<number>) {
   out[0] = color[0];
@@ -202,17 +195,14 @@ export function computeHighVisibilityContrastColor<T extends Float32Array>(
   out: T,
   sourceColor: vec3 | vec4,
 ) {
-  let bestColor = visibleHighlightCandidates[0];
-  let bestContrast = getContrastRatio(bestColor, sourceColor);
-  for (let i = 1; i < visibleHighlightCandidates.length; ++i) {
-    const candidate = visibleHighlightCandidates[i];
-    const contrast = getContrastRatio(candidate, sourceColor);
-    if (contrast > bestContrast) {
-      bestColor = candidate;
-      bestContrast = contrast;
-    }
-  }
-  return copyRgb(out, bestColor);
+  const yellowContrast = getContrastRatio(yellowHighlight, sourceColor);
+  const redContrast = getContrastRatio(redHighlight, sourceColor);
+  return copyRgb(
+    out,
+    redContrast > yellowContrast * RED_HIGHLIGHT_CONTRAST_BIAS
+      ? redHighlight
+      : yellowHighlight,
+  );
 }
 
 export class TrackableRGB extends WatchableValue<vec3> {

--- a/src/util/color.ts
+++ b/src/util/color.ts
@@ -161,6 +161,14 @@ export function getRelativeLuminance(color: vec3 | vec4) {
   );
 }
 
+export function getContrastRatio(colorA: vec3 | vec4, colorB: vec3 | vec4) {
+  const luminanceA = getRelativeLuminance(colorA);
+  const luminanceB = getRelativeLuminance(colorB);
+  const darker = Math.min(luminanceA, luminanceB);
+  const lighter = Math.max(luminanceA, luminanceB);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
 // Determines whether a white background would provide higher contrast than a black background for
 // the given foreground color.
 //
@@ -170,6 +178,41 @@ export function getRelativeLuminance(color: vec3 | vec4) {
 // https://stackoverflow.com/a/3943023
 export function useWhiteBackground(foregroundColor: vec3 | vec4) {
   return getRelativeLuminance(foregroundColor) <= 0.179;
+}
+
+const whiteAccent = vec3.fromValues(1, 1, 1);
+const visibleHighlightCandidates = [
+  whiteAccent,
+  vec3.fromValues(1, 0.95, 0.35), // yellow
+  vec3.fromValues(0, 1, 1), // cyan
+  vec3.fromValues(1, 0, 1), // magenta
+  vec3.fromValues(1, 0, 0), // red
+  vec3.fromValues(0.35, 1, 0.35), // green
+  vec3.fromValues(1, 0.55, 0), // orange
+];
+
+function copyRgb<T extends Float32Array>(out: T, color: ArrayLike<number>) {
+  out[0] = color[0];
+  out[1] = color[1];
+  out[2] = color[2];
+  return out;
+}
+
+export function computeHighVisibilityContrastColor<T extends Float32Array>(
+  out: T,
+  sourceColor: vec3 | vec4,
+) {
+  let bestColor = visibleHighlightCandidates[0];
+  let bestContrast = getContrastRatio(bestColor, sourceColor);
+  for (let i = 1; i < visibleHighlightCandidates.length; ++i) {
+    const candidate = visibleHighlightCandidates[i];
+    const contrast = getContrastRatio(candidate, sourceColor);
+    if (contrast > bestContrast) {
+      bestColor = candidate;
+      bestContrast = contrast;
+    }
+  }
+  return copyRgb(out, bestColor);
 }
 
 export class TrackableRGB extends WatchableValue<vec3> {

--- a/src/util/color.ts
+++ b/src/util/color.ts
@@ -184,7 +184,7 @@ export function useWhiteBackground(foregroundColor: vec3 | vec4) {
 
 const yellowHighlight = vec3.fromValues(1, 0.95, 0.35);
 const redHighlight = vec3.fromValues(1, 0, 0);
-const RED_HIGHLIGHT_CONTRAST_BIAS = 1.2;
+const YELLOW_HIGHLIGHT_CONTRAST_BIAS = 1.2;
 
 export function computeHighVisibilityContrastColor<T extends Float32Array>(
   out: T,
@@ -193,7 +193,7 @@ export function computeHighVisibilityContrastColor<T extends Float32Array>(
   const yellowContrast = getContrastRatio(yellowHighlight, sourceColor);
   const redContrast = getContrastRatio(redHighlight, sourceColor);
   const color =
-    redContrast > yellowContrast * RED_HIGHLIGHT_CONTRAST_BIAS
+    redContrast > yellowContrast * YELLOW_HIGHLIGHT_CONTRAST_BIAS
       ? redHighlight
       : yellowHighlight;
   out[0] = color[0];


### PR DESCRIPTION
Closes https://metacell.atlassian.net/browse/NA-650

Instead of using a fixed yellow outline, the selected node outline color is now computed on the CPU from the displayed segment color and passed to the shader as uSelectedNodeOutlineColor. The implementation chooses a high-visibility highlight color from a bright palette based on contrast with the segment color

https://github.com/user-attachments/assets/0288e948-c2de-475a-abdb-36ed1145b944

