### PR TITLE
feat: clarify tool messages in navigation

### DIFF
--- a/src/ui/spatial_skeleton_edit_tab.ts
+++ b/src/ui/spatial_skeleton_edit_tab.ts
@@ -89,6 +89,12 @@ import { Tab } from "#src/widget/tab_view.js";
 import type { VirtualListSource } from "#src/widget/virtual_list.js";
 import { VirtualList } from "#src/widget/virtual_list.js";
 
+const NO_SEGMENT_SELECTED_MESSAGE = "No segment/skeleton is selected.";
+const NO_NODE_SELECTED_MESSAGE =
+  "No skeleton node is selected, only go to root is supported on skeleton edges.";
+const NAVIGATE_FROM_SPATIAL_INDEX_MESSAGE =
+  "A non-visible segment is selected. Make it visible to use skeleton navigation features.";
+
 export type SegmentDisplayState = SpatialSkeletonSegmentRenderState & {
   segmentLabel: string | undefined;
 };
@@ -380,12 +386,6 @@ export class SpatialSkeletonEditTab extends Tab {
         );
       }
       return [0, 1, 2].map((i) => String(Math.round(Number(position[i]))));
-    };
-
-    const getSelectedNode = () => {
-      const selectedId = layer.selectedSpatialSkeletonNodeId.value;
-      if (selectedId === undefined) return undefined;
-      return allNodes.find((node) => node.nodeId === selectedId);
     };
 
     const getFilterText = () => nodeQuery.value.trim().toLowerCase();
@@ -680,44 +680,52 @@ export class SpatialSkeletonEditTab extends Tab {
     };
 
     const ensureSkeletonNavigationReady = (segmentId: number) => {
+      try {
+        getSegmentNavigationGraph(segmentId);
+        return true;
+      } catch (error) {
+        StatusMessage.showTemporaryMessage(NAVIGATE_FROM_SPATIAL_INDEX_MESSAGE);
+        return false;
+      }
+    };
+
+    const getSelectedNavigationContext = (requireNode: boolean = true) => {
+      // Inspect actions NA, message handled in ensureActionsAllowed
       if (
         !ensureActionsAllowed(SpatialSkeletonActions.inspect, {
           requireVisibleChunks: false,
         })
       ) {
-        return false;
+        return undefined;
       }
-      try {
-        getSegmentNavigationGraph(segmentId);
-        return true;
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        StatusMessage.showTemporaryMessage(
-          `Unable to resolve the local skeleton graph for navigation: ${message}`,
-        );
-        return false;
-      }
-    };
 
