### PR TITLE
feat: when undo/redo or other edit in progress, wait before undo/redo again

### DIFF
--- a/src/skeleton/spatial_skeleton_commands.ts
+++ b/src/skeleton/spatial_skeleton_commands.ts
@@ -346,19 +346,43 @@ export function executeSpatialSkeletonMerge(
 export async function undoSpatialSkeletonCommand(
   layer: SpatialSkeletonLayerContext,
 ) {
-  const changed = await layer.spatialSkeletonState.commandHistory.undo();
-  if (!changed) {
+  const { commandHistory } = layer.spatialSkeletonState;
+  if (commandHistory.isBusy.value) {
+    StatusMessage.showTemporaryMessage(
+      "Wait for the current skeleton edit to finish.",
+    );
     return false;
   }
-  return true;
+  if (!commandHistory.canUndo.value) {
+    return false;
+  }
+  const undoLabel = commandHistory.undoLabel.value;
+  const pendingMessage =
+    undoLabel !== undefined ? `Undoing ${undoLabel}...` : "Undoing...";
+  return executeCommandWithPendingMessage(
+    commandHistory.undo(),
+    pendingMessage,
+  );
 }
 
 export async function redoSpatialSkeletonCommand(
   layer: SpatialSkeletonLayerContext,
 ) {
-  const changed = await layer.spatialSkeletonState.commandHistory.redo();
-  if (!changed) {
+  const { commandHistory } = layer.spatialSkeletonState;
+  if (commandHistory.isBusy.value) {
+    StatusMessage.showTemporaryMessage(
+      "Wait for the current skeleton edit to finish.",
+    );
     return false;
   }
-  return true;
+  if (!commandHistory.canRedo.value) {
+    return false;
+  }
+  const redoLabel = commandHistory.redoLabel.value;
+  const pendingMessage =
+    redoLabel !== undefined ? `Redoing ${redoLabel}...` : "Redoing...";
+  return executeCommandWithPendingMessage(
+    commandHistory.redo(),
+    pendingMessage,
+  );
 }


### PR DESCRIPTION
Intention is so that undo/redo are blocked if called from outside of the UI. In the UI we could disable the buttons instead. But if we bind control + Z / control + shift + Z that's where this comes in.