### PR TITLE
feat: allow a None filter on skeleton nodes

### DIFF
--- a/python/neuroglancer/viewer_state.py
+++ b/python/neuroglancer/viewer_state.py
@@ -649,6 +649,7 @@ def _linked_segmentation_color_group_value(x):
 
 @export
 class SkeletonNodeFilterType(enum.StrEnum):
+    DEFAULT = "default"
     NONE = "none"
     LEAF = "leaf"
     VIRTUAL_END = "virtual_end"

--- a/src/layer/segmentation/index.ts
+++ b/src/layer/segmentation/index.ts
@@ -718,7 +718,7 @@ class SegmentationUserLayerDisplayState implements SegmentationDisplayState {
   spatialSkeletonNodeQuery = new TrackableValue<string>("", verifyString);
   spatialSkeletonNodeFilter = new TrackableEnum(
     SpatialSkeletonNodeFilterType,
-    SpatialSkeletonNodeFilterType.NONE,
+    SpatialSkeletonNodeFilterType.DEFAULT,
   );
   ignoreNullVisibleSet = new TrackableBoolean(true, true);
   skeletonRenderingOptions = new SkeletonRenderingOptions();

--- a/src/skeleton/node_types.spec.ts
+++ b/src/skeleton/node_types.spec.ts
@@ -92,6 +92,20 @@ describe("skeleton node types", () => {
 
     expect(
       matchesSpatialSkeletonNodeFilter(
+        SpatialSkeletonNodeFilterType.DEFAULT,
+        rootLeaf,
+      ),
+    ).toBe(true);
+    expect(
+      matchesSpatialSkeletonNodeFilter(SpatialSkeletonNodeFilterType.DEFAULT, {
+        isLeaf: false,
+        nodeHasDescription: false,
+        nodeIsTrueEnd: false,
+        nodeType: SpatialSkeletonDisplayNodeType.REGULAR,
+      }),
+    ).toBe(true);
+    expect(
+      matchesSpatialSkeletonNodeFilter(
         SpatialSkeletonNodeFilterType.LEAF,
         rootLeaf,
       ),

--- a/src/skeleton/node_types.ts
+++ b/src/skeleton/node_types.ts
@@ -24,6 +24,7 @@ export enum SpatialSkeletonDisplayNodeType {
 }
 
 export enum SpatialSkeletonNodeFilterType {
+  DEFAULT,
   NONE,
   LEAF,
   VIRTUAL_END,
@@ -55,6 +56,8 @@ export function getSpatialSkeletonNodeFilterLabel(
   filterType: SpatialSkeletonNodeFilterType,
 ) {
   switch (filterType) {
+    case SpatialSkeletonNodeFilterType.DEFAULT:
+      return "Default";
     case SpatialSkeletonNodeFilterType.NONE:
       return "None";
     case SpatialSkeletonNodeFilterType.LEAF:
@@ -78,6 +81,7 @@ export function matchesSpatialSkeletonNodeFilter(
   },
 ) {
   switch (filterType) {
+    case SpatialSkeletonNodeFilterType.DEFAULT:
     case SpatialSkeletonNodeFilterType.NONE:
       return true;
     case SpatialSkeletonNodeFilterType.LEAF:

--- a/src/ui/skeleton_tab.spec.ts
+++ b/src/ui/skeleton_tab.spec.ts
@@ -121,7 +121,7 @@ describe("spatial skeleton edit tab render state", () => {
 
     const state = buildSpatialSkeletonSegmentRenderState(20380, graph, {
       filterText: "",
-      nodeFilterType: SpatialSkeletonNodeFilterType.NONE,
+      nodeFilterType: SpatialSkeletonNodeFilterType.DEFAULT,
       getNodeDescription() {
         return undefined;
       },
@@ -131,6 +131,26 @@ describe("spatial skeleton edit tab render state", () => {
     expect(state.displayedNodeCount).toBe(2);
     expect(state.branchCount).toBe(1);
     expect(state.rows.map((row) => row.node.nodeId)).toEqual([10, 12]);
+  });
+
+  it("shows all nodes including regular chain nodes when filter is None", () => {
+    const graph = buildSpatiallyIndexedSkeletonNavigationGraph([
+      makeNode(10, undefined),
+      makeNode(11, 10),
+      makeNode(12, 11),
+    ]);
+
+    const state = buildSpatialSkeletonSegmentRenderState(20380, graph, {
+      filterText: "",
+      nodeFilterType: SpatialSkeletonNodeFilterType.NONE,
+      getNodeDescription() {
+        return undefined;
+      },
+    });
+
+    expect(state.matchedNodeCount).toBe(3);
+    expect(state.displayedNodeCount).toBe(3);
+    expect(state.rows.map((row) => row.node.nodeId)).toEqual([10, 11, 12]);
   });
 
   it("treats node-type-only matches as disconnected visible branches", () => {
@@ -198,7 +218,7 @@ describe("spatial skeleton edit tab virtual list items", () => {
     const segmentState = {
       ...buildSpatialSkeletonSegmentRenderState(20380, graph, {
         filterText: "",
-        nodeFilterType: SpatialSkeletonNodeFilterType.NONE,
+        nodeFilterType: SpatialSkeletonNodeFilterType.DEFAULT,
         getNodeDescription() {
           return undefined;
         },

--- a/src/ui/skeleton_tab.ts
+++ b/src/ui/skeleton_tab.ts
@@ -1428,7 +1428,8 @@ export class SpatialSkeletonEditTab extends Tab {
         segmentState === undefined ||
         segmentState.totalNodeCount === 0 ||
         (getFilterText().length === 0 &&
-          nodeFilterTypeModel.value === SpatialSkeletonNodeFilterType.NONE)
+          (nodeFilterTypeModel.value === SpatialSkeletonNodeFilterType.DEFAULT ||
+            nodeFilterTypeModel.value === SpatialSkeletonNodeFilterType.NONE))
       ) {
         return "No loaded nodes.";
       }

--- a/src/ui/skeleton_tab_render.ts
+++ b/src/ui/skeleton_tab_render.ts
@@ -109,14 +109,12 @@ export function buildSpatialSkeletonSegmentRenderState(
     if (info === undefined) return false;
     const { node, type, isLeaf, description } = info;
     return (
-      (options.nodeFilterType === SpatialSkeletonNodeFilterType.NONE ||
-        matchesSpatialSkeletonNodeFilter(options.nodeFilterType, {
-          isLeaf,
-          nodeHasDescription: hasNonEmptyNodeDescription(description),
-          nodeIsTrueEnd: node.isTrueEnd ?? false,
-          nodeType: type,
-        })) &&
-      nodeMatchesFilter(node, options.filterText, description)
+      matchesSpatialSkeletonNodeFilter(options.nodeFilterType, {
+        isLeaf,
+        nodeHasDescription: hasNonEmptyNodeDescription(description),
+        nodeIsTrueEnd: node.isTrueEnd ?? false,
+        nodeType: type,
+      }) && nodeMatchesFilter(node, options.filterText, description)
     );
   };
 
@@ -147,11 +145,12 @@ export function buildSpatialSkeletonSegmentRenderState(
   }
 
   // Stage 2: among matched nodes, plain regular chain nodes are collapsed from the
-  // display list when no filter is active. An active filter means the user explicitly
-  // searched for something, so every match should be shown.
+  // display list under the Default filter with no search text. Any other filter
+  // or active search text means the user explicitly narrowed the view, so every
+  // match is shown including regular chain nodes.
   const hasActiveFilter =
     options.filterText.length > 0 ||
-    options.nodeFilterType !== SpatialSkeletonNodeFilterType.NONE;
+    options.nodeFilterType !== SpatialSkeletonNodeFilterType.DEFAULT;
 
   const isCollapsedFromDisplay = (nodeId: number): boolean => {
     if (hasActiveFilter) return false;


### PR DESCRIPTION
Our old "None" was really a root + branch points + leaves filter