### PR TITLE
feat: update JSON keys for filter skeletons and change python keys to match

### DIFF
--- a/python/examples/example_spatial_skeletons.py
+++ b/python/examples/example_spatial_skeletons.py
@@ -43,7 +43,7 @@ with viewer.txn() as s:
     # Can set the new spatial related options
     layer = s.layers[0]
     layer.spatial_skeleton_node_query = "1"
-    layer.spatial_skeleton_node_filter = neuroglancer.SpatialSkeletonNodeFilterType.LEAF
+    layer.spatial_skeleton_node_filter = neuroglancer.SkeletonNodeFilterType.LEAF
     layer.hidden_object_alpha = 0.8
     layer.skeleton_cross_section_render_scale = 4.0
     layer.skeleton_perspective_render_scale = 4.0

--- a/python/neuroglancer/__init__.py
+++ b/python/neuroglancer/__init__.py
@@ -91,7 +91,7 @@ from .viewer_state import (
     InvlerpParameters,  # noqa: F401
     TransferFunctionParameters,  # noqa: F401
     ImageLayer,  # noqa: F401
-    SpatialSkeletonNodeFilterType,  # noqa: F401
+    SkeletonNodeFilterType,  # noqa: F401
     SkeletonRenderingOptions,  # noqa: F401
     StarredSegments,  # noqa: F401
     VisibleSegments,  # noqa: F401

--- a/python/neuroglancer/viewer_state.py
+++ b/python/neuroglancer/viewer_state.py
@@ -645,7 +645,7 @@ def _linked_segmentation_color_group_value(x):
 
 
 @export
-class SpatialSkeletonNodeFilterType(enum.StrEnum):
+class SkeletonNodeFilterType(enum.StrEnum):
     NONE = "none"
     LEAF = "leaf"
     VIRTUAL_END = "virtual_end"
@@ -987,19 +987,19 @@ class SegmentationLayer(Layer, _AnnotationLayerOptions):
     )
     segment_query = segmentQuery = wrapped_property("segmentQuery", optional(str))
     spatial_skeleton_node_query = spatialSkeletonNodeQuery = wrapped_property(
-        "spatialSkeletonNodeQuery", optional(str, "")
+        "skeletonNodeQuery", optional(str, "")
     )
     spatial_skeleton_node_filter = spatialSkeletonNodeFilter = wrapped_property(
-        "spatialSkeletonNodeFilter", optional(SpatialSkeletonNodeFilterType)
+        "skeletonNodeFilter", optional(SkeletonNodeFilterType)
     )
     hidden_object_alpha = hiddenObjectAlpha = wrapped_property(
         "hiddenObjectAlpha", optional(float, 0.5)
     )
     skeleton_cross_section_render_scale = skeletonCrossSectionRenderScale = (
-        wrapped_property("skeletonCrossSectionRenderScale", optional(float, 1))
+        wrapped_property("skeletonCrossSectionSpacing", optional(float, 1))
     )
     skeleton_perspective_render_scale = skeletonPerspectiveRenderScale = (
-        wrapped_property("skeletonPerspectiveRenderScale", optional(float, 1))
+        wrapped_property("skeletonPerspectiveSpacing", optional(float, 1))
     )
     segment_colors = segmentColors = wrapped_property(
         "segmentColors", typed_map(key_type=np.uint64, value_type=str)

--- a/src/layer/segmentation/index.ts
+++ b/src/layer/segmentation/index.ts
@@ -1836,11 +1836,11 @@ export class SegmentationUserLayer extends Base {
       specification[json_keys.HIDDEN_OPACITY_3D_JSON_KEY],
     );
     this.displayState.spatialSkeletonNodeQuery.restoreState(
-      specification[json_keys.SPATIAL_SKELETON_NODE_QUERY_JSON_KEY],
+      specification[json_keys.SKELETON_NODE_QUERY_JSON_KEY],
     );
     verifyOptionalObjectProperty(
       specification,
-      json_keys.SPATIAL_SKELETON_NODE_FILTER_JSON_KEY,
+      json_keys.SKELETON_NODE_FILTER_JSON_KEY,
       (value) =>
         this.displayState.spatialSkeletonNodeFilter.restoreState(value),
     );
@@ -1913,9 +1913,9 @@ export class SegmentationUserLayer extends Base {
       this.displayState.notSelectedAlpha.toJSON();
     x[json_keys.SATURATION_JSON_KEY] = this.displayState.saturation.toJSON();
     x[json_keys.OBJECT_ALPHA_JSON_KEY] = this.displayState.objectAlpha.toJSON();
-    x[json_keys.SPATIAL_SKELETON_NODE_QUERY_JSON_KEY] =
+    x[json_keys.SKELETON_NODE_QUERY_JSON_KEY] =
       this.displayState.spatialSkeletonNodeQuery.toJSON();
-    x[json_keys.SPATIAL_SKELETON_NODE_FILTER_JSON_KEY] =
+    x[json_keys.SKELETON_NODE_FILTER_JSON_KEY] =
       this.displayState.spatialSkeletonNodeFilter.toJSON();
     x[json_keys.HIDDEN_OPACITY_3D_JSON_KEY] =
       this.displayState.hiddenObjectAlpha.toJSON();

--- a/src/layer/segmentation/json_keys.ts
+++ b/src/layer/segmentation/json_keys.ts
@@ -23,9 +23,8 @@ export const SKELETON_RENDERING_JSON_KEY = "skeletonRendering";
 export const SKELETON_SHADER_JSON_KEY = "skeletonShader";
 export const SKELETON_CODE_VISIBLE_KEY = "codeVisible";
 export const SEGMENT_QUERY_JSON_KEY = "segmentQuery";
-export const SPATIAL_SKELETON_NODE_QUERY_JSON_KEY = "spatialSkeletonNodeQuery";
-export const SPATIAL_SKELETON_NODE_FILTER_JSON_KEY =
-  "spatialSkeletonNodeFilter";
+export const SKELETON_NODE_QUERY_JSON_KEY = "skeletonNodeQuery";
+export const SKELETON_NODE_FILTER_JSON_KEY = "skeletonNodeFilter";
 export const MESH_SILHOUETTE_RENDERING_JSON_KEY = "meshSilhouetteRendering";
 export const LINKED_SEGMENTATION_GROUP_JSON_KEY = "linkedSegmentationGroup";
 export const LINKED_SEGMENTATION_COLOR_GROUP_JSON_KEY =


### PR DESCRIPTION
Changes the keys to exclude the spatial prefix, and fixes two keys already out of date
