### PR TITLE
fix: Prevent edits until previous edit is finished

### DIFF
--- a/src/layer/segmentation/index.spec.ts
+++ b/src/layer/segmentation/index.spec.ts
@@ -108,6 +108,33 @@ function makeSpatialSkeletonLayerWithSource(source: unknown) {
   };
 }
 
+function makeSpatialSkeletonActionGateLayer(options: {
+  source: unknown;
+  visibleChunksLoaded?: boolean;
+  visibleChunksNeeded?: number;
+  visibleChunksAvailable?: number;
+  commandBusy?: boolean;
+}) {
+  return Object.assign(Object.create(SegmentationUserLayer.prototype), {
+    getSpatiallyIndexedSkeletonLayer: () =>
+      makeSpatialSkeletonLayerWithSource(options.source),
+    spatialSkeletonState: {
+      commandHistory: {
+        isBusy: new WatchableValue(options.commandBusy ?? false),
+      },
+    },
+    spatialSkeletonVisibleChunksLoaded: new WatchableValue(
+      options.visibleChunksLoaded ?? true,
+    ),
+    spatialSkeletonVisibleChunksNeeded: new WatchableValue(
+      options.visibleChunksNeeded ?? 0,
+    ),
+    spatialSkeletonVisibleChunksAvailable: new WatchableValue(
+      options.visibleChunksAvailable ?? 0,
+    ),
+  });
+}
+
 describe("layer/segmentation spatial skeleton chunk stats", () => {
   it("tracks combined chunk load state from the loading render layers only", () => {
     // After the 2D/3D backend unification, only PerspectiveViewSpatiallyIndexedSkeletonLayer
@@ -152,20 +179,11 @@ describe("layer/segmentation spatial skeleton chunk stats", () => {
 
 describe("layer/segmentation spatial skeleton action gating", () => {
   it("does not require a specific grid level for skeleton actions", () => {
-    const layer = Object.assign(
-      Object.create(SegmentationUserLayer.prototype),
-      {
-        getSpatiallyIndexedSkeletonLayer: () =>
-          makeSpatialSkeletonLayerWithSource(
-            makeEditableSpatialSkeletonSource({
-              rerootCommand: true,
-            }),
-          ),
-        spatialSkeletonVisibleChunksLoaded: new WatchableValue(true),
-        spatialSkeletonVisibleChunksNeeded: new WatchableValue(0),
-        spatialSkeletonVisibleChunksAvailable: new WatchableValue(0),
-      },
-    );
+    const layer = makeSpatialSkeletonActionGateLayer({
+      source: makeEditableSpatialSkeletonSource({
+        rerootCommand: true,
+      }),
+    });
 
     expect(
       layer.getSpatialSkeletonActionsDisabledReason(
@@ -188,19 +206,47 @@ describe("layer/segmentation spatial skeleton action gating", () => {
     ).toBeUndefined();
   });
 
+  it("blocks edit actions while a skeleton edit is in flight", () => {
+    const layer = makeSpatialSkeletonActionGateLayer({
+      source: makeEditableSpatialSkeletonSource({
+        rerootCommand: true,
+      }),
+      commandBusy: true,
+    });
+
+    expect(
+      layer.getSpatialSkeletonActionsDisabledReason(
+        SpatialSkeletonActions.moveNodes,
+      ),
+    ).toBe("Wait for the current skeleton edit to finish.");
+    expect(
+      layer.getSpatialSkeletonActionsDisabledReason([
+        SpatialSkeletonActions.inspect,
+        SpatialSkeletonActions.addNodes,
+      ]),
+    ).toBe("Wait for the current skeleton edit to finish.");
+    expect(
+      layer.getSpatialSkeletonActionsDisabledReason(
+        SpatialSkeletonActions.inspect,
+      ),
+    ).toBeUndefined();
+    expect(
+      layer.getSpatialSkeletonActionsDisabledReason(
+        SpatialSkeletonActions.moveNodes,
+        {
+          ignoreCommandBusy: true,
+        },
+      ),
+    ).toBeUndefined();
+  });
+
   it("still reports visible chunk loading when requested", () => {
-    const layer = Object.assign(
-      Object.create(SegmentationUserLayer.prototype),
-      {
-        getSpatiallyIndexedSkeletonLayer: () =>
-          makeSpatialSkeletonLayerWithSource(
-            makeEditableSpatialSkeletonSource(),
-          ),
-        spatialSkeletonVisibleChunksLoaded: new WatchableValue(false),
-        spatialSkeletonVisibleChunksNeeded: new WatchableValue(3),
-        spatialSkeletonVisibleChunksAvailable: new WatchableValue(1),
-      },
-    );
+    const layer = makeSpatialSkeletonActionGateLayer({
+      source: makeEditableSpatialSkeletonSource(),
+      visibleChunksLoaded: false,
+      visibleChunksNeeded: 3,
+      visibleChunksAvailable: 1,
+    });
 
     expect(
       layer.getSpatialSkeletonActionsDisabledReason(
@@ -213,18 +259,9 @@ describe("layer/segmentation spatial skeleton action gating", () => {
   });
 
   it("reports missing reroot support explicitly", () => {
-    const layer = Object.assign(
-      Object.create(SegmentationUserLayer.prototype),
-      {
-        getSpatiallyIndexedSkeletonLayer: () =>
-          makeSpatialSkeletonLayerWithSource(
-            makeEditableSpatialSkeletonSource(),
-          ),
-        spatialSkeletonVisibleChunksLoaded: new WatchableValue(true),
-        spatialSkeletonVisibleChunksNeeded: new WatchableValue(0),
-        spatialSkeletonVisibleChunksAvailable: new WatchableValue(0),
-      },
-    );
+    const layer = makeSpatialSkeletonActionGateLayer({
+      source: makeEditableSpatialSkeletonSource(),
+    });
 
     expect(
       layer.getSpatialSkeletonActionsDisabledReason(
@@ -239,18 +276,9 @@ describe("layer/segmentation spatial skeleton action gating", () => {
   });
 
   it("requires confidence configuration for confidence edit support", () => {
-    const layer = Object.assign(
-      Object.create(SegmentationUserLayer.prototype),
-      {
-        getSpatiallyIndexedSkeletonLayer: () =>
-          makeSpatialSkeletonLayerWithSource(
-            makeEditableSpatialSkeletonSource(),
-          ),
-        spatialSkeletonVisibleChunksLoaded: new WatchableValue(true),
-        spatialSkeletonVisibleChunksNeeded: new WatchableValue(0),
-        spatialSkeletonVisibleChunksAvailable: new WatchableValue(0),
-      },
-    );
+    const layer = makeSpatialSkeletonActionGateLayer({
+      source: makeEditableSpatialSkeletonSource(),
+    });
 
     expect(
       layer.getSpatialSkeletonActionsDisabledReason(
@@ -275,21 +303,14 @@ describe("layer/segmentation spatial skeleton action gating", () => {
   });
 
   it("reports read-only spatial skeleton sources explicitly", () => {
-    const layer = Object.assign(
-      Object.create(SegmentationUserLayer.prototype),
-      {
-        getSpatiallyIndexedSkeletonLayer: () =>
-          makeSpatialSkeletonLayerWithSource({
-            ...makeEditableSpatialSkeletonSource({
-              rerootCommand: true,
-            }),
-            readonly: true,
-          }),
-        spatialSkeletonVisibleChunksLoaded: new WatchableValue(true),
-        spatialSkeletonVisibleChunksNeeded: new WatchableValue(0),
-        spatialSkeletonVisibleChunksAvailable: new WatchableValue(0),
+    const layer = makeSpatialSkeletonActionGateLayer({
+      source: {
+        ...makeEditableSpatialSkeletonSource({
+          rerootCommand: true,
+        }),
+        readonly: true,
       },
-    );
+    });
 
     expect(
       layer.getSpatialSkeletonActionsDisabledReason(

--- a/src/layer/segmentation/index.ts
+++ b/src/layer/segmentation/index.ts
@@ -109,6 +109,7 @@ import { SharedWatchableValue } from "#src/shared_watchable_value.js";
 import {
   DEFAULT_SPATIAL_SKELETON_EDIT_ACTIONS,
   getSpatialSkeletonActionSupportLabel,
+  isSpatialSkeletonEditAction,
   SpatialSkeletonActions,
   type SpatialSkeletonAction,
 } from "#src/skeleton/actions.js";
@@ -1613,14 +1614,26 @@ export class SegmentationUserLayer extends Base {
       | SpatialSkeletonAction
       | readonly SpatialSkeletonAction[] = DEFAULT_SPATIAL_SKELETON_EDIT_ACTIONS,
     options: {
+      ignoreCommandBusy?: boolean;
       requireVisibleChunks?: boolean;
     } = {},
   ) {
-    const { requireVisibleChunks = false } = options;
+    const { ignoreCommandBusy = false, requireVisibleChunks = false } =
+      options;
     const missingSupportReason =
       this.getMissingSpatialSkeletonSupportReason(requiredActions);
     if (missingSupportReason !== undefined) {
       return missingSupportReason;
+    }
+    const requirements = Array.isArray(requiredActions)
+      ? requiredActions
+      : [requiredActions];
+    if (
+      !ignoreCommandBusy &&
+      requirements.some((action) => isSpatialSkeletonEditAction(action)) &&
+      this.spatialSkeletonState.commandHistory.isBusy.value
+    ) {
+      return "Wait for the current skeleton edit to finish.";
     }
     if (
       requireVisibleChunks &&

--- a/src/skeleton/actions.ts
+++ b/src/skeleton/actions.ts
@@ -38,6 +38,10 @@ export const DEFAULT_SPATIAL_SKELETON_EDIT_ACTIONS = [
   SpatialSkeletonActions.deleteNodes,
 ] as const satisfies readonly SpatialSkeletonAction[];
 
+export function isSpatialSkeletonEditAction(action: SpatialSkeletonAction) {
+  return action !== SpatialSkeletonActions.inspect;
+}
+
 export function getSpatialSkeletonActionSupportLabel(
   action: SpatialSkeletonAction,
 ) {

--- a/src/ui/spatial_skeleton_edit_tab.ts
+++ b/src/ui/spatial_skeleton_edit_tab.ts
@@ -1639,6 +1639,7 @@ export class SpatialSkeletonEditTab extends Tab {
     );
     this.registerDisposer(
       layer.spatialSkeletonState.commandHistory.isBusy.changed.add(() => {
+        updateGateStatus();
         updateHistoryButtons();
       }),
     );

--- a/src/ui/spatial_skeleton_edit_tool.ts
+++ b/src/ui/spatial_skeleton_edit_tool.ts
@@ -579,7 +579,9 @@ abstract class SpatialSkeletonToolBase extends LayerTool<SegmentationUserLayer> 
   ) {
     const handleStateChanged = () => {
       const disabledReason =
-        this.layer.getSpatialSkeletonActionsDisabledReason(requiredActions);
+        this.layer.getSpatialSkeletonActionsDisabledReason(requiredActions, {
+          ignoreCommandBusy: true,
+        });
       if (disabledReason === undefined) {
         onReady?.();
         return;
@@ -747,6 +749,7 @@ export class SpatialSkeletonEditModeTool extends SpatialSkeletonToolBase {
       layer.getSpatialSkeletonActionsDisabledReason(
         [SpatialSkeletonActions.addNodes, SpatialSkeletonActions.moveNodes],
         {
+          ignoreCommandBusy: true,
           requireVisibleChunks: false,
         },
       );
@@ -798,6 +801,11 @@ export class SpatialSkeletonEditModeTool extends SpatialSkeletonToolBase {
     );
     activation.registerDisposer(
       layer.manager.root.selectionState.changed.add(renderStatus),
+    );
+    activation.registerDisposer(
+      layer.spatialSkeletonState.commandHistory.isBusy.changed.add(
+        updateInteractionStatus,
+      ),
     );
     activation.registerDisposer(
       layer.layersChanged.add(() => {


### PR DESCRIPTION
Closes https://metacell.atlassian.net/browse/NA-651

Adds protection against starting a new spatial skeleton edit while a previous edit is still being confirmed. It introduces a shared edit-action busy gate, keeps inspection/navigation available during pending edits

https://github.com/user-attachments/assets/58ab448b-0c32-442d-86e5-43eb7f9ea1a6