-    const getSelectedNavigationContext = () => {
-      const selectedNode = getSelectedNode();
-      if (selectedNode === undefined) {
-        StatusMessage.showTemporaryMessage("No skeleton node is selected.");
+      // Extract selected node and segment ID
+      const selectedId = layer.selectedSpatialSkeletonNodeId.value;
+      const selectedNode =
+        selectedId === undefined
+          ? undefined
+          : allNodes.find((node) => node.nodeId === selectedId);
+      const selectedSegmentId =
+        selectedNode?.segmentId ?? getSelectedSegmentId();
+
+      // No segment selected, can't navigate
+      if (selectedSegmentId === undefined) {
+        StatusMessage.showTemporaryMessage(NO_SEGMENT_SELECTED_MESSAGE);
         return undefined;
       }
-      if (!ensureSkeletonNavigationReady(selectedNode.segmentId))
+
+      // Segment from spatial index, message handled in ensureSkeletonNavigationReady
+      if (!ensureSkeletonNavigationReady(selectedSegmentId)) {
         return undefined;
+      }
+
+      // No node selected, action requires node
+      if (selectedNode === undefined && requireNode) {
+        StatusMessage.showTemporaryMessage(NO_NODE_SELECTED_MESSAGE);
+        return { segmentId: selectedSegmentId, nodeId: undefined };
+      }
+
       return selectedNode;
-    };
-
-    const getSelectedSegmentForNavigation = () => {
-      const segmentId = getSelectedNode()?.segmentId ?? getSelectedSegmentId();
-      if (segmentId === undefined) {
-        StatusMessage.showTemporaryMessage("No segment is selected.");
-        return undefined;
-      }
-      if (!ensureSkeletonNavigationReady(segmentId)) return undefined;
-      return segmentId;
     };
 
     const updateTrueEndLabel = (
@@ -760,7 +768,7 @@ export class SpatialSkeletonEditTab extends Tab {
         try {
           const openLeaves = await skeletonNavigationApi.getOpenLeaves(
             selectedNode.segmentId,
-            selectedNode.nodeId,
+            selectedNode.nodeId!,
           );
           if (openLeaves.length === 0) {
             StatusMessage.showTemporaryMessage(
@@ -849,7 +857,9 @@ export class SpatialSkeletonEditTab extends Tab {
       svg_origin,
       "Go to root",
       () => {
-        const segmentId = getSelectedSegmentForNavigation();
+        const segmentId = getSelectedNavigationContext(
+          false /* requireNode */,
+        )?.segmentId;
         if (segmentId === undefined) return;
         void (async () => {
           try {
@@ -876,7 +886,7 @@ export class SpatialSkeletonEditTab extends Tab {
         void (async () => {
           try {
             navigateToNodeTarget(
-              await skeletonNavigationApi.getBranchStart(selectedNode.nodeId),
+              await skeletonNavigationApi.getBranchStart(selectedNode.nodeId!),
             );
           } catch (error) {
             const message =
@@ -898,7 +908,7 @@ export class SpatialSkeletonEditTab extends Tab {
         void (async () => {
           try {
             navigateToNodeTarget(
-              await skeletonNavigationApi.getBranchEnd(selectedNode.nodeId),
+              await skeletonNavigationApi.getBranchEnd(selectedNode.nodeId!),
             );
           } catch (error) {
             const message =
@@ -921,7 +931,7 @@ export class SpatialSkeletonEditTab extends Tab {
           try {
             navigateToNodeTarget(
               await skeletonNavigationApi.getNextCollapsedLevelNode(
-                selectedNode.nodeId,
+                selectedNode.nodeId!,
               ),
             );
           } catch (error) {
@@ -944,7 +954,7 @@ export class SpatialSkeletonEditTab extends Tab {
         void (async () => {
           try {
             const target = await skeletonNavigationApi.getParentNode(
-              selectedNode.nodeId,
+              selectedNode.nodeId!,
             );
             if (target === undefined) {
               StatusMessage.showTemporaryMessage(
@@ -973,7 +983,7 @@ export class SpatialSkeletonEditTab extends Tab {
         void (async () => {
           try {
             const target = await skeletonNavigationApi.getChildNode(
-              selectedNode.nodeId,
+              selectedNode.nodeId!,
             );
             if (target === undefined) {
               StatusMessage.showTemporaryMessage("Selected node has no child.");

--- a/src/ui/spatial_skeleton_edit_tab.ts
+++ b/src/ui/spatial_skeleton_edit_tab.ts
@@ -689,7 +689,13 @@ export class SpatialSkeletonEditTab extends Tab {
       }
     };
 
-    const getSelectedNavigationContext = (requireNode: boolean = true) => {
+    function getSelectedNavigationContext(
+      requireNode: false,
+    ): { segmentId: number } | undefined;
+    function getSelectedNavigationContext(
+      requireNode?: true,
+    ): SpatiallyIndexedSkeletonNode | undefined;
+    function getSelectedNavigationContext(requireNode: boolean = true) {
       // Inspect actions NA, message handled in ensureActionsAllowed
       if (
         !ensureActionsAllowed(SpatialSkeletonActions.inspect, {
@@ -719,14 +725,14 @@ export class SpatialSkeletonEditTab extends Tab {
         return undefined;
       }
 
-      // No node selected, action requires node
-      if (selectedNode === undefined && requireNode) {
+      // No node selected
+      if (selectedNode === undefined) {
         StatusMessage.showTemporaryMessage(NO_NODE_SELECTED_MESSAGE);
-        return { segmentId: selectedSegmentId, nodeId: undefined };
+        return requireNode ? undefined : { segmentId: selectedSegmentId };
       }
 
       return selectedNode;
-    };
+    }
 
     const updateTrueEndLabel = (
       node: SpatiallyIndexedSkeletonNode,
@@ -768,7 +774,7 @@ export class SpatialSkeletonEditTab extends Tab {
         try {
           const openLeaves = await skeletonNavigationApi.getOpenLeaves(
             selectedNode.segmentId,
-            selectedNode.nodeId!,
+            selectedNode.nodeId,
           );
           if (openLeaves.length === 0) {
             StatusMessage.showTemporaryMessage(
@@ -886,7 +892,7 @@ export class SpatialSkeletonEditTab extends Tab {
         void (async () => {
           try {
             navigateToNodeTarget(
-              await skeletonNavigationApi.getBranchStart(selectedNode.nodeId!),
+              await skeletonNavigationApi.getBranchStart(selectedNode.nodeId),
             );
           } catch (error) {
             const message =
@@ -908,7 +914,7 @@ export class SpatialSkeletonEditTab extends Tab {
         void (async () => {
           try {
             navigateToNodeTarget(
-              await skeletonNavigationApi.getBranchEnd(selectedNode.nodeId!),
+              await skeletonNavigationApi.getBranchEnd(selectedNode.nodeId),
             );
           } catch (error) {
             const message =
@@ -931,7 +937,7 @@ export class SpatialSkeletonEditTab extends Tab {
           try {
             navigateToNodeTarget(
               await skeletonNavigationApi.getNextCollapsedLevelNode(
-                selectedNode.nodeId!,
+                selectedNode.nodeId,
               ),
             );
           } catch (error) {
@@ -954,7 +960,7 @@ export class SpatialSkeletonEditTab extends Tab {
         void (async () => {
           try {
             const target = await skeletonNavigationApi.getParentNode(
-              selectedNode.nodeId!,
+              selectedNode.nodeId,
             );
             if (target === undefined) {
               StatusMessage.showTemporaryMessage(
@@ -983,7 +989,7 @@ export class SpatialSkeletonEditTab extends Tab {
         void (async () => {
           try {
             const target = await skeletonNavigationApi.getChildNode(
-              selectedNode.nodeId!,
+              selectedNode.nodeId,
             );
             if (target === undefined) {
               StatusMessage.showTemporaryMessage("Selected node has no child.");

--- a/src/ui/spatial_skeleton_edit_tab.ts
+++ b/src/ui/spatial_skeleton_edit_tab.ts
@@ -725,10 +725,13 @@ export class SpatialSkeletonEditTab extends Tab {
         return undefined;
       }
 
-      // No node selected
       if (selectedNode === undefined) {
-        StatusMessage.showTemporaryMessage(NO_NODE_SELECTED_MESSAGE);
-        return requireNode ? undefined : { segmentId: selectedSegmentId };
+        // No node selected, but node required
+        if (requireNode) {
+          StatusMessage.showTemporaryMessage(NO_NODE_SELECTED_MESSAGE);
+          return undefined;
+        }
+        return { segmentId: selectedSegmentId };
       }
 
       return selectedNode;


### PR DESCRIPTION
There are many different failure reasons, this aims to clarify them by having more types of messages depending on (in priority order):
1. Actions not available
2. No segment selected
3. Segment not visible
4. Edge selected, but node required 