### PR TITLE
feat: Escape commas in node description

### DIFF
--- a/src/datasource/catmaid/api.spec.ts
+++ b/src/datasource/catmaid/api.spec.ts
@@ -437,6 +437,116 @@ describe("CatmaidClient skeleton editing methods", () => {
     );
   });
 
+  it("parses raw comma labels from compact-detail as descriptions", async () => {
+    const client = new CatmaidClient("https://example.invalid", 1);
+    const fetchMock = vi.fn().mockResolvedValue([
+      [
+        [
+          22107946,
+          null,
+          2,
+          23697030.0,
+          15055839.0,
+          16651262.0,
+          2000.0,
+          5,
+          "2026-03-29T10:15:00Z",
+        ],
+      ],
+      [],
+      {
+        "left, branch": [[22107946, "2026-03-29 10:15:00.000000+00:00"]],
+      },
+      [],
+      [],
+    ]);
+    (client as any).fetchProjectEndpoint = fetchMock;
+
+    await expect(client.getSkeleton(2)).resolves.toEqual([
+      {
+        nodeId: 22107946,
+        parentNodeId: undefined,
+        position: new Float32Array([23697030, 15055839, 16651262]),
+        segmentId: 2,
+        radius: 2000,
+        confidence: 100,
+        description: "left, branch",
+        isTrueEnd: false,
+        sourceState: testSourceState("2026-03-29T10:15:00Z"),
+      },
+    ]);
+  });
+
+  it("decodes compact-detail sentinel labels without treating them as true ends", async () => {
+    const client = new CatmaidClient("https://example.invalid", 1);
+    const fetchMock = vi.fn().mockResolvedValue([
+      [
+        [
+          22107946,
+          null,
+          2,
+          23697030.0,
+          15055839.0,
+          16651262.0,
+          2000.0,
+          5,
+          "2026-03-29T10:15:00Z",
+        ],
+        [
+          22107955,
+          22107946,
+          2,
+          23705874.0,
+          15093672.0,
+          16682375.0,
+          2000.0,
+          5,
+          "2026-03-29T10:16:00Z",
+        ],
+      ],
+      [],
+      {
+        "plain stale description": [
+          [22107946, "2026-03-29 10:14:00.000000+00:00"],
+        ],
+        "plain duplicate": [[22107955, "2026-03-29 10:16:00.000000+00:00"]],
+        "neuroglancer-description:v1:left%2C%20branch": [
+          [22107946, "2026-03-29 10:15:00.000000+00:00"],
+          [22107955, "2026-03-29 10:16:00.000000+00:00"],
+        ],
+        ends: [[22107955, "2026-03-29 10:16:00.000000+00:00"]],
+      },
+      [],
+      [],
+    ]);
+    (client as any).fetchProjectEndpoint = fetchMock;
+
+    await expect(client.getSkeleton(2)).resolves.toEqual([
+      {
+        nodeId: 22107946,
+        parentNodeId: undefined,
+        position: new Float32Array([23697030, 15055839, 16651262]),
+        segmentId: 2,
+        radius: 2000,
+        confidence: 100,
+        description: "left, branch",
+        isTrueEnd: false,
+        sourceState: testSourceState("2026-03-29T10:15:00Z"),
+      },
+      {
+        nodeId: 22107955,
+        parentNodeId: 22107946,
+        position: new Float32Array([23705874, 15093672, 16682375]),
+        segmentId: 2,
+        radius: 2000,
+        confidence: 100,
+        description: "left, branch",
+        isTrueEnd: true,
+        sourceState: testSourceState("2026-03-29T10:16:00Z"),
+      },
+    ]);
+  });
+
   it("parses compact-detail rows without local edition-time validation", async () => {
     const client = new CatmaidClient("https://example.invalid", 1);
     const fetchMock = vi
@@ -969,6 +1079,48 @@ describe("CatmaidClient skeleton editing methods", () => {
     expect(requestBody.get("delete_existing")).toBe("true");
   });
 
+  it("encodes comma descriptions as one comma-free CATMAID label", async () => {
+    const client = new CatmaidClient("https://example.invalid", 1);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ edition_time: "2026-03-29T13:01:00Z" });
+    (client as any).fetchProjectEndpoint = fetchMock;
+
+    await expect(
+      client.updateDescription(11, " left, branch \n LEFT, BRANCH \n ends "),
+    ).resolves.toEqual({
+      description: "left, branch",
+      sourceState: testSourceState("2026-03-29T13:01:00Z"),
+    });
+
+    const requestBody = getFetchBody(fetchMock);
+    expect(requestBody.get("tags")).toBe(
+      "neuroglancer-description:v1:left%2C%20branch",
+    );
+    expect(requestBody.get("tags")).not.toContain(",");
+    expect(requestBody.get("delete_existing")).toBe("true");
+  });
+
+  it("encodes sentinel-prefixed descriptions even without commas", async () => {
+    const client = new CatmaidClient("https://example.invalid", 1);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ edition_time: "2026-03-29T13:02:00Z" });
+    (client as any).fetchProjectEndpoint = fetchMock;
+
+    await expect(
+      client.updateDescription(11, "neuroglancer-description:v1:left"),
+    ).resolves.toEqual({
+      description: "neuroglancer-description:v1:left",
+      sourceState: testSourceState("2026-03-29T13:02:00Z"),
+    });
+
+    const requestBody = getFetchBody(fetchMock);
+    expect(requestBody.get("tags")).toBe(
+      "neuroglancer-description:v1:neuroglancer-description%3Av1%3Aleft",
+    );
+  });
+
   it("preserves true-end labels while replacing description labels", async () => {
     const client = new CatmaidClient("https://example.invalid", 1);
     const fetchMock = vi
@@ -987,6 +1139,29 @@ describe("CatmaidClient skeleton editing methods", () => {
 
     const requestBody = getFetchBody(fetchMock);
     expect(requestBody.get("tags")).toBe("updated description,ends");
+    expect(requestBody.get("delete_existing")).toBe("true");
+  });
+
+  it("preserves true-end labels while replacing comma descriptions", async () => {
+    const client = new CatmaidClient("https://example.invalid", 1);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ edition_time: "2026-03-29T13:06:00Z" });
+    (client as any).fetchProjectEndpoint = fetchMock;
+
+    await expect(
+      client.updateDescription(11, "left, branch\nends", {
+        isTrueEnd: true,
+      }),
+    ).resolves.toEqual({
+      description: "left, branch",
+      sourceState: testSourceState("2026-03-29T13:06:00Z"),
+    });
+
+    const requestBody = getFetchBody(fetchMock);
+    expect(requestBody.get("tags")).toBe(
+      "neuroglancer-description:v1:left%2C%20branch,ends",
+    );
     expect(requestBody.get("delete_existing")).toBe("true");
   });
 

