### PR TITLE
fix: correct volume rendering picking and skeleton picking interactions

### DIFF
--- a/src/perspective_view/panel.ts
+++ b/src/perspective_view/panel.ts
@@ -1363,10 +1363,12 @@ export class PerspectivePanel extends RenderedDataPanel {
       );
       gl.stencilMask(2);
       if (hasVolumeRenderingPick) {
+        gl.depthMask(false);
         this.maxProjectionPickCopyHelper.draw(
           this.maxProjectionPickConfiguration.colorBuffers[0].texture /*depth*/,
           this.maxProjectionPickConfiguration.colorBuffers[1].texture /*pick*/,
         );
+        gl.depthMask(true);
       }
       for (const [renderLayer, attachment] of visibleLayers) {
         if (


### PR DESCRIPTION
This may need further picking priority to make it work better. I'm still admittedly thinking through exactly how to do that best. But in the meantime I think this should make the picking work sometimes and give us a feel for the remaining cases that don't feel good.

Roughly the problem was that the max projection picking result gets copied over into a a picking buffer. After this, a picking pass happens for other transparent layers, and depth testing is used during that pass. The max projection picking result was being copied in with depth writing enabled, which meant that later transparent projection picking writes could get blocked by bogus depth information, instead of the real depth information they are meant to use from the opaque pass or any other depth information which may be written during the transparent pick pass.