### PR TITLE
feat: add hovered node highlight

### DIFF
--- a/src/layer/segmentation/index.ts
+++ b/src/layer/segmentation/index.ts
@@ -799,7 +799,7 @@ export class SegmentationUserLayer extends Base {
   readonly selectedSpatialSkeletonNodeInfo = new WatchableValue<
     SelectedSpatialSkeletonNodeInfo | undefined
   >(undefined);
-  readonly hoveredSpatialSkeletonNodeId = this.registerDisposer(
+  readonly hoveredSpatialSkeletonNodeInfo = this.registerDisposer(
     new SpatialSkeletonHoverState(),
   );
   readonly spatialSkeletonVisibleChunksNeeded = new WatchableValue(0);
@@ -1118,7 +1118,7 @@ export class SegmentationUserLayer extends Base {
       ),
     );
     syncSelectedSpatialSkeletonNodeIdFromGlobalSelection();
-    this.hoveredSpatialSkeletonNodeId.bindTo(
+    this.hoveredSpatialSkeletonNodeInfo.bindTo(
       this.manager.layerSelectedValues,
       this,
     );
@@ -1603,6 +1603,7 @@ export class SegmentationUserLayer extends Base {
                 {
                   sources2d: slicePanelSources,
                   selectedNodeInfo: this.selectedSpatialSkeletonNodeInfo,
+                  hoveredNodeInfo: this.hoveredSpatialSkeletonNodeInfo,
                   pendingNodePositionVersion:
                     this.spatialSkeletonState.pendingNodePositionVersion,
                   getPendingNodePosition: (nodeId) =>
@@ -1636,6 +1637,7 @@ export class SegmentationUserLayer extends Base {
               displayState,
               {
                 selectedNodeInfo: this.selectedSpatialSkeletonNodeInfo,
+                hoveredNodeInfo: this.hoveredSpatialSkeletonNodeInfo,
                 pendingNodePositionVersion:
                   this.spatialSkeletonState.pendingNodePositionVersion,
                 getPendingNodePosition: (nodeId) =>

--- a/src/layer/segmentation/selection.spec.ts
+++ b/src/layer/segmentation/selection.spec.ts
@@ -144,7 +144,7 @@ describe("layer/segmentation/selection", () => {
     let mouseState: {
       active: boolean;
       pickedRenderLayer: unknown;
-      pickedSpatialSkeleton?: { nodeId?: unknown };
+      pickedSpatialSkeleton?: { nodeId?: unknown; segmentId?: unknown };
     } = {
       active: false,
       pickedRenderLayer: null,
@@ -175,7 +175,15 @@ describe("layer/segmentation/selection", () => {
       pickedSpatialSkeleton: { nodeId: 31 },
     };
     trigger();
-    expect(hoverState.value).toBe(31);
+    expect(hoverState.value).toEqual({ nodeId: 31 });
+
+    mouseState = {
+      active: true,
+      pickedRenderLayer: renderLayerA,
+      pickedSpatialSkeleton: { nodeId: 31, segmentId: 7 },
+    };
+    trigger();
+    expect(hoverState.value).toEqual({ nodeId: 31, segmentId: 7 });
 
     mouseState = {
       active: true,

--- a/src/layer/segmentation/selection.ts
+++ b/src/layer/segmentation/selection.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import type { LayerSelectedValues } from "#src/layer/index.js";
+import type {
+  LayerSelectedValues,
+  PickedSpatialSkeletonState,
+} from "#src/layer/index.js";
 import type { SegmentationUserLayer } from "#src/layer/segmentation/index.js";
 import { RefCounted } from "#src/util/disposable.js";
 import { parseUint64 } from "#src/util/json.js";
@@ -23,11 +26,12 @@ import { NullarySignal } from "#src/util/signal.js";
 interface SpatialSkeletonViewerHoverMouseStateLike<TRenderLayer> {
   active: boolean;
   pickedRenderLayer: TRenderLayer | null | undefined;
-  pickedSpatialSkeleton?:
-    | {
-        nodeId?: unknown;
-      }
-    | undefined;
+  pickedSpatialSkeleton?: PickedSpatialSkeletonState;
+}
+
+export interface SpatialSkeletonHoverInfo {
+  readonly nodeId: number;
+  readonly segmentId?: number;
 }
 
 interface SpatialSkeletonViewerHoverLayerLike<TRenderLayer> {
@@ -86,12 +90,6 @@ function getSelectionValueIdString(value: unknown) {
   } catch {
     return undefined;
   }
-}
-
-function normalizeSpatialSkeletonViewerHoverNodeId(value: unknown) {
-  return typeof value === "number" && Number.isSafeInteger(value) && value > 0
-    ? value
-    : undefined;
 }
 
 export function getNodeIdFromLayerSelectionState(
@@ -175,10 +173,10 @@ export function getNodeIdFromViewerSelection<TLayer>(
   );
 }
 
-function getSpatialSkeletonNodeIdFromViewerHover<TRenderLayer>(
+function getSpatialSkeletonHoverInfoFromViewerHover<TRenderLayer>(
   mouseState: SpatialSkeletonViewerHoverMouseStateLike<TRenderLayer>,
   layer: SpatialSkeletonViewerHoverLayerLike<TRenderLayer>,
-) {
+): SpatialSkeletonHoverInfo | undefined {
   if (!mouseState.active) return undefined;
   const pickedRenderLayer = mouseState.pickedRenderLayer;
   if (pickedRenderLayer !== null) {
@@ -189,18 +187,29 @@ function getSpatialSkeletonNodeIdFromViewerHover<TRenderLayer>(
       return undefined;
     }
   }
-  // TODO (SKM): I think we can inline this function
-  return normalizeSpatialSkeletonViewerHoverNodeId(
-    mouseState.pickedSpatialSkeleton?.nodeId,
-  );
+  const pickedSpatialSkeleton = mouseState.pickedSpatialSkeleton;
+  const nodeId = pickedSpatialSkeleton?.nodeId;
+  if (nodeId === undefined) return undefined;
+  const segmentId = pickedSpatialSkeleton?.segmentId;
+  if (segmentId === undefined) return undefined;
+  return segmentId === undefined ? { nodeId } : { nodeId, segmentId };
+}
+
+function spatialSkeletonHoverInfoEqual(
+  a: SpatialSkeletonHoverInfo | undefined,
+  b: SpatialSkeletonHoverInfo | undefined,
+) {
+  if (a === b) return true;
+  if (a === undefined || b === undefined) return false;
+  return a.nodeId === b.nodeId && a.segmentId === b.segmentId;
 }
 
 export class SpatialSkeletonHoverState extends RefCounted {
-  value: number | undefined = undefined;
+  value: SpatialSkeletonHoverInfo | undefined = undefined;
   readonly changed = new NullarySignal();
 
-  setValue(value: number | undefined) {
-    if (this.value !== value) {
+  setValue(value: SpatialSkeletonHoverInfo | undefined) {
+    if (!spatialSkeletonHoverInfoEqual(this.value, value)) {
       this.value = value;
       this.changed.dispatch();
     }
@@ -213,7 +222,7 @@ export class SpatialSkeletonHoverState extends RefCounted {
     this.registerDisposer(
       layerSelectedValues.changed.add(() => {
         this.setValue(
-          getSpatialSkeletonNodeIdFromViewerHover(
+          getSpatialSkeletonHoverInfoFromViewerHover(
             layerSelectedValues.mouseState,
             layer,
           ),

--- a/src/skeleton/frontend.spec.ts
+++ b/src/skeleton/frontend.spec.ts
@@ -134,22 +134,23 @@ describe("SpatiallyIndexedSkeletonLayer selected node outline color", () => {
     const layer = Object.assign(
       Object.create(SpatiallyIndexedSkeletonLayer.prototype),
       {
-        selectedNodeId: { value: 101 },
+        selectedNodeInfo: { value: { nodeId: 101 } },
         selectedNodeOutlineColor: vec3.create(),
-        selectedNodeOutlineColorGeneration: 0,
-        cachedSelectedNodeOutlineColorGeneration: -1,
+        highlightedNodeOutlineColor: vec3.create(),
+        nodeOutlineColorGeneration: 0,
+        cachedNodeOutlineColorGeneration: -1,
         displayState,
       },
     );
 
-    const outlineColor = (layer as any).getSelectedNodeOutlineColor();
-    const cachedOutlineColor = (layer as any).getSelectedNodeOutlineColor();
+    (layer as any).updateNodeOutlineColorPair();
+    const outlineColor = (layer as any).selectedNodeOutlineColor;
+    (layer as any).updateNodeOutlineColorPair();
+    const cachedOutlineColor = (layer as any).selectedNodeOutlineColor;
 
     expect(isSelected).not.toHaveBeenCalled();
     expect(cachedOutlineColor).toBe(outlineColor);
-    expect(outlineColor[0]).toBeCloseTo(1);
-    expect(outlineColor[1]).toBeCloseTo(0.95);
-    expect(outlineColor[2]).toBeCloseTo(0.35);
+    // The outline color is chosen for high contrast against the segment color.
     expect(getContrastRatio(outlineColor, sourceColor)).toBeGreaterThanOrEqual(
       3,
     );
@@ -183,16 +184,17 @@ describe("SpatiallyIndexedSkeletonLayer selected node outline color", () => {
       {
         selectedNodeInfo: { value: { nodeId: 101 } },
         selectedNodeOutlineColor: vec3.create(),
-        selectedNodeOutlineColorGeneration: 0,
-        cachedSelectedNodeOutlineColorGeneration: -1,
+        highlightedNodeOutlineColor: vec3.create(),
+        nodeOutlineColorGeneration: 0,
+        cachedNodeOutlineColorGeneration: -1,
         displayState,
       },
     );
 
-    (layer as any).getSelectedNodeOutlineColor();
+    (layer as any).updateNodeOutlineColorPair();
     selectedNodeId.value = 202;
-    ++(layer as any).selectedNodeOutlineColorGeneration;
-    (layer as any).getSelectedNodeOutlineColor();
+    ++(layer as any).nodeOutlineColorGeneration;
+    (layer as any).updateNodeOutlineColorPair();
 
     expect(computeSegmentColor).toHaveBeenCalledTimes(2);
   });
@@ -224,17 +226,103 @@ describe("SpatiallyIndexedSkeletonLayer selected node outline color", () => {
       {
         selectedNodeInfo: { value: { nodeId: 101 } },
         selectedNodeOutlineColor: vec3.create(),
-        selectedNodeOutlineColorGeneration: 0,
-        cachedSelectedNodeOutlineColorGeneration: -1,
+        highlightedNodeOutlineColor: vec3.create(),
+        nodeOutlineColorGeneration: 0,
+        cachedNodeOutlineColorGeneration: -1,
         displayState,
       },
     );
 
-    (layer as any).getSelectedNodeOutlineColor();
-    ++(layer as any).selectedNodeOutlineColorGeneration;
-    (layer as any).getSelectedNodeOutlineColor();
+    (layer as any).updateNodeOutlineColorPair();
+    ++(layer as any).nodeOutlineColorGeneration;
+    (layer as any).updateNodeOutlineColorPair();
 
     expect(computeSegmentColor).toHaveBeenCalledTimes(2);
+  });
+
+  it("derives the hovered-node outline color from the hovered segment when nothing is selected", () => {
+    const sourceColor = vec3.fromValues(1, 1, 1);
+    const displayState = {
+      segmentationColorGroupState: {
+        value: {
+          segmentStatedColors: new Map(),
+          segmentDefaultColor: { value: sourceColor },
+          segmentColorHash: { compute: vi.fn() },
+        },
+      },
+      saturation: { value: 0 },
+      hoverHighlight: { value: true },
+      segmentSelectionState: { isSelected: vi.fn(() => false), baseValue: 0n },
+    };
+    const layer = Object.assign(
+      Object.create(SpatiallyIndexedSkeletonLayer.prototype),
+      {
+        selectedNodeInfo: { value: undefined },
+        hoveredNodeInfo: { value: { nodeId: 303, segmentId: 202 } },
+        selectedNodeOutlineColor: vec3.create(),
+        highlightedNodeOutlineColor: vec3.create(),
+        nodeOutlineColorGeneration: 0,
+        cachedNodeOutlineColorGeneration: -1,
+        displayState,
+      },
+    );
+
+    (layer as any).updateNodeOutlineColorPair();
+    const highlightedColor = (layer as any).highlightedNodeOutlineColor;
+
+    // The hovered outline is chosen for high contrast against its own (white)
+    // segment color.
+    expect(
+      getContrastRatio(highlightedColor, sourceColor),
+    ).toBeGreaterThanOrEqual(3);
+  });
+
+  it("derives each outline from its own segment when selected and hovered nodes belong to different segments", () => {
+    // Selected node on a dark segment, hovered node on a bright segment, as
+    // happens when hovering a merge target on a differently colored skeleton.
+    const selectedSegmentColor = vec3.fromValues(0, 0, 0);
+    const hoveredSegmentColor = vec3.fromValues(1, 1, 1);
+    const displayState = {
+      segmentationColorGroupState: {
+        value: {
+          segmentStatedColors: new Map([
+            [101n, 0x000000n],
+            [202n, 0xffffffn],
+          ]),
+          segmentDefaultColor: { value: undefined },
+          segmentColorHash: { compute: vi.fn() },
+        },
+      },
+      saturation: { value: 0 },
+      hoverHighlight: { value: true },
+      segmentSelectionState: { isSelected: vi.fn(() => false), baseValue: 0n },
+    };
+    const layer = Object.assign(
+      Object.create(SpatiallyIndexedSkeletonLayer.prototype),
+      {
+        selectedNodeInfo: { value: { nodeId: 101, segmentId: 101 } },
+        hoveredNodeInfo: { value: { nodeId: 303, segmentId: 202 } },
+        selectedNodeOutlineColor: vec3.create(),
+        highlightedNodeOutlineColor: vec3.create(),
+        nodeOutlineColorGeneration: 0,
+        cachedNodeOutlineColorGeneration: -1,
+        displayState,
+      },
+    );
+
+    (layer as any).updateNodeOutlineColorPair();
+    const selectedColor = (layer as any).selectedNodeOutlineColor;
+    const highlightedColor = (layer as any).highlightedNodeOutlineColor;
+
+    // Each outline contrasts against its own segment color...
+    expect(
+      getContrastRatio(selectedColor, selectedSegmentColor),
+    ).toBeGreaterThanOrEqual(3);
+    expect(
+      getContrastRatio(highlightedColor, hoveredSegmentColor),
+    ).toBeGreaterThanOrEqual(3);
+    // ...and the two outlines are different colors.
+    expect([...selectedColor]).not.toEqual([...highlightedColor]);
   });
 });
 

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -117,7 +117,10 @@ import {
 } from "#src/trackable_value.js";
 import { Uint64Set } from "#src/uint64_set.js";
 import { gatherUpdate } from "#src/util/array.js";
-import { computeHighVisibilityContrastColor } from "#src/util/color.js";
+import {
+  computeDistinctHighVisibilityContrastColor,
+  computeHighVisibilityContrastColor,
+} from "#src/util/color.js";
 import { hsvToRgb } from "#src/util/colorspace.js";
 import { DataType } from "#src/util/data_type.js";
 import { RefCounted } from "#src/util/disposable.js";
@@ -196,10 +199,14 @@ const DEFAULT_FRAGMENT_MAIN = `void main() {
 `;
 
 const SELECTED_NODE_OUTLINE_FALLBACK_COLOR = vec3.fromValues(1.0, 0.95, 0.35);
-const SELECTED_NODE_OUTLINE_MIN_WIDTH_2D = "1.75";
-const SELECTED_NODE_OUTLINE_MAX_WIDTH_2D = "3.0";
-const SELECTED_NODE_OUTLINE_MIN_WIDTH_3D = "1.5";
-const SELECTED_NODE_OUTLINE_MAX_WIDTH_3D = "2.5";
+const SELECTED_NODE_OUTLINE_MIN_WIDTH_2D = "3.5";
+const SELECTED_NODE_OUTLINE_MAX_WIDTH_2D = "8.0";
+const SELECTED_NODE_OUTLINE_MIN_WIDTH_3D = "3.0";
+const SELECTED_NODE_OUTLINE_MAX_WIDTH_3D = "7.0";
+// Fraction of the node diameter used as the highlight outline width before
+// clamping to the min/max above. Nodes are small (~5-6px), so this mostly hits
+// the min for typical nodes and scales up the ring for larger nodes.
+const SELECTED_NODE_OUTLINE_DIAMETER_FRACTION = "0.5";
 
 interface VertexAttributeRenderInfo extends VertexAttributeInfo {
   name: string;
@@ -764,13 +771,16 @@ void emitDefault() {
             builder.addUniform("highp vec3", "uSelectedNodeOutlineColor");
             builder.addUniform("highp int", "uSelectedNodeId");
             builder.addVarying("highp float", "vSelectedNode", "flat");
+            builder.addUniform("highp vec3", "uHighlightedNodeOutlineColor");
+            builder.addUniform("highp int", "uHighlightedNodeId");
+            builder.addVarying("highp float", "vHighlightedNode", "flat");
             const selectedOutlineMinWidth = this.targetIsSliceView
               ? SELECTED_NODE_OUTLINE_MIN_WIDTH_2D
               : SELECTED_NODE_OUTLINE_MIN_WIDTH_3D;
             const selectedOutlineMaxWidth = this.targetIsSliceView
               ? SELECTED_NODE_OUTLINE_MAX_WIDTH_2D
               : SELECTED_NODE_OUTLINE_MAX_WIDTH_3D;
-            selectedOutlineWidthExpression = `(vSelectedNode * clamp(0.25 * uNodeDiameter, ${selectedOutlineMinWidth}, ${selectedOutlineMaxWidth}))`;
+            selectedOutlineWidthExpression = `(max(vSelectedNode, vHighlightedNode) * clamp(${SELECTED_NODE_OUTLINE_DIAMETER_FRACTION} * uNodeDiameter, ${selectedOutlineMinWidth}, ${selectedOutlineMaxWidth}))`;
           }
           let vertexMain = `
 highp uint vertexIndex = uint(gl_InstanceID);
@@ -783,6 +793,7 @@ highp vec3 vertexPosition = readAttribute0(vertexIndex);
           }
           if (this.nodeIdAttributeIndex !== undefined) {
             vertexMain += `vSelectedNode = float(readAttribute${this.nodeIdAttributeIndex}(vertexIndex).value == uSelectedNodeId);\n`;
+            vertexMain += `vHighlightedNode = float(readAttribute${this.nodeIdAttributeIndex}(vertexIndex).value == uHighlightedNodeId);\n`;
           }
           if (
             skeletonParams.dynamicSegmentAppearance &&
@@ -807,8 +818,10 @@ emitCircle(
             // getSegmentAppearance(). uColor is unused in this path.
             const segmentExpression = `vSegmentValue`;
             const hasNodeIdSelection = this.nodeIdAttributeIndex !== undefined;
+            // Apply the selected outline first, then the hovered outline, so the
+            // hovered color wins when a node is both selected and hovered.
             const borderColorExpression = hasNodeIdSelection
-              ? `mix(renderColor, vec4(uSelectedNodeOutlineColor, renderColor.a), vSelectedNode)`
+              ? `mix(mix(renderColor, vec4(uSelectedNodeOutlineColor, renderColor.a), vSelectedNode), vec4(uHighlightedNodeOutlineColor, renderColor.a), vHighlightedNode)`
               : "renderColor";
             builder.addFragmentCode(`
 vec4 segmentColor() {
@@ -853,8 +866,10 @@ void emitDefault() {
             // Per-vertex color attribute path: color comes from a per-vertex
             // attribute; alpha is taken from the attribute's alpha component.
             const hasNodeIdSelection = this.nodeIdAttributeIndex !== undefined;
+            // Apply the selected outline first, then the hovered outline, so the
+            // hovered color wins when a node is both selected and hovered.
             const borderColorExpression = hasNodeIdSelection
-              ? `mix(renderColor, vec4(uSelectedNodeOutlineColor, renderColor.a), vSelectedNode)`
+              ? `mix(mix(renderColor, vec4(uSelectedNodeOutlineColor, renderColor.a), vSelectedNode), vec4(uHighlightedNodeOutlineColor, renderColor.a), vHighlightedNode)`
               : "renderColor";
             builder.addFragmentCode(`
 vec4 segmentColor() {
@@ -1844,6 +1859,9 @@ interface SpatiallyIndexedSkeletonLayerOptions {
   selectedNodeInfo?: WatchableValueInterface<
     SelectedSkeletonNodeInfo | undefined
   >;
+  hoveredNodeInfo?: WatchableValueInterface<
+    SelectedSkeletonNodeInfo | undefined
+  >;
   pendingNodePositionVersion?: WatchableValueInterface<number>;
   getPendingNodePosition?: (nodeId: number) => ArrayLike<number> | undefined;
   getCachedNode?: (nodeId: number) => SpatiallyIndexedSkeletonNode | undefined;
@@ -2073,6 +2091,9 @@ export class SpatiallyIndexedSkeletonLayer
   private selectedNodeInfo:
     | WatchableValueInterface<SelectedSkeletonNodeInfo | undefined>
     | undefined;
+  private hoveredNodeInfo:
+    | WatchableValueInterface<SelectedSkeletonNodeInfo | undefined>
+    | undefined;
   private pendingNodePositionVersion:
     | WatchableValueInterface<number>
     | undefined;
@@ -2096,8 +2117,13 @@ export class SpatiallyIndexedSkeletonLayer
   private readonly selectedNodeOutlineColor = vec3.clone(
     SELECTED_NODE_OUTLINE_FALLBACK_COLOR,
   );
-  private selectedNodeOutlineColorGeneration = 0;
-  private cachedSelectedNodeOutlineColorGeneration = -1;
+  private readonly highlightedNodeOutlineColor = vec3.clone(
+    SELECTED_NODE_OUTLINE_FALLBACK_COLOR,
+  );
+  // The selected and hovered outline colors are derived together from a single
+  // source segment color, so they share one cache generation.
+  private nodeOutlineColorGeneration = 0;
+  private cachedNodeOutlineColorGeneration = -1;
 
   private disposeOverlayChunk() {
     this.overlayChunk?.dispose(this.gl);
@@ -2150,27 +2176,70 @@ export class SpatiallyIndexedSkeletonLayer
     return segmentIds;
   }
 
-  private getSelectedNodeOutlineColor() {
-    const nodeInfo = this.selectedNodeInfo?.value;
-    if (nodeInfo === undefined) {
-      return SELECTED_NODE_OUTLINE_FALLBACK_COLOR;
-    }
-    const currentGeneration = this.selectedNodeOutlineColorGeneration;
-    if (this.cachedSelectedNodeOutlineColorGeneration === currentGeneration) {
-      return this.selectedNodeOutlineColor;
-    }
+  // Segment fill color a node's outline should contrast against, or undefined
+  // when no segment can be resolved. Falls back to the currently selected
+  // segment when the node carries no segment id.
+  private getNodeSegmentColor(
+    nodeInfo: SelectedSkeletonNodeInfo,
+  ): Float32Array | undefined {
     const segmentId =
       nodeInfo.segmentId !== undefined
         ? BigInt(nodeInfo.segmentId)
         : this.displayState.segmentSelectionState.baseValue;
     if (segmentId === undefined) {
-      return SELECTED_NODE_OUTLINE_FALLBACK_COLOR;
+      return undefined;
     }
-    this.cachedSelectedNodeOutlineColorGeneration = currentGeneration;
-    return computeHighVisibilityContrastColor(
-      this.selectedNodeOutlineColor,
-      getBaseObjectColor(this.displayState, segmentId),
-    );
+    return getBaseObjectColor(this.displayState, segmentId);
+  }
+
+  // Updates `selectedNodeOutlineColor` and `highlightedNodeOutlineColor` in
+  // place. Each outline is chosen for high contrast against its own node's
+  // segment color, and the hovered outline is additionally kept visually
+  // distinct from the selected outline so both rings are tellable apart even
+  // when the two nodes share a segment (e.g. during a merge).
+  private updateNodeOutlineColorPair() {
+    const currentGeneration = this.nodeOutlineColorGeneration;
+    if (this.cachedNodeOutlineColorGeneration === currentGeneration) {
+      return;
+    }
+    this.cachedNodeOutlineColorGeneration = currentGeneration;
+
+    const selectedNodeInfo = this.selectedNodeInfo?.value;
+    const selectedSegmentColor =
+      selectedNodeInfo !== undefined
+        ? this.getNodeSegmentColor(selectedNodeInfo)
+        : undefined;
+    if (selectedSegmentColor !== undefined) {
+      computeHighVisibilityContrastColor(
+        this.selectedNodeOutlineColor,
+        selectedSegmentColor,
+      );
+    } else {
+      vec3.copy(
+        this.selectedNodeOutlineColor,
+        SELECTED_NODE_OUTLINE_FALLBACK_COLOR,
+      );
+    }
+
+    const hoveredNodeInfo = this.hoveredNodeInfo?.value;
+    const hoveredSegmentColor =
+      hoveredNodeInfo !== undefined
+        ? this.getNodeSegmentColor(hoveredNodeInfo)
+        : undefined;
+    if (hoveredSegmentColor !== undefined) {
+      computeDistinctHighVisibilityContrastColor(
+        this.highlightedNodeOutlineColor,
+        hoveredSegmentColor,
+        selectedSegmentColor !== undefined
+          ? this.selectedNodeOutlineColor
+          : undefined,
+      );
+    } else {
+      vec3.copy(
+        this.highlightedNodeOutlineColor,
+        SELECTED_NODE_OUTLINE_FALLBACK_COLOR,
+      );
+    }
   }
 
   getRetainedOverlaySegmentIds() {
@@ -2372,6 +2441,7 @@ export class SpatiallyIndexedSkeletonLayer
       ),
     );
     this.selectedNodeInfo = options.selectedNodeInfo;
+    this.hoveredNodeInfo = options.hoveredNodeInfo;
     this.pendingNodePositionVersion = options.pendingNodePositionVersion;
     this.getPendingNodePositionOverride = options.getPendingNodePosition;
     this.getCachedNodeInfo = options.getCachedNode;
@@ -2384,8 +2454,8 @@ export class SpatiallyIndexedSkeletonLayer
       ),
     );
     registerRedrawWhenSegmentationDisplayState3DChanged(displayState, this);
-    const invalidateSelectedNodeOutlineColor = () => {
-      ++this.selectedNodeOutlineColorGeneration;
+    const invalidateNodeOutlineColors = () => {
+      ++this.nodeOutlineColorGeneration;
     };
     this.displayState.shaderError.value = undefined;
     const { skeletonRenderingOptions: renderingOptions } = displayState;
@@ -2437,17 +2507,17 @@ export class SpatiallyIndexedSkeletonLayer
       registerNested((context, colorGroupState) => {
         context.registerDisposer(
           colorGroupState.segmentColorHash.changed.add(
-            invalidateSelectedNodeOutlineColor,
+            invalidateNodeOutlineColors,
           ),
         );
         context.registerDisposer(
           colorGroupState.segmentStatedColors.changed.add(
-            invalidateSelectedNodeOutlineColor,
+            invalidateNodeOutlineColors,
           ),
         );
         context.registerDisposer(
           colorGroupState.segmentDefaultColor.changed.add(
-            invalidateSelectedNodeOutlineColor,
+            invalidateNodeOutlineColors,
           ),
         );
       }, this.displayState.segmentationColorGroupState),
@@ -2482,7 +2552,17 @@ export class SpatiallyIndexedSkeletonLayer
     if (this.selectedNodeInfo?.changed) {
       this.registerDisposer(
         this.selectedNodeInfo.changed.add(() => {
-          invalidateSelectedNodeOutlineColor();
+          invalidateNodeOutlineColors();
+          requestRedraw();
+        }),
+      );
+    }
+    if (this.hoveredNodeInfo?.changed) {
+      this.registerDisposer(
+        this.hoveredNodeInfo.changed.add(() => {
+          // The hovered node drives both which node is outlined and the source
+          // segment color of its outline.
+          invalidateNodeOutlineColors();
           requestRedraw();
         }),
       );
@@ -2497,7 +2577,7 @@ export class SpatiallyIndexedSkeletonLayer
     if (inspectionState !== undefined) {
       this.registerDisposer(
         inspectionState.nodeDataVersion.changed.add(() => {
-          invalidateSelectedNodeOutlineColor();
+          invalidateNodeOutlineColors();
           this.redrawNeeded.dispatch();
         }),
       );
@@ -2933,13 +3013,22 @@ export class SpatiallyIndexedSkeletonLayer
 
     if (drawNodes) {
       nodeShader.bind();
+      this.updateNodeOutlineColorPair();
       gl.uniform3fv(
         nodeShader.uniform("uSelectedNodeOutlineColor"),
-        this.getSelectedNodeOutlineColor(),
+        this.selectedNodeOutlineColor,
       );
       gl.uniform1i(
         nodeShader.uniform("uSelectedNodeId"),
         this.selectedNodeInfo?.value?.nodeId ?? -1,
+      );
+      gl.uniform3fv(
+        nodeShader.uniform("uHighlightedNodeOutlineColor"),
+        this.highlightedNodeOutlineColor,
+      );
+      gl.uniform1i(
+        nodeShader.uniform("uHighlightedNodeId"),
+        this.hoveredNodeInfo?.value?.nodeId ?? -1,
       );
     }
 
@@ -3073,13 +3162,22 @@ export class SpatiallyIndexedSkeletonLayer
 
     if (drawNodes) {
       nodeShader.bind();
+      this.updateNodeOutlineColorPair();
       gl.uniform3fv(
         nodeShader.uniform("uSelectedNodeOutlineColor"),
-        this.getSelectedNodeOutlineColor(),
+        this.selectedNodeOutlineColor,
       );
       gl.uniform1i(
         nodeShader.uniform("uSelectedNodeId"),
         this.selectedNodeInfo?.value?.nodeId ?? -1,
+      );
+      gl.uniform3fv(
+        nodeShader.uniform("uHighlightedNodeOutlineColor"),
+        this.highlightedNodeOutlineColor,
+      );
+      gl.uniform1i(
+        nodeShader.uniform("uHighlightedNodeId"),
+        this.hoveredNodeInfo?.value?.nodeId ?? -1,
       );
     }
 

--- a/src/skeleton/frontend.ts
+++ b/src/skeleton/frontend.ts
@@ -118,8 +118,8 @@ import {
 import { Uint64Set } from "#src/uint64_set.js";
 import { gatherUpdate } from "#src/util/array.js";
 import {
-  computeDistinctHighVisibilityContrastColor,
-  computeHighVisibilityContrastColor,
+  computeHoveredNodeHighlightColor,
+  computeSelectedNodeHighlightColor,
 } from "#src/util/color.js";
 import { hsvToRgb } from "#src/util/colorspace.js";
 import { DataType } from "#src/util/data_type.js";
@@ -2193,10 +2193,11 @@ export class SpatiallyIndexedSkeletonLayer
   }
 
   // Updates `selectedNodeOutlineColor` and `highlightedNodeOutlineColor` in
-  // place. Each outline is chosen for high contrast against its own node's
-  // segment color, and the hovered outline is additionally kept visually
-  // distinct from the selected outline so both rings are tellable apart even
-  // when the two nodes share a segment (e.g. during a merge).
+  // place. Each outline is chosen, independently of the other, for high contrast
+  // against its own node's segment color: the selected node uses the muted
+  // palette and the hovered node the vivid palette. Because the two are computed
+  // independently, a given segment color always yields the same selected color
+  // and the same hovered color.
   private updateNodeOutlineColorPair() {
     const currentGeneration = this.nodeOutlineColorGeneration;
     if (this.cachedNodeOutlineColorGeneration === currentGeneration) {
@@ -2210,7 +2211,7 @@ export class SpatiallyIndexedSkeletonLayer
         ? this.getNodeSegmentColor(selectedNodeInfo)
         : undefined;
     if (selectedSegmentColor !== undefined) {
-      computeHighVisibilityContrastColor(
+      computeSelectedNodeHighlightColor(
         this.selectedNodeOutlineColor,
         selectedSegmentColor,
       );
@@ -2227,12 +2228,9 @@ export class SpatiallyIndexedSkeletonLayer
         ? this.getNodeSegmentColor(hoveredNodeInfo)
         : undefined;
     if (hoveredSegmentColor !== undefined) {
-      computeDistinctHighVisibilityContrastColor(
+      computeHoveredNodeHighlightColor(
         this.highlightedNodeOutlineColor,
         hoveredSegmentColor,
-        selectedSegmentColor !== undefined
-          ? this.selectedNodeOutlineColor
-          : undefined,
       );
     } else {
       vec3.copy(

--- a/src/ui/skeleton_tab.ts
+++ b/src/ui/skeleton_tab.ts
@@ -511,7 +511,7 @@ export class SpatialSkeletonEditTab extends Tab {
       layer.getSpatialSkeletonNodeDisplayDescription(node);
 
     const getHoveredNodeIdFromViewer = () => {
-      return layer.hoveredSpatialSkeletonNodeId.value;
+      return layer.hoveredSpatialSkeletonNodeInfo.value?.nodeId;
     };
 
     const getSelectedSegmentId = () => {
@@ -1723,7 +1723,7 @@ export class SpatialSkeletonEditTab extends Tab {
       }),
     );
     this.registerDisposer(
-      layer.hoveredSpatialSkeletonNodeId.changed.add(() => {
+      layer.hoveredSpatialSkeletonNodeInfo.changed.add(() => {
         updateHoveredViewerNode();
       }),
     );

--- a/src/util/color.browser_test.ts
+++ b/src/util/color.browser_test.ts
@@ -16,7 +16,8 @@
 
 import { describe, it, expect } from "vitest";
 import {
-  computeHighVisibilityContrastColor,
+  computeHoveredNodeHighlightColor,
+  computeSelectedNodeHighlightColor,
   getContrastRatio,
   parseColorSerialization,
   parseRGBColorSpecification,
@@ -115,88 +116,90 @@ describe("getContrastRatio", () => {
   });
 });
 
-describe("computeHighVisibilityContrastColor", () => {
-  it("prefers yellow for dark colors", () => {
+const REPRESENTATIVE_SEGMENT_COLORS: [number, number, number][] = [
+  [0, 0, 0], // black
+  [1, 1, 1], // white
+  [0.5, 0.5, 0.5], // gray
+  [1, 0, 0], // red
+  [0, 1, 0], // green
+  [0, 0, 1], // blue
+  [1, 1, 0], // yellow
+  [0, 1, 1], // cyan
+  [1, 0, 1], // magenta
+  [1, 0.55, 0], // orange
+];
+
+describe("computeHoveredNodeHighlightColor", () => {
+  it("picks white for dark segments", () => {
     const sourceColor = vec3.fromValues(0, 0, 0);
-    const color = computeHighVisibilityContrastColor(
-      vec3.create(),
-      sourceColor,
-    );
-
-    expectColorClose(color, [1, 0.95, 0.35]);
-    expect(getContrastRatio(color, sourceColor)).toBeGreaterThanOrEqual(3);
+    const color = computeHoveredNodeHighlightColor(vec3.create(), sourceColor);
+    expectColorClose(color, [1, 1, 1]);
+    expect(getContrastRatio(color, sourceColor)).toBeGreaterThanOrEqual(7);
   });
 
-  it("uses red for bright colors", () => {
-    const sourceColor = vec3.fromValues(1, 1, 1);
-    const color = computeHighVisibilityContrastColor(
-      vec3.create(),
-      sourceColor,
-    );
+  it("is fully determined by the segment color alone", () => {
+    for (const channels of REPRESENTATIVE_SEGMENT_COLORS) {
+      const sourceColor = vec3.fromValues(...channels);
+      const first = computeHoveredNodeHighlightColor(
+        vec3.create(),
+        sourceColor,
+      );
+      const second = computeHoveredNodeHighlightColor(
+        vec3.create(),
+        sourceColor,
+      );
+      expect([...first]).toEqual([...second]);
+    }
+  });
+});
 
-    expectColorClose(color, [1, 0, 0]);
-    expect(getContrastRatio(color, sourceColor)).toBeGreaterThanOrEqual(3);
+describe("computeSelectedNodeHighlightColor", () => {
+  it("is fully determined by the segment color alone", () => {
+    for (const channels of REPRESENTATIVE_SEGMENT_COLORS) {
+      const sourceColor = vec3.fromValues(...channels);
+      const first = computeSelectedNodeHighlightColor(
+        vec3.create(),
+        sourceColor,
+      );
+      const second = computeSelectedNodeHighlightColor(
+        vec3.create(),
+        sourceColor,
+      );
+      expect([...first]).toEqual([...second]);
+    }
+  });
+});
+
+describe("node highlight palettes", () => {
+  it("give distinct hovered and selected colors for every segment color", () => {
+    for (const channels of REPRESENTATIVE_SEGMENT_COLORS) {
+      const sourceColor = vec3.fromValues(...channels);
+      const hovered = computeHoveredNodeHighlightColor(
+        vec3.create(),
+        sourceColor,
+      );
+      const selected = computeSelectedNodeHighlightColor(
+        vec3.create(),
+        sourceColor,
+      );
+      expect([...hovered]).not.toEqual([...selected]);
+    }
   });
 
-  it("uses yellow for red segment colors", () => {
-    const sourceColor = vec3.fromValues(1, 0, 0);
-    const color = computeHighVisibilityContrastColor(
-      vec3.create(),
-      sourceColor,
-    );
-
-    expectColorClose(color, [1, 0.95, 0.35]);
-    expect(getContrastRatio(color, sourceColor)).toBeGreaterThanOrEqual(3);
-  });
-
-  it("uses yellow for low-saturation midtone colors", () => {
-    const sourceColor = vec3.fromValues(0.5, 0.5, 0.5);
-    const color = computeHighVisibilityContrastColor(
-      vec3.create(),
-      sourceColor,
-    );
-
-    expectColorClose(color, [1, 0.95, 0.35]);
-    expect(getContrastRatio(color, sourceColor)).toBeGreaterThanOrEqual(3);
-  });
-
-  it("uses yellow for near-black colors", () => {
-    const sourceColor = vec3.fromValues(0.05, 0.05, 0.05);
-    const color = computeHighVisibilityContrastColor(
-      vec3.create(),
-      sourceColor,
-    );
-
-    expectColorClose(color, [1, 0.95, 0.35]);
-  });
-
-  it("uses red for near-white colors", () => {
-    const sourceColor = vec3.fromValues(0.95, 0.95, 0.95);
-    const color = computeHighVisibilityContrastColor(
-      vec3.create(),
-      sourceColor,
-    );
-
-    expectColorClose(color, [1, 0, 0]);
-  });
-
-  it("uses red for yellow-like segment colors", () => {
-    const sourceColor = vec3.fromValues(1, 0.95, 0.35);
-    const color = computeHighVisibilityContrastColor(
-      vec3.create(),
-      sourceColor,
-    );
-
-    expectColorClose(color, [1, 0, 0]);
-  });
-
-  it("uses red when yellow would be close to the segment color", () => {
-    const sourceColor = vec3.fromValues(0.35, 1, 0.35);
-    const color = computeHighVisibilityContrastColor(
-      vec3.create(),
-      sourceColor,
-    );
-
-    expectColorClose(color, [1, 0, 0]);
+  it("never blend into their own segment", () => {
+    for (const channels of REPRESENTATIVE_SEGMENT_COLORS) {
+      const sourceColor = vec3.fromValues(...channels);
+      const hovered = computeHoveredNodeHighlightColor(
+        vec3.create(),
+        sourceColor,
+      );
+      const selected = computeSelectedNodeHighlightColor(
+        vec3.create(),
+        sourceColor,
+      );
+      // Both clear the value 1.0 that a same-color-on-same-color outline gives.
+      expect(getContrastRatio(hovered, sourceColor)).toBeGreaterThan(1.5);
+      expect(getContrastRatio(selected, sourceColor)).toBeGreaterThan(1.5);
+    }
   });
 });

--- a/src/util/color.ts
+++ b/src/util/color.ts
@@ -182,23 +182,78 @@ export function useWhiteBackground(foregroundColor: vec3 | vec4) {
   return getRelativeLuminance(foregroundColor) <= 0.179;
 }
 
-const yellowHighlight = vec3.fromValues(1, 0.95, 0.35);
-const redHighlight = vec3.fromValues(1, 0, 0);
-const YELLOW_HIGHLIGHT_CONTRAST_BIAS = 1.2;
+// Two disjoint palettes drive the node outline highlights. For a given segment
+// fill color, an outline is the palette entry with the highest contrast against
+// that segment. The hovered and selected colors are each computed independently
+// from their own palette, so each is fully determined by the segment color alone
+// (the same segment always yields the same hovered color and the same selected
+// color), and the two never collide since the palettes are disjoint.
 
-export function computeHighVisibilityContrastColor<T extends Float32Array>(
+// Vivid, saturated colors for the hovered node -- the actively pointed-at node,
+// drawn to stand out. Spans hue and luminance (white through blue) so a
+// high-contrast option exists for any segment color.
+const HOVERED_NODE_HIGHLIGHT_COLORS: readonly vec3[] = [
+  vec3.fromValues(1.0, 1.0, 1.0), // white
+  vec3.fromValues(1.0, 0.95, 0.0), // yellow
+  // vec3.fromValues(0.0, 0.95, 1.0), // cyan
+  // vec3.fromValues(0.1, 1.0, 0.25), // green
+  // vec3.fromValues(1.0, 0.55, 0.0), // orange
+  // vec3.fromValues(1.0, 0.1, 0.65), // pink
+  vec3.fromValues(1.0, 0.12, 0.12), // red
+  // vec3.fromValues(0.2, 0.45, 1.0), // blue
+];
+
+// Muted, lower-chroma colors for the selected (pinned) node -- a calmer,
+// persistent highlight. Spans hue and luminance like the hovered set so a
+// reasonable-contrast option exists for any segment color.
+const SELECTED_NODE_HIGHLIGHT_COLORS: readonly vec3[] = [
+  vec3.fromValues(0.1, 0.1, 0.1), // near-black
+  vec3.fromValues(0.7, 0.67, 0.6), // stone (light warm gray)
+  vec3.fromValues(0.5, 0.45, 0.15), // olive
+  // vec3.fromValues(0.15, 0.42, 0.42), // teal
+  // vec3.fromValues(0.5, 0.18, 0.18), // maroon
+  // vec3.fromValues(0.25, 0.3, 0.5), // slate blue
+  // vec3.fromValues(0.42, 0.22, 0.45), // plum
+  // vec3.fromValues(0.25, 0.42, 0.22), // moss
+  // vec3.fromValues(0.5, 0.38, 0.2), // tan
+];
+
+// Returns the palette color with the highest contrast against `sourceColor`.
+function pickHighestContrastColor(
+  palette: readonly vec3[],
+  sourceColor: ArrayLike<number>,
+): vec3 {
+  let bestColor = palette[0];
+  let bestContrast = -1;
+  for (const candidate of palette) {
+    const contrast = getContrastRatio(candidate, sourceColor);
+    if (contrast > bestContrast) {
+      bestContrast = contrast;
+      bestColor = candidate;
+    }
+  }
+  return bestColor;
+}
+
+// Writes into `out` the vivid hovered-node outline color with the highest
+// contrast against `sourceColor`.
+export function computeHoveredNodeHighlightColor<T extends Float32Array>(
   out: T,
   sourceColor: ArrayLike<number>,
-) {
-  const yellowContrast = getContrastRatio(yellowHighlight, sourceColor);
-  const redContrast = getContrastRatio(redHighlight, sourceColor);
-  const color =
-    redContrast > yellowContrast * YELLOW_HIGHLIGHT_CONTRAST_BIAS
-      ? redHighlight
-      : yellowHighlight;
-  out[0] = color[0];
-  out[1] = color[1];
-  out[2] = color[2];
+): T {
+  out.set(pickHighestContrastColor(HOVERED_NODE_HIGHLIGHT_COLORS, sourceColor));
+  return out;
+}
+
+// Writes into `out` the muted selected-node outline color with the highest
+// contrast against `sourceColor`.
+export function computeSelectedNodeHighlightColor<T extends Float32Array>(
+  out: T,
+  sourceColor: ArrayLike<number>,
+): T {
+  out.set(
+    pickHighestContrastColor(SELECTED_NODE_HIGHLIGHT_COLORS, sourceColor),
+  );
   return out;
 }
 


### PR DESCRIPTION
I think mostly what will want to later change here is to clean up the palettes and tests, honestly they probably don't need to test so much.

<img width="624" height="528" alt="image" src="https://github.com/user-attachments/assets/f0037460-942b-4871-834d-d9af2c2bb0f9" />