--- a/src/datasource/catmaid/api.ts
+++ b/src/datasource/catmaid/api.ts
@@ -253,6 +253,7 @@ export const CATMAID_SPATIAL_SKELETON_CONFIDENCE_VALUES = [
 ] as const;
 
 const CATMAID_TRUE_END_LABEL = "ends";
+const CATMAID_ENCODED_DESCRIPTION_LABEL_PREFIX = "neuroglancer-description:v1:";
 const CATMAID_CLOSED_END_LABEL_PATTERNS = [
   /^uncertain continuation$/i,
   /^not a branch$/i,
@@ -324,6 +325,27 @@ interface ParsedCatmaidNodeLabel {
   time?: number;
 }
 
+function decodeCatmaidDescriptionLabel(label: string): string | undefined {
+  const trimmed = label.trim();
+  if (!trimmed.startsWith(CATMAID_ENCODED_DESCRIPTION_LABEL_PREFIX)) {
+    return undefined;
+  }
+  try {
+    const decoded = decodeURIComponent(
+      trimmed.substring(CATMAID_ENCODED_DESCRIPTION_LABEL_PREFIX.length),
+    ).trim();
+    return decoded.length === 0 ? undefined : decoded;
+  } catch {
+    return undefined;
+  }
+}
+
+function makeCatmaidEncodedDescriptionLabel(description: string) {
+  return `${CATMAID_ENCODED_DESCRIPTION_LABEL_PREFIX}${encodeURIComponent(
+    description,
+  )}`;
+}
+
 function normalizeCatmaidDescription(
   labels: readonly ParsedCatmaidNodeLabel[] | undefined,
 ): string | undefined {
@@ -350,9 +372,19 @@ function normalizeCatmaidDescription(
             ({ time }) => time === latestTime,
           );
         })();
-  return currentDescriptionLabels.length === 0
+  if (currentDescriptionLabels.length === 0) {
+    return undefined;
+  }
+  const decodedDescriptionLabels = currentDescriptionLabels
+    .map(({ label }) => decodeCatmaidDescriptionLabel(label))
+    .filter((label): label is string => label !== undefined);
+  const visibleDescriptionLabels =
+    decodedDescriptionLabels.length === 0
+      ? currentDescriptionLabels.map(({ label }) => label)
+      : decodedDescriptionLabels;
+  return visibleDescriptionLabels.length === 0
     ? undefined
-    : currentDescriptionLabels.map(({ label }) => label).join("\n");
+    : visibleDescriptionLabels.join("\n");
 }
 
 function parseCatmaidLabelNodeReference(entry: unknown):
@@ -1854,13 +1886,38 @@ export class CatmaidClient implements CatmaidSpatialSkeletonEditApi {
     return normalizedLabels;
   }
 
-  private buildDescriptionLabels(description: string) {
-    return this.normalizeNodeLabels(
-      description
-        .split(/\r?\n/)
-        .map((label) => label.trim())
-        .filter((label) => label.length > 0 && !isCatmaidClosedEndLabel(label)),
-    );
+  private normalizeDescriptionLabels(description: string) {
+    const normalizedLabels: string[] = [];
+    const seen = new Set<string>();
+    for (const label of description.split(/\r?\n/)) {
+      const trimmed = label.trim();
+      if (trimmed.length === 0 || isCatmaidClosedEndLabel(trimmed)) continue;
+      const key = trimmed.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      normalizedLabels.push(trimmed);
+    }
+    return normalizedLabels;
+  }
+
+  private buildDescriptionUpdate(description: string) {
+    const normalizedDescriptionLabels =
+      this.normalizeDescriptionLabels(description);
+    if (normalizedDescriptionLabels.length === 0) {
+      return { labels: [], description: undefined };
+    }
+    const normalizedDescription = normalizedDescriptionLabels.join("\n");
+    const requiresEncodedDescription =
+      normalizedDescription.includes(",") ||
+      normalizedDescriptionLabels.some((label) =>
+        label.startsWith(CATMAID_ENCODED_DESCRIPTION_LABEL_PREFIX),
+      );
+    return {
+      labels: requiresEncodedDescription
+        ? [makeCatmaidEncodedDescriptionLabel(normalizedDescription)]
+        : normalizedDescriptionLabels,
+      description: normalizedDescription,
+    };
   }
 
   private async replaceNodeLabels(nodeId: number, labels: readonly string[]) {
@@ -1907,18 +1964,17 @@ export class CatmaidClient implements CatmaidSpatialSkeletonEditApi {
     description: string,
     options: CatmaidDescriptionUpdateOptions = {},
   ): Promise<CatmaidDescriptionUpdateResult> {
-    const normalizedLabels = this.buildDescriptionLabels(description);
+    const descriptionUpdate = this.buildDescriptionUpdate(description);
     const labels =
       options.isTrueEnd === true
-        ? [...normalizedLabels, CATMAID_TRUE_END_LABEL]
-        : normalizedLabels;
+        ? [...descriptionUpdate.labels, CATMAID_TRUE_END_LABEL]
+        : descriptionUpdate.labels;
     const response = await this.replaceNodeLabels(nodeId, labels);
     return {
       ...getCatmaidSingleNodeRevisionResult(
         normalizeCatmaidRevisionToken(response?.edition_time),
       ),
-      description:
-        normalizedLabels.length === 0 ? undefined : normalizedLabels.join("\n"),
+      description: descriptionUpdate.description,
     };
   }
 

--- a/src/datasource/catmaid/spatial_skeleton_commands.ts
+++ b/src/datasource/catmaid/spatial_skeleton_commands.ts
@@ -448,15 +448,6 @@ function requireCatmaidMergeCommandPayload(payload: object) {
   );
 }
 
-function validateCatmaidNodeDescription(description: string | undefined) {
-  if (description === undefined) return;
-  for (const line of description.split(/\r?\n/)) {
-    if (line.trim().includes(",")) {
-      throw new Error("Node descriptions containing commas are not supported.");
-    }
-  }
-}
-
 function cloneNodeSnapshot(
   node: SpatiallyIndexedSkeletonNode,
 ): SpatiallyIndexedSkeletonNode {
@@ -1489,7 +1480,6 @@ class NodeDescriptionCommand implements SpatialSkeletonCommand {
     nextDescription: string | undefined,
     statusPrefix: string,
   ) {
-    validateCatmaidNodeDescription(nextDescription);
     const { node } = await getResolvedNodeForEdit(
       this.layer,
       this.stableNodeId,

--- a/src/skeleton/spatial_skeleton_commands.spec.ts
+++ b/src/skeleton/spatial_skeleton_commands.spec.ts
@@ -709,7 +709,7 @@ describe("spatial_skeleton_commands", () => {
       sourceState: testSourceState("before"),
     };
     const updateDescription = vi.fn().mockResolvedValue({
-      description: "after",
+      description: "after, comma",
       sourceState: testSourceState("after"),
     });
     const toggleTrueEnd = vi.fn();
@@ -759,15 +759,15 @@ describe("spatial_skeleton_commands", () => {
 
     await executeSpatialSkeletonNodeDescriptionUpdate(layer as any, {
       node: cachedNode,
-      nextDescription: "after",
+      nextDescription: "after, comma",
     });
 
-    expect(updateDescription).toHaveBeenCalledWith(17, "after", {
+    expect(updateDescription).toHaveBeenCalledWith(17, "after, comma", {
       isTrueEnd: true,
     });
     expect(toggleTrueEnd).not.toHaveBeenCalled();
     expect(cachedNode).toMatchObject({
-      description: "after",
+      description: "after, comma",
       isTrueEnd: true,
       sourceState: testSourceState("after"),
     });


### PR DESCRIPTION
Closes https://metacell.atlassian.net/browse/NA-862

- Introduces a Neuroglancer-private sentinel label format, neuroglancer-description:v1:<encoded>, so comma-containing descriptions can be stored as a single comma-free CATMAID label without requiring backend changes.